### PR TITLE
Fixes #300 Where Locale is set to Zulu when settings are opened

### DIFF
--- a/app/src/main/java/org/torproject/android/settings/Languages.java
+++ b/app/src/main/java/org/torproject/android/settings/Languages.java
@@ -71,9 +71,8 @@ public class Languages {
         DisplayMetrics ignored = new DisplayMetrics();
         activity.getWindowManager().getDefaultDisplay().getMetrics(ignored);
         Resources resources;
-        Set<Locale> localeSet = new LinkedHashSet<Locale>();
+        Set<Locale> localeSet = new LinkedHashSet<>();
         for (Locale locale : localesToTest) {
-            config.locale = locale;
             resources = new Resources(assets, ignored, config);
             if (!TextUtils.equals(defaultString, resources.getString(resId))
                     || locale.equals(Locale.ENGLISH))
@@ -190,21 +189,6 @@ public class Languages {
         activity.overridePendingTransition(0, 0);
         activity.startActivity(intent);
         activity.overridePendingTransition(0, 0);
-    }
-
-    /**
-     * Return the name of the language based on the locale.
-     *
-     * @param locale
-     * @return
-     */
-    public String getName(String locale) {
-        String ret = nameMap.get(locale);
-        // if no match, try to return a more general name (i.e. English for
-        // en_IN)
-        if (ret == null && locale.contains("_"))
-            ret = nameMap.get(locale.split("_")[0]);
-        return ret;
     }
 
     /**

--- a/app/src/main/java/org/torproject/android/settings/LocaleHelper.java
+++ b/app/src/main/java/org/torproject/android/settings/LocaleHelper.java
@@ -20,8 +20,6 @@ import java.util.Locale;
  */
 public class LocaleHelper {
 
-    private static final String SELECTED_LANGUAGE = "Locale.Helper.Selected.Language";
-
     public static Context onAttach(Context context) {
         String lang = getPersistedData(context, Locale.getDefault().getLanguage());
         return setLocale(context, lang);
@@ -30,10 +28,6 @@ public class LocaleHelper {
     public static Context onAttach(Context context, String defaultLanguage) {
         String lang = getPersistedData(context, defaultLanguage);
         return setLocale(context, lang);
-    }
-
-    public static String getLanguage(Context context) {
-        return getPersistedData(context, Locale.getDefault().getLanguage());
     }
 
     public static Context setLocale(Context context, String language) {


### PR DESCRIPTION
The locale to the app was set to isiZulu (`zu`) when the Settings screen is opened even if the user didn't explicitly set another language. This is because of a line in `Languages.java` in a loop for each Locale: `config.locale = locale` is assigned to the Activity's Configuration object. 

This assignment is not necessary and occurs for each Locale supported by the app. The reason the locale is always set to isiZulu because `zu` is the last locale alphabetically included in Orbot. 

Bug #300 says that only context menu text is changed to isiZulu because Orbot doesn't have any isiZulu localization, so only the Android context menu changes. If more isiZulu localization was included in Orbot, other parts of the app would have been effected too. This bug is for every language supported in Orbot, any time you open the settings and do not explicitly set a locale.

This PR removes the assignment statement causing the bug, and also removes some code that isn't used by the app anymore. 