### PR TITLE
Fixes #334 about and MOAT error dialogs preserved upon rotation 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -459,9 +459,7 @@ public class OrbotMainActivity extends AppCompatActivity
             Intent intent = new Intent(OrbotMainActivity.this, SettingsPreferences.class);
             startActivityForResult(intent, REQUEST_SETTINGS);
         } else if (item.getItemId() == R.id.menu_exit) {
-            //exit app
-            doExit();
-
+            doExit(); // exit appp
         } else if (item.getItemId() == R.id.menu_about) {
             new AboutDialogFragment().show(getSupportFragmentManager(), AboutDialogFragment.TAG);
         } else if (item.getItemId() == R.id.menu_scan) {

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -6,6 +6,7 @@ package org.torproject.android;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningServiceInfo;
 import android.app.AlertDialog;
+
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.ContentValues;
@@ -17,14 +18,12 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.PackageManager.NameNotFoundException;
 import android.database.Cursor;
 import android.net.Uri;
 import android.net.VpnService;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
@@ -66,6 +65,7 @@ import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.settings.SettingsPreferences;
 import org.torproject.android.ui.AppManagerActivity;
 import org.torproject.android.ui.Rotate3dAnimation;
+import org.torproject.android.ui.dialog.AboutDialogFragment;
 import org.torproject.android.ui.hiddenservices.ClientCookiesActivity;
 import org.torproject.android.ui.hiddenservices.HiddenServicesActivity;
 import org.torproject.android.ui.hiddenservices.backup.BackupUtils;
@@ -74,10 +74,7 @@ import org.torproject.android.ui.hiddenservices.providers.HSContentProvider;
 import org.torproject.android.ui.onboarding.BridgeWizardActivity;
 import org.torproject.android.ui.onboarding.OnboardingActivity;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -466,8 +463,7 @@ public class OrbotMainActivity extends AppCompatActivity
             doExit();
 
         } else if (item.getItemId() == R.id.menu_about) {
-            showAbout();
-
+            new AboutDialogFragment().show(getSupportFragmentManager(), AboutDialogFragment.TAG);
         } else if (item.getItemId() == R.id.menu_scan) {
             IntentIntegrator integrator = new IntentIntegrator(OrbotMainActivity.this);
             integrator.initiateScan();
@@ -495,51 +491,6 @@ public class OrbotMainActivity extends AppCompatActivity
 
         return super.onOptionsItemSelected(item);
     }
