### PR TITLE
Rename hidden services to onion services

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,7 @@
     <string name="hidden_service_request">An app wants to open hidden server port %1$s to the Tor network. This is safe if you trust the app.</string>
     <string name="found_existing_tor_process">found existing Tor process&#8230;</string>
     <string name="something_bad_happened">Something bad happened. Check the log</string>
-    <string name="unable_to_read_hidden_service_name">unable to read hidden service name</string>
+    <string name="unable_to_read_hidden_service_name">unable to read onion service name</string>
     <string name="unable_to_start_tor">Unable to start Tor:</string>
 
     <string name="pref_use_persistent_notifications">Always keep the icon in toolbar when Orbot is connected</string>
@@ -183,9 +183,9 @@
     <string name="install_orweb">Install Orfox</string>
 
     <string name="vpn_default_world">Global (Auto)</string>
-    <string name="hidden_services">Hidden Services</string>
-    <string name="title_activity_hidden_services">Hidden Services</string>
-    <string name="menu_hidden_services">Hidden Services</string>
+    <string name="hidden_services">Onion Services</string>
+    <string name="title_activity_hidden_services">Onion Services</string>
+    <string name="menu_hidden_services">Onion Services</string>
     <string name="save">Save</string>
     <string name="local_port">Local Port</string>
     <string name="onion_port">Onion Port</string>

--- a/orbotservice/src/main/res/values/strings.xml
+++ b/orbotservice/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
   <string name="your_relay_settings_caused_an_exception_">Your relay settings caused an exception!</string>
     <string name="found_existing_tor_process">found existing Tor process&#8230;</string>
   <string name="something_bad_happened">Something bad happened. Check the log</string>
-    <string name="unable_to_read_hidden_service_name">unable to read hidden service name</string>
+    <string name="unable_to_read_hidden_service_name">unable to read onion service name</string>
   <string name="unable_to_start_tor">Unable to start Tor:</string>
 
     <string name="no_internet_connection_tor">No internet connection; Tor is on standby…</string>


### PR DESCRIPTION
As described in #132, the Tor Project has deprecated the use of the name *hidden service* and has adopted *onion service* as a replacement.

Closes #132