### PR TITLE
Fixed the welcome screen being blank after rotation 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -194,9 +194,6 @@ public class OrbotMainActivity extends AppCompatActivity
 
         if (showFirstTime)
         {
-            Editor pEdit = mPrefs.edit();
-            pEdit.putBoolean("connect_first_time", false);
-            pEdit.commit();
             startActivity(new Intent(this,OnboardingActivity.class));
         }
 

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -22,8 +22,8 @@ public class CustomSlideBigText extends Fragment {
     private String mButtonText;
     private String mSubTitle;
     private View.OnClickListener mButtonListener;
-    TextView tv, title;
-    Button button;
+    private TextView tv, title;
+    private Button button;
 
     public static CustomSlideBigText newInstance(int layoutResId) {
         CustomSlideBigText sampleSlide = new CustomSlideBigText();
@@ -81,11 +81,12 @@ public class CustomSlideBigText extends Fragment {
 
     }
 
+    //Restoring the data
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            savedInstanceState.getString(getResources().getString(R.string.Title));
+            title.setText(savedInstanceState.getString(getResources().getString(R.string.Title)));
             tv.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
             if (mButtonText != null) {
                 button.setText(savedInstanceState.getString(getResources().getString(R.string.ButtonText)));
@@ -94,6 +95,7 @@ public class CustomSlideBigText extends Fragment {
         }
     }
 
+    //Saving the data
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -21,7 +21,7 @@ public class CustomSlideBigText extends Fragment {
     private String mButtonText;
     private String mSubTitle;
     private View.OnClickListener mButtonListener;
-    private TextView tv, title;
+    private TextView bigTextSub, title;
     private Button button;
 
     public static CustomSlideBigText newInstance(int layoutResId) {
@@ -63,11 +63,11 @@ public class CustomSlideBigText extends Fragment {
         View view = inflater.inflate(layoutResId, container, false);
         title = ((TextView) view.findViewById(R.id.custom_slide_big_text));
         title.setText(mTitle);
-        tv = (TextView) view.findViewById(R.id.custom_slide_big_text_sub);
+        bigTextSub = (TextView) view.findViewById(R.id.custom_slide_big_text_sub);
         if (!TextUtils.isEmpty(mSubTitle)) {
 
-            tv.setText(mSubTitle);
-            tv.setVisibility(View.VISIBLE);
+            bigTextSub.setText(mSubTitle);
+            bigTextSub.setVisibility(View.VISIBLE);
         }
 
         if (mButtonText != null) {
@@ -85,8 +85,8 @@ public class CustomSlideBigText extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            title.setText(savedInstanceState.getString(getResources().getString(R.string.Title)));
-            tv.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
+            title.setText(savedInstanceState.getString(getResources().getString(R.string.Pref_title)));
+            bigTextSub.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
             if (mButtonText != null) {
                 button.setText(savedInstanceState.getString(getResources().getString(R.string.ButtonText)));
             }
@@ -98,7 +98,7 @@ public class CustomSlideBigText extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString(getResources().getString(R.string.Title), mTitle);
+        outState.putString(getResources().getString(R.string.Pref_title), mTitle);
         outState.putString(getResources().getString(R.string.SubTitle), mSubTitle);
         if (mButtonText != null) {
             outState.putString(getResources().getString(R.string.ButtonText), mButtonText);

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -1,14 +1,17 @@
 package org.torproject.android.ui.onboarding;
 
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
+
 import org.torproject.android.R;
 
 public class CustomSlideBigText extends Fragment {
@@ -19,6 +22,8 @@ public class CustomSlideBigText extends Fragment {
     private String mButtonText;
     private String mSubTitle;
     private View.OnClickListener mButtonListener;
+    TextView tv, title;
+    Button button;
 
     public static CustomSlideBigText newInstance(int layoutResId) {
         CustomSlideBigText sampleSlide = new CustomSlideBigText();
@@ -30,15 +35,15 @@ public class CustomSlideBigText extends Fragment {
         return sampleSlide;
     }
 
-    public void setTitle (String title)
-    {
+    public void setTitle(String title) {
         mTitle = title;
     }
 
-    public void setSubTitle(String subTitle) { mSubTitle = subTitle; }
+    public void setSubTitle(String subTitle) {
+        mSubTitle = subTitle;
+    }
 
-    public void showButton (String buttonText, View.OnClickListener buttonListener)
-    {
+    public void showButton(String buttonText, View.OnClickListener buttonListener) {
         mButtonText = buttonText;
         mButtonListener = buttonListener;
     }
@@ -57,19 +62,17 @@ public class CustomSlideBigText extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(layoutResId, container, false);
-        ((TextView)view.findViewById(R.id.custom_slide_big_text)).setText(mTitle);
-
+        title = ((TextView) view.findViewById(R.id.custom_slide_big_text));
+        title.setText(mTitle);
+        tv = (TextView) view.findViewById(R.id.custom_slide_big_text_sub);
         if (!TextUtils.isEmpty(mSubTitle)) {
 
-            TextView tv =
-                    (TextView)view.findViewById(R.id.custom_slide_big_text_sub);
             tv.setText(mSubTitle);
             tv.setVisibility(View.VISIBLE);
         }
 
-        if (mButtonText != null)
-        {
-            Button button = (Button)view.findViewById(R.id.custom_slide_button);
+        if (mButtonText != null) {
+            button = (Button) view.findViewById(R.id.custom_slide_button);
             button.setVisibility(View.VISIBLE);
             button.setText(mButtonText);
             button.setOnClickListener(mButtonListener);
@@ -77,4 +80,28 @@ public class CustomSlideBigText extends Fragment {
         return view;
 
     }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (savedInstanceState != null) {
+            savedInstanceState.getString("Title");
+            tv.setText(savedInstanceState.getString("SubTitle"));
+            if (mButtonText != null) {
+                button.setText(savedInstanceState.getString("ButtonText"));
+            }
+
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("Title", mTitle);
+        outState.putString("SubTitle", mSubTitle);
+        if (mButtonText != null) {
+            outState.putString("ButtonText", mButtonText);
+        }
+    }
+
 }

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -1,16 +1,15 @@
 package org.torproject.android.ui.onboarding;
 
 import android.os.Bundle;
-
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 import org.torproject.android.R;
 

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -85,10 +85,10 @@ public class CustomSlideBigText extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            savedInstanceState.getString("Title");
-            tv.setText(savedInstanceState.getString("SubTitle"));
+            savedInstanceState.getString(getResources().getString(R.string.Title));
+            tv.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
             if (mButtonText != null) {
-                button.setText(savedInstanceState.getString("ButtonText"));
+                button.setText(savedInstanceState.getString(getResources().getString(R.string.ButtonText)));
             }
 
         }
@@ -97,10 +97,10 @@ public class CustomSlideBigText extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString("Title", mTitle);
-        outState.putString("SubTitle", mSubTitle);
+        outState.putString(getResources().getString(R.string.Title), mTitle);
+        outState.putString(getResources().getString(R.string.SubTitle), mSubTitle);
         if (mButtonText != null) {
-            outState.putString("ButtonText", mButtonText);
+            outState.putString(getResources().getString(R.string.ButtonText), mButtonText);
         }
     }
 

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -4,12 +4,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import android.util.Log;
 import android.view.View;
+
 import com.github.paolorotolo.appintro.AppIntro;
+
 import org.torproject.android.R;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.settings.LocaleHelper;
@@ -28,13 +31,13 @@ public class OnboardingActivity extends AppIntro {
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState != null) {
-            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "welcome");
-            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "intro2");
-            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "cs2");
+            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.WelcomeFragment));
+            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.Intro2Fragment));
+            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.CS2Fragment));
             if (PermissionManager.isLollipopOrHigher())
-                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "cs3");
+                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.CS3Fragment));
 
