### PR TITLE
rename TorService to OrbotService to prep for standalone TorService

### DIFF
--- a/app-mini/src/debug/AndroidManifest.xml
+++ b/app-mini/src/debug/AndroidManifest.xml
@@ -82,7 +82,7 @@
             />
 
         <service
-            android:name="org.torproject.android.service.TorService"
+            android:name="org.torproject.android.service.OrbotService"
             android:enabled="true"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:stopWithTask="false"></service>

--- a/app-mini/src/main/AndroidManifest.xml
+++ b/app-mini/src/main/AndroidManifest.xml
@@ -87,7 +87,7 @@
         </receiver>
 
         <service
-            android:name="org.torproject.android.service.TorService"
+            android:name="org.torproject.android.service.OrbotService"
             android:enabled="true"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:stopWithTask="false" />

--- a/app-mini/src/main/java/org/torproject/android/mini/MiniMainActivity.java
+++ b/app-mini/src/main/java/org/torproject/android/mini/MiniMainActivity.java
@@ -23,14 +23,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.palette.graphics.Palette;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.SwitchCompat;
-import androidx.appcompat.widget.Toolbar;
 import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
@@ -46,6 +38,14 @@ import android.view.animation.AccelerateInterpolator;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.appcompat.widget.Toolbar;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.palette.graphics.Palette;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 import org.json.JSONArray;
@@ -58,10 +58,10 @@ import org.torproject.android.mini.ui.Rotate3dAnimation;
 import org.torproject.android.mini.ui.onboarding.OnboardingActivity;
 import org.torproject.android.mini.vpn.VPNEnableActivity;
 import org.torproject.android.service.OrbotConstants;
-import org.torproject.android.service.vpn.TorVpnService;
-import org.torproject.android.service.TorService;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
+import org.torproject.android.service.vpn.TorVpnService;
 import org.torproject.android.service.vpn.TorifiedApp;
 import org.torproject.android.service.vpn.VpnConstants;
 import org.torproject.android.service.vpn.VpnPrefs;
@@ -163,25 +163,25 @@ public class MiniMainActivity extends AppCompatActivity
 
     }
 
-	private void sendIntentToService(final String action) {
+    private void sendIntentToService(final String action) {
 
-		Intent torService = new Intent(MiniMainActivity.this, TorService.class);
-        torService.setAction(action);
-        startService(torService);
+        Intent intent = new Intent(MiniMainActivity.this, OrbotService.class);
+        intent.setAction(action);
+        startService(intent);
 
-	}
+    }
 
     private void stopTor() {
 
 //        requestTorStatus();
 
-        Intent torService = new Intent(MiniMainActivity.this, TorService.class);
-        stopService(torService);
+        Intent intent = new Intent(MiniMainActivity.this, OrbotService.class);
+        stopService(intent);
 
     }
 
     /**
-     * The state and log info from {@link TorService} are sent to the UI here in
+     * The state and log info from {@link OrbotService} are sent to the UI here in
      * the form of a local broadcast. Regular broadcasts can be sent by any app,
      * so local ones are used here so other apps cannot interfere with Orbot's
      * operation.
@@ -226,8 +226,8 @@ public class MiniMainActivity extends AppCompatActivity
             else if (action.equals(TorServiceConstants.LOCAL_ACTION_PORTS)) {
 
                 Message msg = mStatusUpdateHandler.obtainMessage(MESSAGE_PORTS);
-                msg.getData().putInt("socks",intent.getIntExtra(TorService.EXTRA_SOCKS_PROXY_PORT,-1));
-                msg.getData().putInt("http",intent.getIntExtra(TorService.EXTRA_HTTP_PROXY_PORT,-1));
+                msg.getData().putInt("socks",intent.getIntExtra(OrbotService.EXTRA_SOCKS_PROXY_PORT,-1));
+                msg.getData().putInt("http",intent.getIntExtra(OrbotService.EXTRA_HTTP_PROXY_PORT,-1));
 
                 mStatusUpdateHandler.sendMessage(msg);
 
@@ -386,7 +386,7 @@ public class MiniMainActivity extends AppCompatActivity
             String version = "";
             
             try {
-                version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName + " (Tor " + TorService.BINARY_TOR_VERSION + ")";
+                version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName + " (Tor " + OrbotService.BINARY_TOR_VERSION + ")";
             } catch (NameNotFoundException e) {
                 version = "Version Not Found";
             }
@@ -428,7 +428,7 @@ public class MiniMainActivity extends AppCompatActivity
     /**
      * This is our attempt to REALLY exit Orbot, and stop the background service
      * However, Android doesn't like people "quitting" apps, and/or our code may
-     * not be quite right b/c no matter what we do, it seems like the TorService
+     * not be quite right b/c no matter what we do, it seems like the OrbotService
      * still exists
      **/
     private void doExit() {
@@ -781,7 +781,7 @@ public class MiniMainActivity extends AppCompatActivity
     }
 
     /**
-     * Update the layout_main UI based on the status of {@link TorService}.
+     * Update the layout_main UI based on the status of {@link OrbotService}.
      * {@code torServiceMsg} must never be {@code null}
      */
     private void updateStatus(String torServiceMsg, String newTorStatus) {
@@ -855,7 +855,7 @@ public class MiniMainActivity extends AppCompatActivity
         } else if (torStatus == TorServiceConstants.STATUS_OFF) {
 
             imgStatus.setImageResource(R.drawable.toroff);
-  //          lblStatus.setText("Tor v" + TorService.BINARY_TOR_VERSION);
+  //          lblStatus.setText("Tor v" + OrbotService.BINARY_TOR_VERSION);
 
 
         }
