### PR TITLE
Fixes Compile Error on master and Refactored Surrounding Code

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -85,7 +85,7 @@ public class CustomSlideBigText extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            title.setText(savedInstanceState.getString(getResources().getString(R.string.Pref_title)));
+            title.setText(savedInstanceState.getString(getResources().getString(R.string.Title)));
             bigTextSub.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
             if (mButtonText != null) {
                 button.setText(savedInstanceState.getString(getResources().getString(R.string.ButtonText)));
@@ -98,7 +98,7 @@ public class CustomSlideBigText extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString(getResources().getString(R.string.Pref_title), mTitle);
+        outState.putString(getResources().getString(R.string.Title), mTitle);
         outState.putString(getResources().getString(R.string.SubTitle), mSubTitle);
         if (mButtonText != null) {
             outState.putString(getResources().getString(R.string.ButtonText), mButtonText);

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -24,6 +24,11 @@ public class CustomSlideBigText extends Fragment {
     private TextView bigTextSub, title;
     private Button button;
 
+    private static final String BUNDLE_KEY_TITLE = "Title";
+    private static final String BUNDLE_KEY_SUBTITLE = "Subtitle";
+    private static final String BUNDLE_KEY_BUTTON_TEXT = "ButtonText";
+
+
     public static CustomSlideBigText newInstance(int layoutResId) {
         CustomSlideBigText sampleSlide = new CustomSlideBigText();
 
@@ -61,23 +66,21 @@ public class CustomSlideBigText extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(layoutResId, container, false);
-        title = ((TextView) view.findViewById(R.id.custom_slide_big_text));
+        title = view.findViewById(R.id.custom_slide_big_text);
         title.setText(mTitle);
-        bigTextSub = (TextView) view.findViewById(R.id.custom_slide_big_text_sub);
+        bigTextSub = view.findViewById(R.id.custom_slide_big_text_sub);
         if (!TextUtils.isEmpty(mSubTitle)) {
-
             bigTextSub.setText(mSubTitle);
             bigTextSub.setVisibility(View.VISIBLE);
         }
 
         if (mButtonText != null) {
-            button = (Button) view.findViewById(R.id.custom_slide_button);
+            button = view.findViewById(R.id.custom_slide_button);
             button.setVisibility(View.VISIBLE);
             button.setText(mButtonText);
             button.setOnClickListener(mButtonListener);
         }
         return view;
-
     }
 
     //Restoring the data
@@ -85,10 +88,10 @@ public class CustomSlideBigText extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            title.setText(savedInstanceState.getString(getResources().getString(R.string.Title)));
-            bigTextSub.setText(savedInstanceState.getString(getResources().getString(R.string.SubTitle)));
+            title.setText(savedInstanceState.getString(BUNDLE_KEY_TITLE));
+            bigTextSub.setText(BUNDLE_KEY_SUBTITLE);
             if (mButtonText != null) {
-                button.setText(savedInstanceState.getString(getResources().getString(R.string.ButtonText)));
+                button.setText(savedInstanceState.getString(BUNDLE_KEY_BUTTON_TEXT));
             }
 
         }
@@ -98,10 +101,10 @@ public class CustomSlideBigText extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString(getResources().getString(R.string.Title), mTitle);
-        outState.putString(getResources().getString(R.string.SubTitle), mSubTitle);
+        outState.putString(BUNDLE_KEY_TITLE, mTitle);
+        outState.putString(BUNDLE_KEY_SUBTITLE, mSubTitle);
         if (mButtonText != null) {
-            outState.putString(getResources().getString(R.string.ButtonText), mButtonText);
+            outState.putString(BUNDLE_KEY_BUTTON_TEXT, mButtonText);
         }
     }
 

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -19,18 +19,24 @@ import org.torproject.android.ui.VPNEnableActivity;
 import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 
 public class OnboardingActivity extends AppIntro {
-    CustomSlideBigText welcome, intro2, cs2, cs3;
+    private CustomSlideBigText welcome, intro2, cs2, cs3;
+
+    private static final String BUNDLE_KEY_WELCOME_FRAGMENT = "Welcome";
+    private static final String BUNDLE_KEY_INTRO_2_FRAGMENT = "Intro2";
+    private static final String BUNDLE_KEY_CS2_FRAGMENT = "CS2";
+    private static final String BUNDLE_KEY_CS3_FRAGMENT = "CS3";
+
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState != null) { //Restoring the fragments
-            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.WelcomeFragment));
-            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.Intro2Fragment));
-            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.CS2Fragment));
+        if (savedInstanceState != null) { // Restoring the fragments
+            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_WELCOME_FRAGMENT);
+            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_INTRO_2_FRAGMENT);
+            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_CS2_FRAGMENT);
             if (PermissionManager.isLollipopOrHigher())
-                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, getResources().getString(R.string.CS3Fragment));
+                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_CS3_FRAGMENT);
 
         } else {
             // Instead of fragments, you can also use our default slide
@@ -65,7 +71,6 @@ public class OnboardingActivity extends AppIntro {
                     public void onClick(View v) {
                         startActivity(new Intent(OnboardingActivity.this, VPNEnableActivity.class));
                         startActivityForResult(new Intent(OnboardingActivity.this, AppManagerActivity.class), 9999);
-
                     }
                 });
                 addSlide(cs3);
@@ -87,11 +92,10 @@ public class OnboardingActivity extends AppIntro {
     @Override
     public void onDonePressed(Fragment currentFragment) {
         super.onDonePressed(currentFragment);
-        // Setting first time app open flag "connect_firest_time" to false
+        // Setting first time app open flag "connect_first_time" to false
         SharedPreferences.Editor pEdit = Prefs.getSharedPrefs(getApplicationContext()).edit();
         pEdit.putBoolean("connect_first_time", false);
         pEdit.apply();
-
         finish();
     }
 
@@ -112,12 +116,12 @@ public class OnboardingActivity extends AppIntro {
 
         //Should check if the fragment exists in the fragment manager or else it'll flag error
         if (count >= 1)
-            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.WelcomeFragment), welcome);
+            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_WELCOME_FRAGMENT, welcome);
         if (count >= 2)
-            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.Intro2Fragment), intro2);
+            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_INTRO_2_FRAGMENT, intro2);
         if (count >= 3)
-            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.CS2Fragment), cs2);
+            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_CS2_FRAGMENT, cs2);
         if (count >= 4 && PermissionManager.isLollipopOrHigher())
-            getSupportFragmentManager().putFragment(outState, getResources().getString(R.string.CS3Fragment), cs3);
+            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_CS3_FRAGMENT, cs3);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,11 +259,4 @@
     <string name="app_services">App services</string>
     <string name="default_socks_http">SOCKS: - HTTP: -</string>
     <string name="refresh_apps">Refresh Apps</string>
-    <string name="Title">Title</string>
-    <string name="SubTitle">SubTitle</string>
-    <string name="ButtonText">ButtonText</string>
-    <string name="WelcomeFragment">welcome</string>
-    <string name="Intro2Fragment">intro2</string>
-    <string name="CS2Fragment">cs2</string>
-    <string name="CS3Fragment">cs3</string>
 </resources>


### PR DESCRIPTION
There was a compile error on `master` where an XML preference key was incorrectly named in a java file causing a compile error. 

Beyond that, I refactored that part of the code anyway because `Bundle` keys that were only used in these Fragments/Activities were declared as XML String resources. In other places in Orbot local String constants are used since they aren't values the user interacts with and that people need to localize.