### PR TITLE
Fixed VPN App UI for apps that were disabled or uninstalled

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -49,6 +49,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.database.Cursor;
@@ -1321,19 +1322,17 @@ public class OrbotMainActivity extends AppCompatActivity
                 String tordAppString = mPrefs.getString(PREFS_KEY_TORIFIED, "");
 
                 if (TextUtils.isEmpty(tordAppString)) {
-                    TextView tv = new TextView(this);
-                    LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-                    params.setMargins(12, 3, 3, 3);
-                    tv.setLayoutParams(params);
-                    tv.setText(R.string.full_device_vpn);
-                    llBoxShortcuts.addView(tv);
+                    addFullDeviceVpnView(llBoxShortcuts);
                 } else {
                     StringTokenizer st = new StringTokenizer(tordAppString, "|");
                     while (st.hasMoreTokens() && pkgIds.size() < 4)
                         pkgIds.add(st.nextToken());
-
+                    int appsAdded = 0;
                     for (final String pkgId : pkgIds) {
                         try {
+                            ApplicationInfo aInfo = getPackageManager().getApplicationInfo(pkgId, 0);
+                            // skip disabled packages
+                            if (!aInfo.enabled) continue;
                             ImageView iv = new ImageView(this);
                             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
                             params.setMargins(3, 3, 3, 3);
@@ -1348,10 +1347,16 @@ public class OrbotMainActivity extends AppCompatActivity
                             });
 
                             llBoxShortcuts.addView(iv);
-
+                            appsAdded++;
                         } catch (Exception e) {
                             //package not installed?
                         }
+                    }
+                    if (appsAdded == 0) {
+                        /* if a user uninstalled or disabled all apps that were set on the device
+                           then we want to have the no apps added view appear even though
+                           the tordAppString variable is not empty */
+                        addFullDeviceVpnView(llBoxShortcuts);
                     }
                 }
             }
@@ -1381,6 +1386,15 @@ public class OrbotMainActivity extends AppCompatActivity
             });
         }
 
+    }
+
+    private void addFullDeviceVpnView(LinearLayout llBoxShortcuts) {
+        TextView tv = new TextView(this);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        params.setMargins(12, 3, 3, 3);
+        tv.setLayoutParams(params);
+        tv.setText(R.string.full_device_vpn);
+        llBoxShortcuts.addView(tv);
     }
 
 }

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -16,6 +16,7 @@ import org.torproject.android.R;
 import org.torproject.android.service.util.TorServiceUtils;
 import org.torproject.android.service.vpn.TorifiedApp;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -204,7 +205,8 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
         while (itAppInfo.hasNext())
         {
             aInfo = itAppInfo.next();
-
+            // don't include apps user has disabled, often these ship with the device
+            if (!aInfo.enabled) continue;
             app = new TorifiedApp();
 
             try {
@@ -214,10 +216,9 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
                 {
                     for (String permInfo:pInfo.requestedPermissions)
                     {
-                        if (permInfo.equals("android.permission.INTERNET"))
+                        if (permInfo.equals(Manifest.permission.INTERNET))
                         {
                             app.setUsesInternet(true);
-
                         }
                     }
 
@@ -228,14 +229,6 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
-
-            /**
-             if ((aInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 1)
-             {
-             //System app
-             app.setUsesInternet(true);
-             }**/
-
 
             try
             {

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -1,5 +1,6 @@
 package org.torproject.android.service.vpn;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
@@ -193,7 +194,7 @@ public class TorifiedApp implements Comparable {
 				{
 					for (String permInfo:pInfo.requestedPermissions)
 					{
-						if (permInfo.equals("android.permission.INTERNET"))
+						if (permInfo.equals(Manifest.permission.INTERNET))
 						{
 							app.setUsesInternet(true);
 


### PR DESCRIPTION
There was a glitch on the VPN app UI screen creating an inconsistent user experience. If a user disabled an app, it would still appear in the VPN app selection screen despite not appearing in their launcher or anywhere else on the device.

Similarly, if a disabled app was on enabled for VPN within Orbot, it would appear on the main screen despite being disabled. 

Finally, if a user had previously enabled any app to use the VPN functionality, but then uninstalled or disabled that app, and there were no other apps active apps configured to use the VPN, the vpn app area on the main screen would be empty because because none of the apps saved to Orbot's preferences were found. If this is the case, we render the same UI that is used if no apps are saved to Orbot's preferences.

Also I replaced some string literals used for the `INTERNET` permission with references to constants defined in the Android framework 