### PR TITLE
After following the BUILD file, could not build the apk because of a …

### DIFF
--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -6,7 +6,7 @@ android {
 
     sourceSets {
         main {
-            jni.srcDirs = []
+            jniLibs.srcDirs = ['./src/main/libs']
         }
     }
 


### PR DESCRIPTION
…issue mentioned in #217: Execution failed for task :orbotservice:mergeDebugJniLibFolders. This change fixes that.

This does depend on where your jniLibs end up, but if you follow the instructions in BUILD, that is where they end up.