### PR TITLE
Fix onion service only working intermittently in VPN mode

### DIFF
--- a/orbotservice/src/main/res/values/pdnsd.xml
+++ b/orbotservice/src/main/res/values/pdnsd.xml
@@ -7,7 +7,7 @@ global {
 	server_port = 8091;
 	server_ip = 0.0.0.0;
 	query_method=udp_only;
-	min_ttl=15m;
+	min_ttl=1m;
 	max_ttl=1w;
 	timeout=10;
 	daemon=on;


### PR DESCRIPTION
This reduces the min. TTL for DNS request to 60 seconds which is also
the time for which the mapping of an onion address to a virtual IP is
valid. This change is needed because Tor's internal mapping sometimes
expired before the 900 seconds previously configured as TTL. This would
lead to request failing with `WARN: Missing mapping for virtual address
'[scrubbed]'. Refusing.`

Tor, when resolving onion addresses, uses a TTL of 60 seconds:

    $ dig ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion @localhost -p 5400

    ; <<>> DiG 9.14.2 <<>> ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion @localhost -p 5400
    ;; global options: +cmd
    ;; Got answer:
    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25321
    ;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

    ;; QUESTION SECTION:
    ;ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion. IN  A

    ;; ANSWER SECTION:
    ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion. 60   IN A 10.209.112.10

    ;; Query time: 0 msec
    ;; SERVER: 127.0.0.1#5400(127.0.0.1)
    ;; WHEN: Tue Jun 04 19:39:54 CEST 2019
    ;; MSG SIZE  rcvd: 85

However, pdnsd changed the TTL to 15 minutes:

     $ dig ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion

     ; <<>> DiG 9.14.2 <<>> ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion
     ;; global options: +cmd
     ;; Got answer:
     ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40438
     ;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

     ;; OPT PSEUDOSECTION:
     ; EDNS: version: 0, flags:; udp: 1024
     ;; QUESTION SECTION:
     ;ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion. IN  A

     ;; ANSWER SECTION:
     ye3s2gcp2t6ernhy7rtgk6him4iddkvhy4h2csc2wvrfj.onion. 900 IN A 10.209.112.10

     ;; Query time: 1 msec
     ;; SERVER: 8.8.8.8#53(8.8.8.8)
     ;; WHEN: Tue Jun 04 19:39:59 CEST 2019
     ;; MSG SIZE  rcvd: 96