-        }else{
+        } else {
             // Instead of fragments, you can also use our default slide
             // Just set a title, description, background and image. AppIntro will do the rest.
             welcome = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
@@ -52,7 +55,7 @@ public class OnboardingActivity extends AppIntro {
             cs2.showButton(getString(R.string.action_more), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    startActivity(new Intent(OnboardingActivity.this,BridgeWizardActivity.class));
+                    startActivity(new Intent(OnboardingActivity.this, BridgeWizardActivity.class));
                 }
             });
             addSlide(cs2);
@@ -113,13 +116,13 @@ public class OnboardingActivity extends AppIntro {
         }
 
         //Should check if the fragment exists in the fragment manager or else it'll flag error
-        if(count >= 1)
-            getSupportFragmentManager().putFragment(outState, "welcome", welcome);
-        if(count >= 2)
-            getSupportFragmentManager().putFragment(outState, "intro2", intro2);
-        if(count >=3)
-            getSupportFragmentManager().putFragment(outState, "cs2", cs2);
+        if (count >= 1)
+            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.WelcomeFragment), welcome);
+        if (count >= 2)
+            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.Intro2Fragment), intro2);
+        if (count >= 3)
+            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.CS2Fragment), cs2);
         if (count >= 4 && PermissionManager.isLollipopOrHigher())
