### PR TITLE
Removes APP_PLATFORM warning at the start of ndk-build

### DIFF
--- a/orbotservice/src/main/AndroidManifest.xml
+++ b/orbotservice/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.torproject.android.service">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
+    <uses-sdk android:minSdkVersion="16"/>
 </manifest>


### PR DESCRIPTION
When you run `ndk-build` you first get this warning:

> Android NDK: WARNING: APP_PLATFORM android-16 is higher than android:minSdkVersion 1 in ./AndroidManifest.xml. NDK binaries will *not* be compatible with devices older than android-16. See https://android.googlesource.com/platform/ndk/+/master/docs/user/common_problems.md for more information.    

Because `APP_PLATFORM` was set to `android-16` in `Application.mk` but no `android:minSdkVersion` was set in the project's manifest so it defaulted to 1. Setting it to 16 explicitly (Orbot's minimum supported version) removes this warning at compile time.