-
-    private void showAbout() {
-        View view = getLayoutInflater().inflate(R.layout.layout_about, null);
-        String version;
-
-        try {
-            version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName + " (Tor " + OrbotService.BINARY_TOR_VERSION + ")";
-        } catch (NameNotFoundException e) {
-            version = "Version Not Found";
-        }
-
-        TextView versionName = view.findViewById(R.id.versionName);
-        versionName.setText(version);
-
-        TextView aboutOther = view.findViewById(R.id.aboutother);
-
-        try {
-            String aboutText = readFromAssets(this, "LICENSE");
-            aboutText = aboutText.replace("\n", "<br/>");
-            aboutOther.setText(Html.fromHtml(aboutText));
-        } catch (IOException e) {
-        }
-
-
-        new AlertDialog.Builder(this)
-                .setTitle(getString(R.string.button_about))
-                .setView(view)
-                .show();
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static String readFromAssets(Context context, String filename) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(filename)));
-
-        // do reading, usually loop until end of file reading
-        StringBuilder sb = new StringBuilder();
-        String mLine = reader.readLine();
-        while (mLine != null) {
-            sb.append(mLine).append('\n'); // process line
-            mLine = reader.readLine();
-        }
-        reader.close();
-        return sb.toString();
-    }
-
 
     /**
      * This is our attempt to REALLY exit Orbot, and stop the background service
@@ -589,14 +540,13 @@ public class OrbotMainActivity extends AppCompatActivity
 
             Intent intentVPN = VpnService.prepare(this);
             if (intentVPN != null)
-                startActivityForResult(intentVPN,REQUEST_VPN);
+                startActivityForResult(intentVPN, REQUEST_VPN);
             else {
                 sendIntentToService(ACTION_START);
                 sendIntentToService(ACTION_START_VPN);
             }
 
-        } else
-        {
+        } else {
             //stop the VPN here
             sendIntentToService(ACTION_STOP_VPN);
         }
@@ -879,11 +829,9 @@ public class OrbotMainActivity extends AppCompatActivity
                     torStatus.equals(TorServiceConstants.STATUS_ON))
                 refreshVPNApps();
 
-        }
-        else if (request == REQUEST_VPN && response == RESULT_OK) {
+        } else if (request == REQUEST_VPN && response == RESULT_OK) {
             sendIntentToService(ACTION_START_VPN);
-        }
-        else if (request == REQUEST_VPN && response == RESULT_CANCELED) {
+        } else if (request == REQUEST_VPN && response == RESULT_CANCELED) {
             mBtnVPN.setChecked(false);
             Prefs.putUseVpn(false);
         }

--- a/app/src/main/java/org/torproject/android/ui/dialog/AboutDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/dialog/AboutDialogFragment.java
@@ -46,7 +46,7 @@ public class AboutDialogFragment extends DialogFragment {
         boolean buildAboutText = true;
 
         if (savedInstanceState != null) {
-            String tvAboutText = savedInstanceState.getParcelable(BUNDLE_KEY_TV_ABOUT_TEXT);
+            String tvAboutText = savedInstanceState.getString(BUNDLE_KEY_TV_ABOUT_TEXT);
             if (tvAboutText != null) {
                 buildAboutText = false;
                 tvAbout.setText(tvAboutText);

--- a/app/src/main/java/org/torproject/android/ui/dialog/AboutDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/dialog/AboutDialogFragment.java
@@ -1,0 +1,90 @@
+package org.torproject.android.ui.dialog;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.text.Html;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.fragment.app.DialogFragment;
+
+import org.torproject.android.R;
+import org.torproject.android.service.OrbotService;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class AboutDialogFragment extends DialogFragment {
+
+    public static final String TAG = AboutDialogFragment.class.getSimpleName();
+
+    private TextView tvAbout;
+    private static final String BUNDLE_KEY_TV_ABOUT_TEXT = "about_tv_txt";
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View view = getActivity().getLayoutInflater().inflate(R.layout.layout_about, null);
+        String version;
+
+        try {
+            version = getContext().getPackageManager().getPackageInfo(
+                    getContext().getPackageName(), 0).versionName + " (Tor " +
+                    OrbotService.BINARY_TOR_VERSION + ")";
+        } catch (PackageManager.NameNotFoundException e) {
+            version = "Version Not Found";
+        }
+
+        TextView versionName = view.findViewById(R.id.versionName);
+        versionName.setText(version);
+
+        tvAbout = view.findViewById(R.id.aboutother);
+
+        boolean buildAboutText = true;
+
+        if (savedInstanceState != null) {
+            String tvAboutText = savedInstanceState.getParcelable(BUNDLE_KEY_TV_ABOUT_TEXT);
+            if (tvAboutText != null) {
+                buildAboutText = false;
+                tvAbout.setText(tvAboutText);
+            }
+        }
+
+        if (buildAboutText) {
+            try {
+                String aboutText = readFromAssets(getContext(), "LICENSE");
+                aboutText = aboutText.replace("\n", "<br/>");
+                tvAbout.setText(Html.fromHtml(aboutText));
+            } catch (IOException e) {
+            }
+        }
+        return new AlertDialog.Builder(getContext())
+                .setTitle(getString(R.string.button_about))
+                .setView(view)
+                .create();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static String readFromAssets(Context context, String filename) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(filename)));
+
+        // do reading, usually loop until end of file reading
+        StringBuilder sb = new StringBuilder();
+        String mLine = reader.readLine();
+        while (mLine != null) {
+            sb.append(mLine).append('\n'); // process line
+            mLine = reader.readLine();
+        }
+        reader.close();
+        return sb.toString();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(BUNDLE_KEY_TV_ABOUT_TEXT, tvAbout.getText().toString());
+    }
+}

--- a/app/src/main/java/org/torproject/android/ui/dialog/MoatErrorDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/dialog/MoatErrorDialogFragment.java
@@ -1,0 +1,32 @@
+package org.torproject.android.ui.dialog;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.fragment.app.DialogFragment;
+
+import org.torproject.android.R;
+
+public class MoatErrorDialogFragment extends DialogFragment {
+
+    public static final String TAG = MoatErrorDialogFragment.class.getSimpleName();
+    private static final String BUNDLE_KEY_MSG = "msg";
+
+    public static MoatErrorDialogFragment newInstance(String message) {
+        MoatErrorDialogFragment fragment = new MoatErrorDialogFragment();
+        Bundle args = new Bundle();
+        args.putString(BUNDLE_KEY_MSG, message);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return new AlertDialog.Builder(getContext())
+                .setTitle(R.string.error)
+                .setMessage(getArguments().getString(BUNDLE_KEY_MSG))
+                .setNegativeButton(R.string.btn_okay, null)
+                .create();
+    }
+}

--- a/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
@@ -26,7 +26,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -46,6 +45,7 @@ import org.torproject.android.R;
 import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
+import org.torproject.android.ui.dialog.MoatErrorDialogFragment;
 
 /**
  Implements the MOAT protocol: Fetches OBFS4 bridges via Meek Azure.
@@ -435,11 +435,8 @@ public class MoatActivity extends AppCompatActivity implements View.OnClickListe
         mBtRequest.setEnabled(mIvCaptcha.getVisibility() == View.VISIBLE);
 
         if (!isFinishing()) {
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.error)
-                    .setMessage(TextUtils.isEmpty(detail) ? exception.getLocalizedMessage() : detail)
-                    .setNegativeButton(R.string.btn_okay, null)
-                    .show();
+            String message = TextUtils.isEmpty(detail) ? exception.getLocalizedMessage() : detail;
+            MoatErrorDialogFragment.newInstance(message).show(getSupportFragmentManager(), MoatErrorDialogFragment.TAG);
         }
     }
 }

--- a/app/src/main/res/layout/layout_about.xml
+++ b/app/src/main/res/layout/layout_about.xml
@@ -1,117 +1,143 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
-	<ScrollView
-        android:orientation="vertical"
-		android:layout_width="fill_parent" 
-		android:layout_height="fill_parent">    
-		<LinearLayout
-		    android:orientation="vertical"
-		    android:layout_width="fill_parent"
-		    android:layout_height="fill_parent">
-		    <TextView android:text="@string/wizard_details"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"		
-				android:paddingTop="15px"
-				android:paddingLeft="15px"
-				android:textStyle="bold"
-				android:textColor="#00ff00" />	
-			<TextView android:text="@string/wizard_details_msg"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"		
-				android:textColor="#ffffff" />
-				
-			<TextView android:text="Version: "
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:paddingTop="15px"
-				android:paddingLeft="15px"
-				android:textStyle="bold"
-				android:textColor="#00ff00" />
-			<TextView android:text="- Unknown -"
-				android:id="@+id/versionName"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:paddingLeft="15px"		
-				android:layout_gravity="center_vertical"
-				android:textColor="#ffffff" />	
-			<TextView android:text="@string/project_home"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"		
-				android:paddingTop="15px"
-				android:paddingLeft="15px"
-				android:textStyle="bold"
-				android:textColor="#00ff00" />
-			<TextView android:text="@string/project_urls"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"		
-				android:textColor="#ffffff" />
-			<TextView android:text="@string/third_party_software"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"		
-				android:paddingTop="15px"
-				android:paddingLeft="15px"
-				android:textStyle="bold"
-				android:textColor="#00ff00" />	
-			<TextView android:text="@string/tor_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"
-				android:textColor="#ffffff" />				
-			<TextView android:text="@string/libevent_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"	
-				android:textColor="#ffffff" />	
-			<TextView android:text="@string/polipo_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"	
-				android:textColor="#ffffff" />	
-			<TextView android:text="@string/obfsproxy_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"
-				android:textColor="#ffffff"/>
-			<TextView android:text="@string/openssl_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"	
-				android:textColor="#ffffff" />
+<?xml version="1.0" encoding="utf-8"?>)
+            archivesBaseName = "Orbot-$versionName"
+    android:orientation="vertical">
 
-			<TextView android:text="License: "
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:paddingTop="15px"
-				android:paddingLeft="15px"
-				android:textStyle="bold"
-				android:textColor="#00ff00" />
-			<TextView
-				android:id="@+id/aboutother"
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"
-				android:textColor="#ffffff" />
-		</LinearLayout>
-		</ScrollView>			
+    <ScrollView
+		android:id="@+id/scrollView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="15px"
+                android:paddingTop="15px"
+                android:text="@string/wizard_details"
+                android:textColor="#00ff00"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/wizard_details_msg"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="15px"
+                android:paddingTop="15px"
+                android:text="Version: "
+                android:textColor="#00ff00"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/versionName"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:paddingLeft="15px"
+                android:text="- Unknown -"
+                android:textColor="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="15px"
+                android:paddingTop="15px"
+                android:text="@string/project_home"
+                android:textColor="#00ff00"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/project_urls"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="15px"
+                android:paddingTop="15px"
+                android:text="@string/third_party_software"
+                android:textColor="#00ff00"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/tor_version"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/libevent_version"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/polipo_version"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/obfsproxy_version"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:text="@string/openssl_version"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="15px"
+                android:paddingTop="15px"
+                android:text="License: "
+                android:textColor="#00ff00"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/aboutother"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:paddingLeft="15px"
+                android:textColor="#ffffff"
+                android:textColorLink="#ffffff" />
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/layout_about.xml
+++ b/app/src/main/res/layout/layout_about.xml
@@ -1,5 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>)
-            archivesBaseName = "Orbot-$versionName"
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
     android:orientation="vertical">
 
     <ScrollView


### PR DESCRIPTION
Creates `DialogFragment` subclasses for the `AlertDialog`s that were previously used for showing Orbot's "About" content and displaying errors with the new MOAT flow. Using `DialogFragment`s ensures that the dialogs remain open and in the same state when you rotate the device; prior to this pull request those two dialogs would just close upon orientation change. 

Creating `DialogFragment` classes also helps clean up code in `OrbotMainActivity` and `MoatActivity` 