-            getSupportFragmentManager().putFragment(outState, "cs3", cs3);
+            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.CS3Fragment), cs3);
     }
 }

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -30,7 +30,7 @@ public class OnboardingActivity extends AppIntro {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState != null) {
+        if (savedInstanceState != null) { //Restoring the fragments
             welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.WelcomeFragment));
             intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.Intro2Fragment));
             cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.CS2Fragment));
@@ -106,7 +106,7 @@ public class OnboardingActivity extends AppIntro {
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(Bundle outState) { //Saving the fragments
         super.onSaveInstanceState(outState);
 
         //Save the fragment's instance

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -4,12 +4,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-
-import android.util.Log;
-import android.view.View;
 
 import com.github.paolorotolo.appintro.AppIntro;
 
@@ -19,9 +17,6 @@ import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.ui.AppManagerActivity;
 import org.torproject.android.ui.VPNEnableActivity;
 import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
-
-import java.util.HashMap;
-import java.util.LinkedList;
 
 public class OnboardingActivity extends AppIntro {
     CustomSlideBigText welcome, intro2, cs2, cs3;

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -2,61 +2,79 @@ package org.torproject.android.ui.onboarding;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import android.util.Log;
 import android.view.View;
 import com.github.paolorotolo.appintro.AppIntro;
 import org.torproject.android.R;
+import org.torproject.android.service.util.Prefs;
 import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.ui.AppManagerActivity;
 import org.torproject.android.ui.VPNEnableActivity;
 import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 
+import java.util.HashMap;
+import java.util.LinkedList;
+
 public class OnboardingActivity extends AppIntro {
+    CustomSlideBigText welcome, intro2, cs2, cs3;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Instead of fragments, you can also use our default slide
-        // Just set a title, description, background and image. AppIntro will do the rest.
-        CustomSlideBigText welcome = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-        welcome.setTitle(getString(R.string.hello));
-        welcome.setSubTitle(getString(R.string.welcome));
-        addSlide(welcome);
+        if (savedInstanceState != null) {
+            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "welcome");
+            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "intro2");
+            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "cs2");
+            if (PermissionManager.isLollipopOrHigher())
+                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, "cs3");
 
-        CustomSlideBigText intro2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-        intro2.setTitle(getString(R.string.browser_the_internet));
-        intro2.setSubTitle(getString(R.string.no_tracking));
-        addSlide(intro2);
+        }else{
+            // Instead of fragments, you can also use our default slide
+            // Just set a title, description, background and image. AppIntro will do the rest.
+            welcome = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
+            welcome.setTitle(getString(R.string.hello));
+            welcome.setSubTitle(getString(R.string.welcome));
+            addSlide(welcome);
 
-        CustomSlideBigText cs2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-        cs2.setTitle(getString(R.string.bridges_sometimes));
-        cs2.showButton(getString(R.string.action_more), new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(OnboardingActivity.this,BridgeWizardActivity.class));
-            }
-        });
-        addSlide(cs2);
+            intro2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
+            intro2.setTitle(getString(R.string.browser_the_internet));
+            intro2.setSubTitle(getString(R.string.no_tracking));
+            addSlide(intro2);
 
