### PR TITLE
Funding button contains users not enrolled in GitHub sponsors program

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,4 +1,4 @@
 liberapay: GuardianProject
 patreon: guardianproject
-github:
-    - eighthave
+#github:
+#    - eighthave


### PR DESCRIPTION
Commented out the individual github users so the feature doesn't display errors to users:

![image](https://user-images.githubusercontent.com/22125581/68245596-35664800-ffe5-11e9-900b-f8edc4e48a68.png)

@eighthave i think you have to enroll in something to get this feature to work ~ in the mean time, this fixes the button on the website 