### PR TITLE
Fixes bugs in #289 pertaining to parsing bridges

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -25,8 +25,6 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
@@ -37,14 +35,12 @@ import androidx.core.app.NotificationCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.util.Log;
-import android.widget.RemoteViews;
 
 import com.jaredrummler.android.shell.CommandResult;
 
 import net.freehaven.tor.control.ConfigEntry;
 import net.freehaven.tor.control.TorControlConnection;
 
-import org.apache.commons.io.IOUtils;
 import org.torproject.android.service.util.CustomShell;
 import org.torproject.android.service.util.CustomTorResourceInstaller;
 import org.torproject.android.service.util.DummyActivity;
@@ -70,7 +66,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -78,7 +73,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1628,10 +1622,8 @@ public class OrbotService extends Service implements TorServiceConstants, OrbotC
 
                 if (bridgeList != null && bridgeList.length() > 5) //longer then 1 = some real values here
                 {
-                    String[] bridgeListLines = bridgeList.trim().split("\\n");
-
-
-                    int bridgeIdx = (int)Math.round(Math.random()*((double)bridgeListLines.length));
+                    String[] bridgeListLines = parseBridgesFromSettings(bridgeList);
+                    int bridgeIdx = (int)Math.floor(Math.random()*((double)bridgeListLines.length));
                     String bridgeLine = bridgeListLines[bridgeIdx];
                     extraLines.append("Bridge ");
                     extraLines.append(bridgeLine);
@@ -1645,7 +1637,6 @@ public class OrbotService extends Service implements TorServiceConstants, OrbotC
                         }
 
                     }**/
-
                 } else {
 
                     String type = "obfs4";
@@ -1786,15 +1777,14 @@ public class OrbotService extends Service implements TorServiceConstants, OrbotC
         return extraLines;
     }
 
-    public static String flattenToAscii(String string) {
-        char[] out = new char[string.length()];
-        string = Normalizer.normalize(string, Normalizer.Form.NFD);
-        int j = 0;
-        for (int i = 0, n = string.length(); i < n; ++i) {
-            char c = string.charAt(i);
-            if (c <= '\u007F') out[j++] = c;
-        }
-        return new String(out);
+    /**
+     * @param bridgeList bridges that were manually entered into Orbot settings
+     * @return Array with each bridge as an element, no whitespace entries see issue #289...
+     */
+    private static String[] parseBridgesFromSettings(String bridgeList) {
+        // this regex replaces lines that only contain whitespace with an empty String
+        bridgeList = bridgeList.trim().replaceAll("(?m)^[ \t]*\r?\n", "");
+        return bridgeList.split("\\n");
     }
 
     //using Google DNS for now as the public DNS server


### PR DESCRIPTION
Fixes the problems addressed in #289 where you could possibly get an empty String when parsing custom bridges or Orbot would throw an IndexOutOfBoundsException. A deeper explanation of things can be found on the page for #289. 

One thing that remains uncertain is some commented out code in OrbotService that seems like it used to handle the parsing:
```
/**
for (String bridgeConfigLine : bridgeListLines) {
  if (!TextUtils.isEmpty(bridgeConfigLine)) {
  extraLines.append("Bridge ");
  extraLines.append(bridgeConfigLine.trim());
  extraLines.append("\n");
 }
}**/
```

This old parsing implementation would put all bridges into the torrc file VS the current implementation at the time of fixing #289 which randomly selects one of the custom bridges for some reason. @n8fr8 do you know why one bridge is selected instead of using all of them? It almost seems deceptive that a user could enter multiple bridges and only one of them would actually be used whenever Orbot is run. I'm pretty ignorant about how tor actually pulls bridges from the torrc file so maybe it's possible that tor would just end up selecting one at random anyway? 

Anyway, I'm quite confident that this fixes the parsing problems from #289