-        if (PermissionManager.isLollipopOrHigher()) {
-
-            CustomSlideBigText cs3 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-            cs3.setTitle(getString(R.string.vpn_setup));
-            cs3.setSubTitle(getString(R.string.vpn_setup_sub));
-            cs3.showButton(getString(R.string.action_vpn_choose), new View.OnClickListener() {
+            cs2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
+            cs2.setTitle(getString(R.string.bridges_sometimes));
+            cs2.showButton(getString(R.string.action_more), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    startActivity(new Intent(OnboardingActivity.this, VPNEnableActivity.class));
-                    startActivityForResult(new Intent(OnboardingActivity.this, AppManagerActivity.class), 9999);
-
+                    startActivity(new Intent(OnboardingActivity.this,BridgeWizardActivity.class));
                 }
             });
-            addSlide(cs3);
+            addSlide(cs2);
 
+            if (PermissionManager.isLollipopOrHigher()) {
+
+                cs3 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
+                cs3.setTitle(getString(R.string.vpn_setup));
+                cs3.setSubTitle(getString(R.string.vpn_setup_sub));
+                cs3.showButton(getString(R.string.action_vpn_choose), new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(OnboardingActivity.this, VPNEnableActivity.class));
+                        startActivityForResult(new Intent(OnboardingActivity.this, AppManagerActivity.class), 9999);
+
+                    }
+                });
+                addSlide(cs3);
+
+            }
         }
+
 
         // OPTIONAL METHODS
         // Override bar/separator color.
@@ -71,12 +89,37 @@ public class OnboardingActivity extends AppIntro {
     @Override
     public void onDonePressed(Fragment currentFragment) {
         super.onDonePressed(currentFragment);
-        // Do something when users tap on Done button.
+        // Setting first time app open flag "connect_firest_time" to false
+        SharedPreferences.Editor pEdit = Prefs.getSharedPrefs(getApplicationContext()).edit();
+        pEdit.putBoolean("connect_first_time", false);
+        pEdit.apply();
+
         finish();
     }
 
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        //Save the fragment's instance
+        int count = 0;
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            count++;
+        }
+
+        //Should check if the fragment exists in the fragment manager or else it'll flag error
+        if(count >= 1)
+            getSupportFragmentManager().putFragment(outState, "welcome", welcome);
+        if(count >= 2)
+            getSupportFragmentManager().putFragment(outState, "intro2", intro2);
+        if(count >=3)
+            getSupportFragmentManager().putFragment(outState, "cs2", cs2);
+        if (count >= 4 && PermissionManager.isLollipopOrHigher())
+            getSupportFragmentManager().putFragment(outState, "cs3", cs3);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,4 +259,11 @@
     <string name="app_services">App services</string>
     <string name="default_socks_http">SOCKS: - HTTP: -</string>
     <string name="refresh_apps">Refresh Apps</string>
+    <string name="Title">Title</string>
+    <string name="SubTitle">SubTitle</string>
+    <string name="ButtonText">ButtonText</string>
+    <string name="WelcomeFragment">welcome</string>
+    <string name="Intro2Fragment">intro2</string>
+    <string name="CS2Fragment">cs2</string>
+    <string name="CS3Fragment">cs3</string>
 </resources>


### PR DESCRIPTION
Fixed the welcome screen, when you open the app for the first time, is showing a blank screen when you rotate the device (change orientation). I test this on API 18, 28.  There are no issues nor crashes. I just saved the instances and restored them.

This fixes the issue #304 
Before: 
![Before](https://user-images.githubusercontent.com/22850179/75464137-c4d8a200-59ac-11ea-812b-9a359a1654f9.gif)
After:
![After](https://user-images.githubusercontent.com/22850179/75464185-d457eb00-59ac-11ea-97c4-60f576801eb5.gif)
