### PR TITLE
String resource missed from #222

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
     <string name="polipo_version">Polipo: https://github.com/jech/polipo</string>
     <string name="obfsproxy_version">Obfs4proxy: https://github.com/Yawning/obfs4</string>
     <string name="openssl_version">OpenSSL: http://www.openssl.org</string>
-    <string name="hidden_service_request">An app wants to open hidden server port %1$s to the Tor network. This is safe if you trust the app.</string>
+    <string name="hidden_service_request">An app wants to open onion server port %1$s to the Tor network. This is safe if you trust the app.</string>
     <string name="found_existing_tor_process">found existing Tor process&#8230;</string>
     <string name="something_bad_happened">Something bad happened. Check the log</string>
     <string name="unable_to_read_hidden_service_name">unable to read onion service name</string>


### PR DESCRIPTION
The string resource `hidden_service_request` was missed in the "hidden service" to "onion service" rename in #222