@@ -866,7 +866,7 @@ public class MiniMainActivity extends AppCompatActivity
     /**
      * Starts tor and related daemons by sending an
      * {@link TorServiceConstants#ACTION_START} {@link Intent} to
-     * {@link TorService}
+     * {@link OrbotService}
      */
     private void startTor() {
         sendIntentToService(TorServiceConstants.ACTION_START);
@@ -876,7 +876,7 @@ public class MiniMainActivity extends AppCompatActivity
     /**
      * Request tor status without starting it
      * {@link TorServiceConstants#ACTION_START} {@link Intent} to
-     * {@link TorService}
+     * {@link OrbotService}
      */
     private void requestTorStatus() {
         sendIntentToService(TorServiceConstants.ACTION_STATUS);
@@ -885,7 +885,7 @@ public class MiniMainActivity extends AppCompatActivity
     private boolean isTorServiceRunning() {
         ActivityManager manager = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
-            if (TorService.class.getName().equals(service.service.getClassName())) {
+            if (OrbotService.class.getName().equals(service.service.getClassName())) {
                 return true;
             }
         }

--- a/app-mini/src/main/java/org/torproject/android/mini/OnBootReceiver.java
+++ b/app-mini/src/main/java/org/torproject/android/mini/OnBootReceiver.java
@@ -6,7 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import org.torproject.android.mini.vpn.VPNEnableActivity;
-import org.torproject.android.service.TorService;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 
@@ -38,15 +38,15 @@ public class OnBootReceiver extends BroadcastReceiver {
 
 	private void startService (String action, Context context)
 	{
-		
-		Intent torService = new Intent(context, TorService.class);
-		torService.setAction(action);
+
+		Intent intent = new Intent(context, OrbotService.class);
+		intent.setAction(action);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			context.startForegroundService(torService);
+			context.startForegroundService(intent);
 		}
 		else
 		{
-			context.startService(torService);
+			context.startService(intent);
 		}
 
 	}

--- a/app-mini/src/main/java/org/torproject/android/mini/vpn/VPNEnableActivity.java
+++ b/app-mini/src/main/java/org/torproject/android/mini/vpn/VPNEnableActivity.java
@@ -5,10 +5,10 @@ import android.net.VpnService;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Window;
-import org.torproject.android.service.TorService;
+import androidx.appcompat.app.AppCompatActivity;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.vpn.TorVpnService;
@@ -108,14 +108,14 @@ public class VPNEnableActivity extends AppCompatActivity {
 	  
 
 		private void sendIntentToService(String action) {
-			Intent torService = new Intent(this, TorService.class);    
-			torService.setAction(action);
+			Intent intent = new Intent(this, OrbotService.class);
+			intent.setAction(action);
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				startForegroundService(torService);
+				startForegroundService(intent);
 			}
 			else
 			{
-				startService(torService);
+				startService(intent);
 			}
 		}
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
             android:theme="@style/Theme.AppCompat" />
 
         <service
-            android:name=".service.TorService"
+            android:name=".service.OrbotService"
             android:enabled="true"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:stopWithTask="false"></service>

--- a/app/src/main/java/org/torproject/android/OnBootReceiver.java
+++ b/app/src/main/java/org/torproject/android/OnBootReceiver.java
@@ -5,7 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import org.torproject.android.service.TorService;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.ui.VPNEnableActivity;
@@ -38,15 +38,15 @@ public class OnBootReceiver extends BroadcastReceiver {
 
 	private void startService (String action, Context context)
 	{
-		
-		Intent torService = new Intent(context, TorService.class);
-		torService.setAction(action);
+
+		Intent intent = new Intent(context, OrbotService.class);
+		intent.setAction(action);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			context.startForegroundService(torService);
+			context.startForegroundService(intent);
 		}
 		else
 		{
-			context.startService(torService);
+			context.startService(intent);
 		}
 
 	}

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -24,11 +24,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.RemoteException;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.SwitchCompat;
-import androidx.appcompat.widget.Toolbar;
 import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
@@ -50,11 +45,16 @@ import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.appcompat.widget.Toolbar;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 import org.json.JSONArray;
 import org.torproject.android.service.OrbotConstants;
-import org.torproject.android.service.TorService;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.vpn.TorVpnService;
@@ -210,9 +210,9 @@ public class OrbotMainActivity extends AppCompatActivity
 
 	private void sendIntentToService(final String action) {
 
-		Intent torService = new Intent(OrbotMainActivity.this, TorService.class);
-        torService.setAction(action);
-        startService(torService);
+        Intent intent = new Intent(OrbotMainActivity.this, OrbotService.class);
+        intent.setAction(action);
+        startService(intent);
 
 	}
 
@@ -220,13 +220,13 @@ public class OrbotMainActivity extends AppCompatActivity
 
 //        requestTorStatus();
 
-        Intent torService = new Intent(OrbotMainActivity.this, TorService.class);
-        stopService(torService);
+        Intent intent = new Intent(OrbotMainActivity.this, OrbotService.class);
+        stopService(intent);
 
     }
 
     /**
-     * The state and log info from {@link TorService} are sent to the UI here in
+     * The state and log info from {@link OrbotService} are sent to the UI here in
      * the form of a local broadcast. Regular broadcasts can be sent by any app,
      * so local ones are used here so other apps cannot interfere with Orbot's
      * operation.
@@ -271,8 +271,8 @@ public class OrbotMainActivity extends AppCompatActivity
             else if (action.equals(TorServiceConstants.LOCAL_ACTION_PORTS)) {
 
                 Message msg = mStatusUpdateHandler.obtainMessage(MESSAGE_PORTS);
-                msg.getData().putInt("socks",intent.getIntExtra(TorService.EXTRA_SOCKS_PROXY_PORT,-1));
-                msg.getData().putInt("http",intent.getIntExtra(TorService.EXTRA_HTTP_PROXY_PORT,-1));
+                msg.getData().putInt("socks",intent.getIntExtra(OrbotService.EXTRA_SOCKS_PROXY_PORT,-1));
+                msg.getData().putInt("http",intent.getIntExtra(OrbotService.EXTRA_HTTP_PROXY_PORT,-1));
 
                 mStatusUpdateHandler.sendMessage(msg);
 
@@ -419,10 +419,10 @@ public class OrbotMainActivity extends AppCompatActivity
                     else
                         country = '{' + COUNTRY_CODES[position - 1] + '}';
 
-                    Intent torService = new Intent(OrbotMainActivity.this, TorService.class);
-                    torService.setAction(TorServiceConstants.CMD_SET_EXIT);
-                    torService.putExtra("exit", country);
-                    startService(torService);
+                    Intent intent = new Intent(OrbotMainActivity.this, OrbotService.class);
+                    intent.setAction(TorServiceConstants.CMD_SET_EXIT);
+                    intent.putExtra("exit", country);
+                    startService(intent);
 
                 }
 
@@ -520,7 +520,7 @@ public class OrbotMainActivity extends AppCompatActivity
             String version = "";
             
             try {
-                version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName + " (Tor " + TorService.BINARY_TOR_VERSION + ")";
+                version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName + " (Tor " + OrbotService.BINARY_TOR_VERSION + ")";
             } catch (NameNotFoundException e) {
                 version = "Version Not Found";
             }
@@ -562,7 +562,7 @@ public class OrbotMainActivity extends AppCompatActivity
     /**
      * This is our attempt to REALLY exit Orbot, and stop the background service
      * However, Android doesn't like people "quitting" apps, and/or our code may
-     * not be quite right b/c no matter what we do, it seems like the TorService
+     * not be quite right b/c no matter what we do, it seems like the OrbotService
      * still exists
      **/
     private void doExit() {
@@ -1059,7 +1059,7 @@ public class OrbotMainActivity extends AppCompatActivity
     }
 
     /**
-     * Update the layout_main UI based on the status of {@link TorService}.
+     * Update the layout_main UI based on the status of {@link OrbotService}.
      * {@code torServiceMsg} must never be {@code null}
      */
     private synchronized void updateStatus(String torServiceMsg, String newTorStatus) {
@@ -1136,7 +1136,7 @@ public class OrbotMainActivity extends AppCompatActivity
         } else if (torStatus == TorServiceConstants.STATUS_OFF) {
 
             imgStatus.setImageResource(R.drawable.toroff);
-            lblStatus.setText("Tor v" + TorService.BINARY_TOR_VERSION);
+            lblStatus.setText("Tor v" + OrbotService.BINARY_TOR_VERSION);
 			mBtnStart.setText(R.string.menu_start);
             mPulsator.start();
 
@@ -1148,7 +1148,7 @@ public class OrbotMainActivity extends AppCompatActivity
     /**
      * Starts tor and related daemons by sending an
      * {@link TorServiceConstants#ACTION_START} {@link Intent} to
-     * {@link TorService}
+     * {@link OrbotService}
      */
     private void startTor() {
         sendIntentToService(TorServiceConstants.ACTION_START);
@@ -1158,7 +1158,7 @@ public class OrbotMainActivity extends AppCompatActivity
     /**
      * Request tor status without starting it
      * {@link TorServiceConstants#ACTION_START} {@link Intent} to
-     * {@link TorService}
+     * {@link OrbotService}
      */
     private void requestTorStatus() {
         sendIntentToService(TorServiceConstants.ACTION_STATUS);
@@ -1167,7 +1167,7 @@ public class OrbotMainActivity extends AppCompatActivity
     private boolean isTorServiceRunning() {
         ActivityManager manager = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
-            if (TorService.class.getName().equals(service.service.getClassName())) {
+            if (OrbotService.class.getName().equals(service.service.getClassName())) {
                 return true;
             }
         }

--- a/app/src/main/java/org/torproject/android/ui/VPNEnableActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/VPNEnableActivity.java
@@ -5,10 +5,10 @@ import android.net.VpnService;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Window;
-import org.torproject.android.service.TorService;
+import androidx.appcompat.app.AppCompatActivity;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.vpn.TorVpnService;
@@ -107,14 +107,14 @@ public class VPNEnableActivity extends AppCompatActivity {
 	  
 
 		private void sendIntentToService(String action) {
-			Intent torService = new Intent(this, TorService.class);    
-			torService.setAction(action);
+			Intent intent = new Intent(this, OrbotService.class);
+			intent.setAction(action);
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				startForegroundService(torService);
+				startForegroundService(intent);
 			}
 			else
 			{
-				startService(torService);
+				startService(intent);
 			}
 		}
 }

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -83,7 +83,7 @@ import java.util.concurrent.TimeoutException;
 import static org.torproject.android.service.vpn.VpnUtils.getSharedPrefs;
 import static org.torproject.android.service.vpn.VpnUtils.killProcess;
 
-public class TorService extends Service implements TorServiceConstants, OrbotConstants
+public class OrbotService extends Service implements TorServiceConstants, OrbotConstants
 {
 
     public final static String BINARY_TOR_VERSION = org.torproject.android.binary.TorServiceConstants.BINARY_TOR_VERSION;
@@ -269,7 +269,7 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
          //Reusable code.
          PackageManager pm = getPackageManager();
          Intent intent = pm.getLaunchIntentForPackage(getPackageName());
-         PendingIntent pendIntent = PendingIntent.getActivity(TorService.this, 0, intent, 0);
+         PendingIntent pendIntent = PendingIntent.getActivity(OrbotService.this, 0, intent, 0);
 
         if (mNotifyBuilder == null)
         {
@@ -383,7 +383,7 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
                 	setExitNode(mIntent.getStringExtra("exit"));
 
                 } else {
-                    Log.w(OrbotConstants.TAG, "unhandled TorService Intent: " + action);
+                    Log.w(OrbotConstants.TAG, "unhandled OrbotService Intent: " + action);
                 }
             }
         }
@@ -428,7 +428,7 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
     }
 
     private void stopTorAsync () {
-        Log.i("TorService", "stopTor");
+        Log.i("OrbotService", "stopTor");
         try {
             sendCallbackStatus(STATUS_STOPPING);
             sendCallbackLogMessage(getString(R.string.status_shutting_down));
@@ -569,7 +569,7 @@ public class TorService extends Service implements TorServiceConstants, OrbotCon
             logNotice("There was an error installing Orbot binaries");
         }
 
-        Log.i("TorService", "onCreate end");
+        Log.i("OrbotService", "onCreate end");
     }
 
     protected String getCurrentStatus ()

--- a/orbotservice/src/main/java/org/torproject/android/service/StartTorReceiver.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/StartTorReceiver.java
@@ -13,16 +13,16 @@ public class StartTorReceiver extends BroadcastReceiver implements TorServiceCon
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        /* sanitize the Intent before forwarding it to TorService */
+        /* sanitize the Intent before forwarding it to OrbotService */
         Prefs.setContext(context);
         String action = intent.getAction();
         if (TextUtils.equals(action, ACTION_START)) {
             String packageName = intent.getStringExtra(EXTRA_PACKAGE_NAME);
             if (Prefs.allowBackgroundStarts()) {
-                Intent startTorIntent = new Intent(context, TorService.class);
+                Intent startTorIntent = new Intent(context, OrbotService.class);
                 startTorIntent.setAction(action);
                 if (packageName != null) {
-                    startTorIntent.putExtra(TorService.EXTRA_PACKAGE_NAME, packageName);
+                    startTorIntent.putExtra(OrbotService.EXTRA_PACKAGE_NAME, packageName);
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Prefs.persistNotifications()) {
                     context.startForegroundService(startTorIntent);

--- a/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
@@ -17,7 +17,7 @@ import java.util.StringTokenizer;
  */
 public class TorEventHandler implements EventHandler, TorServiceConstants {
 
-    private TorService mService;
+    private OrbotService mService;
 
 
     private long lastRead = -1;
@@ -45,7 +45,7 @@ public class TorEventHandler implements EventHandler, TorServiceConstants {
         return hmBuiltNodes;
     }
 
-    public TorEventHandler (TorService service)
+    public TorEventHandler (OrbotService service)
     {
         mService = service;
         mNumberFormat = NumberFormat.getInstance(Locale.getDefault()); //localized numbers!

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -34,8 +34,8 @@ import android.widget.Toast;
 import com.runjva.sourceforge.jsocks.protocol.ProxyServer;
 import com.runjva.sourceforge.jsocks.server.ServerAuthenticatorNone;
 import org.torproject.android.service.OrbotConstants;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.R;
-import org.torproject.android.service.TorService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.CustomNativeLoader;
 
@@ -139,8 +139,8 @@ public class OrbotVpnManager implements Handler.Callback {
 			{
 				Log.d(TAG,"starting OrbotVPNService service!");
 
-				int torSocks = intent.getIntExtra(TorService.EXTRA_SOCKS_PROXY_PORT,-1);
-				int torDns = intent.getIntExtra(TorService.EXTRA_DNS_PORT,-1);
+				int torSocks = intent.getIntExtra(OrbotService.EXTRA_SOCKS_PROXY_PORT,-1);
+				int torDns = intent.getIntExtra(OrbotService.EXTRA_DNS_PORT,-1);
 
 				//if running, we need to restart
 				if ((torSocks != mTorSocks || torDns != mTorDns)) {

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorVpnService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorVpnService.java
@@ -8,7 +8,7 @@ import android.content.IntentFilter;
 import android.net.VpnService;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.util.Log;
-import org.torproject.android.service.TorService;
+import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 
@@ -86,7 +86,7 @@ public class TorVpnService extends VpnService {
     }
 
     /**
-     * The state and log info from {@link TorService} are sent to the UI here in
+     * The state and log info from {@link OrbotService} are sent to the UI here in
      * the form of a local broadcast. Regular broadcasts can be sent by any app,
      * so local ones are used here so other apps cannot interfere with Orbot's
      * operation.


### PR DESCRIPTION
This renames Orbot's `TorService` to `OrbotService` since it handles a lot more than just Tor.  Also, this prepares Orbot for the new standalone `TorService.