### PR TITLE
Fixes VPN Request Cancel Bugs

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -602,7 +602,7 @@ public class OrbotMainActivity extends AppCompatActivity
         Prefs.putUseVpn(enable);
 
         if (enable) {
-            startActivity(new Intent(OrbotMainActivity.this, VPNEnableActivity.class));
+            startActivityForResult(new Intent(OrbotMainActivity.this, VPNEnableActivity.class), REQUEST_VPN);
         } else
             stopVpnService();
 
@@ -952,8 +952,9 @@ public class OrbotMainActivity extends AppCompatActivity
 			if (response == RESULT_OK) {
                 sendIntentToService(TorServiceConstants.CMD_VPN);
             }
-			else
+			else if (response == VPNEnableActivity.ACTIVITY_RESULT_VPN_DENIED)
 			{
+			    mBtnVPN.setChecked(false);
 				Prefs.putUseVpn(false);
 			}
         }

--- a/app/src/main/java/org/torproject/android/vpn/VPNEnableActivity.java
+++ b/app/src/main/java/org/torproject/android/vpn/VPNEnableActivity.java
@@ -24,20 +24,15 @@ public class VPNEnableActivity extends AppCompatActivity {
 	private Handler h = new Handler();
 	
 	@Override
-	public void onCreate( Bundle icicle ) {
-		
+	public void onCreate(Bundle icicle ) {
 		requestWindowFeature(Window.FEATURE_NO_TITLE);
-        //getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
 		super.onCreate( icicle );
 
 		Log.d("VPNEnableActivity","prompting user to start Orbot VPN");
-
-		
 	}
 	
-	public void onResume ()
-	{
+	public void onResume() {
 		super.onResume();
 		
 		if (checkVpn)
@@ -53,10 +48,9 @@ public class VPNEnableActivity extends AppCompatActivity {
 		}
 	}
 	
-	public void promptStartVpnService ()
-    {
+	public void promptStartVpnService () {
+		// todo no actual prompting happens here and this should be refactored
 		startVpnService();
-         
     }
 	 
 	private void startVpnService ()
@@ -88,27 +82,27 @@ public class VPNEnableActivity extends AppCompatActivity {
    		}
 
 	}
-	
-	  @Override
-	    protected void onActivityResult(int request, int response, Intent data) {
-	        super.onActivityResult(request, response, data);
+
+	public static final int ACTIVITY_RESULT_VPN_DENIED = 63;
+
+	@Override
+	protected void onActivityResult(int request, int response, Intent data) {
+		super.onActivityResult(request, response, data);
 	        
-	        if (request == REQUEST_VPN && response == RESULT_OK)
-	        {
-	            sendIntentToService(TorServiceConstants.CMD_VPN);	    
-	            
-	            h.postDelayed(new Runnable () {
-	            	
-	            	public void run ()
-	            	{
-	            		sendIntentToService(TorServiceConstants.ACTION_START);		
-	            		 finish();
+		if (request == REQUEST_VPN && response == RESULT_OK) {
+			sendIntentToService(TorServiceConstants.CMD_VPN);
+			h.postDelayed(new Runnable () {
+	            	@Override
+	            	public void run () {
+	            		sendIntentToService(TorServiceConstants.ACTION_START);
+	            		finish();
 	            	}
 	            }, 1000);
-	            
-	           
-	            
-	        }
+		}
+		else if (request == REQUEST_VPN && response == RESULT_CANCELED) {
+			setResult(ACTIVITY_RESULT_VPN_DENIED);
+			finish();
+		}
 	  }
 	  
 
@@ -122,8 +116,5 @@ public class VPNEnableActivity extends AppCompatActivity {
 			{
 				startService(torService);
 			}
-
-
 		}
-    
 }


### PR DESCRIPTION
When the VPN Permission is denied the app is left on a blank screen that the user has to manually back out of.

This happens during onboarding:
![vpn_bug_onboarding](https://user-images.githubusercontent.com/22125581/60231960-1999ab00-9869-11e9-8674-4d265db5bf4f.gif)

And also on the main screen:
![vpn_bug_main](https://user-images.githubusercontent.com/22125581/60231996-36ce7980-9869-11e9-83a5-51915152fbdf.gif)

Additionally, if you invoke deny the permission for VPN from the main screen, the VPN switch is still checked despite the app being unable to actually do anything with VPNs. This is also fixed in this pull request: 
![vpn_switch_working](https://user-images.githubusercontent.com/22125581/60232036-58c7fc00-9869-11e9-953d-062387cdb1b2.gif)
 