### PR TITLE
Separate Constants For VPN, TOR and MAIN_APP

### DIFF
--- a/app/src/main/java/org/torproject/android/MainConstants.java
+++ b/app/src/main/java/org/torproject/android/MainConstants.java
@@ -1,0 +1,15 @@
+package org.torproject.android;
+
+public interface MainConstants {
+
+    //EXIT COUNTRY CODES
+    String[] COUNTRY_CODES = {"DE","AT","SE","CH","IS","CA","US","ES","FR","BG","PL","AU","BR","CZ","DK","FI","GB","HU","NL","JP","RO","RU","SG","SK"};
+
+    //path to check Tor against
+    String URL_TOR_CHECK = "https://check.torproject.org";
+
+    String URL_TOR_BRIDGES = "https://bridges.torproject.org/bridges?transport=";
+
+    int RESULT_CLOSE_ALL = 0;
+
+}

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -21,6 +21,8 @@ import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.TorService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.TorServiceUtils;
+import org.torproject.android.service.vpn.VpnConstants;
+import org.torproject.android.service.vpn.VpnPrefs;
 import org.torproject.android.settings.Languages;
 import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.settings.SettingsPreferences;
@@ -88,6 +90,11 @@ import com.google.zxing.integration.android.IntentResult;
 import pl.bclogic.pulsator4droid.library.PulsatorLayout;
 
 import static android.support.v4.content.FileProvider.getUriForFile;
+import static org.torproject.android.MainConstants.COUNTRY_CODES;
+import static org.torproject.android.MainConstants.RESULT_CLOSE_ALL;
+import static org.torproject.android.MainConstants.URL_TOR_CHECK;
+import static org.torproject.android.service.vpn.VpnPrefs.PREFS_KEY_TORIFIED;
+import static org.torproject.android.service.vpn.VpnUtils.getSharedPrefs;
 
 public class OrbotMainActivity extends AppCompatActivity
         implements OrbotConstants, OnLongClickListener {
@@ -195,6 +202,11 @@ public class OrbotMainActivity extends AppCompatActivity
             startActivity(new Intent(this,OnboardingActivity.class));
         }
 
+        /**
+         * Resets previous DNS Port to the default
+         */
+        getSharedPrefs(getApplicationContext()).edit().putInt(VpnPrefs.PREFS_DNS_PORT,
+                VpnConstants.TOR_DNS_PORT_DEFAULT).apply();
 
     }
 
@@ -375,11 +387,11 @@ public class OrbotMainActivity extends AppCompatActivity
             ArrayList<String> cList = new ArrayList<String>();
             cList.add(0, getString(R.string.vpn_default_world));
 
-            for (int i = 0; i < TorServiceConstants.COUNTRY_CODES.length; i++) {
-                Locale locale = new Locale("", TorServiceConstants.COUNTRY_CODES[i]);
+            for (int i = 0; i < COUNTRY_CODES.length; i++) {
+                Locale locale = new Locale("", COUNTRY_CODES[i]);
                 cList.add(locale.getDisplayCountry());
 
-                if (currentExit.contains(TorServiceConstants.COUNTRY_CODES[i]))
+                if (currentExit.contains(COUNTRY_CODES[i]))
                     selIdx = i + 1;
             }
 
@@ -407,7 +419,7 @@ public class OrbotMainActivity extends AppCompatActivity
                     if (position == 0)
                         country = "";
                     else
-                        country = '{' + TorServiceConstants.COUNTRY_CODES[position - 1] + '}';
+                        country = '{' + COUNTRY_CODES[position - 1] + '}';
 
                     Intent torService = new Intent(OrbotMainActivity.this, TorService.class);
                     torService.setAction(TorServiceConstants.CMD_SET_EXIT);

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -38,6 +38,8 @@ import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import static org.torproject.android.service.vpn.VpnPrefs.PREFS_KEY_TORIFIED;
+
 public class AppManagerActivity extends AppCompatActivity implements OnClickListener, OrbotConstants {
 
     private GridView listApps;

--- a/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
@@ -26,6 +26,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 
+import static org.torproject.android.MainConstants.URL_TOR_BRIDGES;
+
 public class BridgeWizardActivity extends AppCompatActivity {
 
     private TextView tvStatus;
@@ -128,7 +130,7 @@ public class BridgeWizardActivity extends AppCompatActivity {
                 .setPositiveButton(R.string.get_bridges_web, new Dialog.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        openBrowser(OrbotConstants.URL_TOR_BRIDGES, true);
+                        openBrowser(URL_TOR_BRIDGES, true);
                     }
                 }).show();
     }

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -7,25 +7,12 @@ public interface OrbotConstants {
 
 	String TAG = "Orbot";
 
-	String PREFS_KEY = "OrbotPrefs";
-	String PREFS_KEY_TORIFIED = "PrefTord";
-
-	int FILE_WRITE_BUFFER_SIZE = 2048;
-	
-	//path to check Tor against
-	String URL_TOR_CHECK = "https://check.torproject.org";
-	
-    String URL_TOR_BRIDGES = "https://bridges.torproject.org/bridges?transport=";
-
-	String PREF_BRIDGES_UPDATED = "pref_bridges_enabled";
-	//String PREF_BRIDGES_OBFUSCATED = "pref_bridges_obfuscated";
     String PREF_OR = "pref_or";
     String PREF_OR_PORT = "pref_or_port";
     String PREF_OR_NICKNAME = "pref_or_nickname";
     String PREF_REACHABLE_ADDRESSES = "pref_reachable_addresses";
     String PREF_REACHABLE_ADDRESSES_PORTS = "pref_reachable_addresses_ports";
-	 int RESULT_CLOSE_ALL = 0;
-	
+
 	String PREF_DISABLE_NETWORK = "pref_disable_network";
 	
 	String PREF_TOR_SHARED_PREFS = "org.torproject.android_preferences";

--- a/orbotservice/src/main/java/org/torproject/android/service/TorService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorService.java
@@ -51,6 +51,7 @@ import org.torproject.android.service.util.TorServiceUtils;
 import org.torproject.android.service.util.Utils;
 import org.torproject.android.service.vpn.OrbotVpnManager;
 import org.torproject.android.service.vpn.TorVpnService;
+import org.torproject.android.service.vpn.VpnPrefs;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -80,6 +81,9 @@ import java.util.concurrent.TimeoutException;
 
 import info.pluggabletransports.dispatch.util.TransportListener;
 import info.pluggabletransports.dispatch.util.TransportManager;
+
+import static org.torproject.android.service.vpn.VpnUtils.getSharedPrefs;
+import static org.torproject.android.service.vpn.VpnUtils.killProcess;
 
 public class TorService extends Service implements TorServiceConstants, OrbotConstants
 {
@@ -492,7 +496,7 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
         }
         // if that fails, try again using native utils
         try {
-        	TorServiceUtils.killProcess(fileTor, "-1"); // this is -HUP
+            killProcess(fileTor, "-1"); // this is -HUP
         } catch (Exception e) {
             e.printStackTrace();
         } 
@@ -1105,6 +1109,8 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
                         confDns = st.nextToken().split(":")[1];
                         confDns = confDns.substring(0,confDns.length()-1);
                         mPortDns = Integer.parseInt(confDns);
+                        getSharedPrefs(getApplicationContext()).edit().putInt(VpnPrefs.PREFS_DNS_PORT, mPortDns).apply();
+
 
                         String confTrans = conn.getInfo("net/listeners/trans");
                         st = new StringTokenizer(confTrans," ");

--- a/orbotservice/src/main/java/org/torproject/android/service/TorServiceConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorServiceConstants.java
@@ -7,67 +7,29 @@ import android.content.Intent;
 
 public interface TorServiceConstants {
 
-	String TOR_APP_USERNAME = "org.torproject.android";
 
-	//String DIRECTORY_TOR_BINARY = "bin";
 	String DIRECTORY_TOR_DATA = "data";
 
 	String TOR_CONTROL_PORT_FILE = "control.txt";
-
-	//name of the tor C binary
-	String TOR_ASSET_KEY = "tor";	
 	
 	//torrc (tor config file)
 	String TORRC_ASSET_KEY = "torrc";
-	String TORRCDIAG_ASSET_KEY = "torrcdiag";
-	String TORRC_TETHER_KEY = "torrctether";
 	
 	String TOR_CONTROL_COOKIE = "control_auth_cookie";
-	
-	//privoxy
-	String POLIPO_ASSET_KEY = "polipo";
-	
-	//privoxy.config
-	String POLIPOCONFIG_ASSET_KEY = "torpolipo.conf";
 	
 	//geoip data file asset key
 	String GEOIP_ASSET_KEY = "geoip";
 	String GEOIP6_ASSET_KEY = "geoip6";
 
-	//various console cmds
-	String SHELL_CMD_CHMOD = "chmod";
-	String SHELL_CMD_KILL = "kill -9";
-	String SHELL_CMD_RM = "rm";
-	String SHELL_CMD_PS = "toolbox ps";
-	String SHELL_CMD_PS_ALT = "ps";
-    
-    
-	//String SHELL_CMD_PIDOF = "pidof";
-	String SHELL_CMD_LINK = "ln -s";
-	String SHELL_CMD_CP = "cp";
-	
-
-	String CHMOD_EXE_VALUE = "770";
-
-	int FILE_WRITE_BUFFER_SIZE = 1024;
-
 	String IP_LOCALHOST = "127.0.0.1";
-//	int UPDATE_TIMEOUT = 1000;
 	int TOR_TRANSPROXY_PORT_DEFAULT = 9040;
 	
-//	int STANDARD_DNS_PORT = 53;
 	int TOR_DNS_PORT_DEFAULT = 5400;
-//	String TOR_VPN_DNS_LISTEN_ADDRESS = "127.0.0.1";
-	
-//	int CONTROL_PORT_DEFAULT = 9051;
+
     String HTTP_PROXY_PORT_DEFAULT = "8118"; // like Privoxy!
     String SOCKS_PROXY_PORT_DEFAULT = "9050";
 
-	//path to check Tor against
-	String URL_TOR_CHECK = "https://check.torproject.org";
-
     //control port 
-    String TOR_CONTROL_PORT_MSG_BOOTSTRAP_DONE = "Bootstrapped 100%";
     String LOG_NOTICE_HEADER = "NOTICE";
     String LOG_NOTICE_BOOTSTRAPPED = "Bootstrapped";
     
@@ -136,17 +98,10 @@ public interface TorServiceConstants {
      String CMD_UPDATE_TRANS_PROXY = "update";
      String CMD_SET_EXIT = "setexit";
 
-   //  String BINARY_TOR_VERSION = "0.3.1.8-openssl1.0.2k";
      String PREF_BINARY_TOR_VERSION_INSTALLED = "BINARY_TOR_VERSION_INSTALLED";
     
     //obfsproxy 
      String OBFSCLIENT_ASSET_KEY = "obfs4proxy";
-    
-   //  String MEEK_ASSET_KEY = "meek-client";
-
-	//EXIT COUNTRY CODES
-	String[] COUNTRY_CODES = {"DE","AT","SE","CH","IS","CA","US","ES","FR","BG","PL","AU","BR","CZ","DK","FI","GB","HU","NL","JP","RO","RU","SG","SK"};
-
 
 	 String HIDDEN_SERVICES_DIR = "hidden_services";
 

--- a/orbotservice/src/main/java/org/torproject/android/service/util/TorServiceUtils.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/TorServiceUtils.java
@@ -2,159 +2,21 @@
 /* See LICENSE for licensing information */
 package org.torproject.android.service.util;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import org.torproject.android.service.OrbotConstants;
 import org.torproject.android.service.TorServiceConstants;
 
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
 public class TorServiceUtils implements TorServiceConstants {
 
-	
-	
-	public static int findProcessId(String command) throws IOException 
-	{
-		int procId = findProcessIdWithPS(command);
-		return procId;
-	}
-	
-	//use 'pidof' command
-	/**
-	public static int findProcessIdWithPidOf(String command) throws Exception
-	{
-		
-		int procId = -1;
-		
-		Runtime r = Runtime.getRuntime();
-		    	
-		Process procPs = null;
-		
-		String baseName = new File(command).getName();
-		//fix contributed my mikos on 2010.12.10
-		procPs = r.exec(new String[] {SHELL_CMD_PIDOF, baseName});
-        //procPs = r.exec(SHELL_CMD_PIDOF);
-            
-        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
-        String line = null;
-
-        while ((line = reader.readLine())!=null)
-        {
-        
-        	try
-        	{
-        		//this line should just be the process id
-        		procId = Integer.parseInt(line.trim());
-        		break;
-        	}
-        	catch (NumberFormatException e)
-        	{
-        		Log.e("TorServiceUtils","unable to parse process pid: " + line,e);
-        	}
-        }
-            
-       
-        return procId;
-
-	}
-	 * @throws IOException */
-	
-	//use 'ps' command
-	public static int findProcessIdWithPS(String command) throws IOException 
-	{
-		
-		int procId = -1;
-		
-		Runtime r = Runtime.getRuntime();
-		    	
-		Process procPs = null;
-		
-        procPs = r.exec(SHELL_CMD_PS); // this is the android ps <name> command
-            
-        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
-        String line = null;
-        
-        while ((line = reader.readLine())!=null)
-        {
-        	if (line.contains("PID"))
-        		continue;
-        		
-        	if (line.contains(command))
-        	{
-        		
-        		String[] lineParts = line.split("\\s+");
-        		
-        	    try { 
-        	        
-        	        procId = Integer.parseInt(lineParts[1]); //for most devices it is the second number
-        	    } catch(NumberFormatException e) {
-        	    	procId = Integer.parseInt(lineParts[0]); //but for samsungs it is the first
-        	        
-        	    }
-        		
-        		
-        		break;
-        	}
-        }
-        
-        try { procPs.destroy(); } catch (Exception e) {} // try to destroy just to make sure we clean it up
-       
-        return procId;
-
-	}
-	
 	public static SharedPreferences getSharedPrefs (Context context) {
 		return context.getSharedPreferences(OrbotConstants.PREF_TOR_SHARED_PREFS,0 | Context.MODE_MULTI_PROCESS);
 	}
-	
-	public static void killProcess(File fileProcBin) throws Exception {
-        killProcess(fileProcBin, "-9"); // this is -KILL
-    }
-
-    public static void killProcess(File fileProcBin, String signal) throws Exception {
-        int procId = -1;
-        int killAttempts = 0;
-
-        while ((procId = TorServiceUtils.findProcessId(fileProcBin.getCanonicalPath())) != -1) {
-            killAttempts++;
-            //logNotice("Found " + fileProcBin.getName() + " PID=" + procId + " - killing now...");
-            String pidString = String.valueOf(procId);
-            /*
-             * first try as the normal app user to be safe, then if that fails,
-             * try root since the process might be left over from
-             * uninstall/reinstall with different UID.
-             */
-
-			/**
-            if (Prefs.useRoot() && killAttempts > 2) {
-                shell = Shell.startRootShell();
-                Log.i(OrbotApp.TAG, "using a root shell");
-            } else {
-                shell = Shell.startShell();
-            }*/
-
-            try { Runtime.getRuntime().exec("busybox killall " + signal + " " + fileProcBin.getName());}catch(IOException ioe){}
-			try { Runtime.getRuntime().exec("toolbox kill " + signal + " " + pidString);}catch(IOException ioe){}
-			try { Runtime.getRuntime().exec("busybox kill " + signal + " " + pidString);}catch(IOException ioe){}
-			try { Runtime.getRuntime().exec("kill " + signal + " " + pidString);}catch(IOException ioe){}
-
-			try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                // ignored
-            }
-
-            if (killAttempts > 4)
-                throw new Exception("Cannot kill: " + fileProcBin.getAbsolutePath());
-        }
-    }
 
     public static boolean isPortOpen(final String ip, final int port, final int timeout) {
         try {

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -17,7 +17,6 @@
 package org.torproject.android.service.vpn;
 
 import android.annotation.TargetApi;
-import android.app.Application;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -37,9 +36,6 @@ import com.runjva.sourceforge.jsocks.protocol.ProxyServer;
 import com.runjva.sourceforge.jsocks.server.ServerAuthenticatorNone;
 
 import org.torproject.android.service.R;
-import org.torproject.android.service.TorService;
-import org.torproject.android.service.TorServiceConstants;
-import org.torproject.android.service.util.TorServiceUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -51,6 +47,9 @@ import java.io.PrintStream;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
+
+import static org.torproject.android.service.vpn.VpnUtils.getSharedPrefs;
+import static org.torproject.android.service.vpn.VpnUtils.killProcess;
 
 public class OrbotVpnManager implements Handler.Callback {
     private static final String TAG = "OrbotVpnService";
@@ -250,7 +249,7 @@ public class OrbotVpnManager implements Handler.Callback {
         Tun2Socks.Stop();
         
         try {
-        	TorServiceUtils.killProcess(filePdnsd);
+        	killProcess(filePdnsd);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -278,7 +277,7 @@ public class OrbotVpnManager implements Handler.Callback {
         	Tun2Socks.Stop();
         }
 
-        final int localDns = TorService.mPortDns;
+		final int localDns = getSharedPrefs(this.mService.getApplicationContext()).getInt(VpnPrefs.PREFS_DNS_PORT, 0);
         
     	mThreadVPN = new Thread ()
     	{
@@ -367,7 +366,7 @@ public class OrbotVpnManager implements Handler.Callback {
 	private void doLollipopAppRouting (Builder builder) throws NameNotFoundException
     {    
     	   
-        ArrayList<TorifiedApp> apps = TorifiedApp.getApps(mService, TorServiceUtils.getSharedPrefs(mService.getApplicationContext()));
+        ArrayList<TorifiedApp> apps = TorifiedApp.getApps(mService, getSharedPrefs(mService.getApplicationContext()));
     
         boolean perAppEnabled = false;
         
@@ -393,7 +392,7 @@ public class OrbotVpnManager implements Handler.Callback {
     	
     	if (!isRestart)
     	{
-	    	SharedPreferences prefs = TorServiceUtils.getSharedPrefs(mService.getApplicationContext()); 
+	    	SharedPreferences prefs = getSharedPrefs(mService.getApplicationContext());
 	        prefs.edit().putBoolean("pref_vpn", false).commit();      
 	    	stopVPN();	
     	}

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/PDNSDInstaller.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/PDNSDInstaller.java
@@ -1,34 +1,24 @@
 package org.torproject.android.service.vpn;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.util.Log;
+
+import org.torproject.android.service.util.CustomNativeLoader;
+
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.StringBufferInputStream;
-import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
-import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.os.Build;
-import android.util.Log;
+import static org.torproject.android.service.vpn.VpnConstants.FILE_WRITE_BUFFER_SIZE;
 
-import org.torproject.android.service.OrbotConstants;
-import org.torproject.android.service.R;
-import org.torproject.android.service.TorServiceConstants;
-import org.torproject.android.service.util.CustomNativeLoader;
-import org.torproject.android.service.util.NativeLoader;
-
-public class PDNSDInstaller implements TorServiceConstants {
+public class PDNSDInstaller {
 
     private final static String LIB_NAME = "pdnsd";
     private final static String LIB_SO_NAME = "pdnsd.so";

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -7,14 +7,14 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 
-import org.torproject.android.service.OrbotConstants;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
+
+import static org.torproject.android.service.vpn.VpnPrefs.PREFS_KEY_TORIFIED;
 
 public class TorifiedApp implements Comparable {
 
@@ -153,7 +153,7 @@ public class TorifiedApp implements Comparable {
 	public static ArrayList<TorifiedApp> getApps (Context context, SharedPreferences prefs)
 	{
 
-		String tordAppString = prefs.getString(OrbotConstants.PREFS_KEY_TORIFIED, "");
+		String tordAppString = prefs.getString(PREFS_KEY_TORIFIED, "");
 		String[] tordApps;
 
 		StringTokenizer st = new StringTokenizer(tordAppString,"|");

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnConstants.java
@@ -1,0 +1,14 @@
+package org.torproject.android.service.vpn;
+
+import org.torproject.android.service.TorServiceConstants;
+
+public interface VpnConstants {
+
+    int FILE_WRITE_BUFFER_SIZE = 2048;
+
+    String SHELL_CMD_PS = "toolbox ps";
+
+    //Keep Aligned with TorServiceContants,
+    int TOR_DNS_PORT_DEFAULT = TorServiceConstants.TOR_DNS_PORT_DEFAULT;
+
+}

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnPrefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnPrefs.java
@@ -1,0 +1,15 @@
+package org.torproject.android.service.vpn;
+
+public interface VpnPrefs {
+
+    String PREFS_DNS_PORT= "PREFS_DNS_PORT";
+
+    String PREFS_KEY_TORIFIED = "PrefTord";
+
+    /**
+     * Keep this in sync with the one in TorServiceUtils
+     */
+    String PREF_TOR_SHARED_PREFS = "org.torproject.android_preferences";
+
+
+}

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnUtils.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnUtils.java
@@ -1,0 +1,84 @@
+package org.torproject.android.service.vpn;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static java.lang.Runtime.getRuntime;
+import static org.torproject.android.service.vpn.VpnConstants.SHELL_CMD_PS;
+import static org.torproject.android.service.vpn.VpnPrefs.PREF_TOR_SHARED_PREFS;
+
+public class VpnUtils {
+
+    public static SharedPreferences getSharedPrefs(Context context) {
+        return context.getSharedPreferences(PREF_TOR_SHARED_PREFS,
+                Context.MODE_MULTI_PROCESS);
+    }
+
+    public static int findProcessId(String command) throws IOException {
+        Process procPs = getRuntime().exec(SHELL_CMD_PS);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(procPs.getInputStream()));
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (!line.contains("PID") && line.contains(command)) {
+                String[] lineParts = line.split("\\s+");
+                try {
+                    return Integer.parseInt(lineParts[1]); //for most devices it is the second
+                } catch (NumberFormatException e) {
+                    return Integer.parseInt(lineParts[0]); //but for samsungs it is the first
+                } finally {
+                    try {
+                        procPs.destroy();
+                    } catch (Exception e) {
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    public static void killProcess(File fileProcBin) throws Exception {
+        killProcess(fileProcBin, "-9"); // this is -KILL
+    }
+
+    public static void killProcess(File fileProcBin, String signal) throws Exception {
+        int procId = -1;
+        int killAttempts = 0;
+
+        while ((procId = findProcessId(fileProcBin.getCanonicalPath())) != -1) {
+            killAttempts++;
+            String pidString = String.valueOf(procId);
+            try {
+                getRuntime().exec("busybox killall " + signal + " " + fileProcBin.getName
+                        ());
+            } catch (IOException ioe) {
+            }
+            try {
+                getRuntime().exec("toolbox kill " + signal + " " + pidString);
+            } catch (IOException ioe) {
+            }
+            try {
+                getRuntime().exec("busybox kill " + signal + " " + pidString);
+            } catch (IOException ioe) {
+            }
+            try {
+                getRuntime().exec("kill " + signal + " " + pidString);
+            } catch (IOException ioe) {
+            }
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+
+            if (killAttempts > 4)
+                throw new Exception("Cannot kill: " + fileProcBin.getAbsolutePath());
+        }
+    }
+}


### PR DESCRIPTION
Took Orbot constants and broke it apart based upon module usage. This will help with encapsulation and provided some additional cohesion for the VPN and the Tor Service modules.

Specifically, I introduced VpnConstants and VpnPrefs to contain Vpn specific information. The app also has a MainConstants, containing constants it needs.

I moved some methods from TorServiceUtils to VpnUtils to help with layering. The sharedPrefs method is duplicated but this assists with the separation for now.

The other thing to note is that the dnsPort is now set as a pref, rather than directly as a field on TorService. This removes a direct dependency.

Note this merge also includes #237 (Unfortunately I need this to build in my environment)