### PR TITLE
When a new CAPTCHA is requested, immediately clear the old solution

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
@@ -184,13 +184,12 @@ public class MoatActivity extends AppCompatActivity implements View.OnClickListe
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_refresh:
+                mEtSolution.setText("");
                 fetchCaptcha();
-
                 return true;
 
             case android.R.id.home:
                 finish();
-
                 return true;
         }
 


### PR DESCRIPTION
This immediately clears the solution `EditText` in the MOAT flow. Previously the text would eventually clear as a new CAPTCHA loads, although this is confusing to the user and any old attempt at giving a solution immediately becomes valueless when you dismiss the old CAPTCHA anyway.

Before:
![before](https://user-images.githubusercontent.com/22125581/81513869-a28ec900-92f9-11ea-814d-21f4dd267652.gif)


After:
![fix](https://user-images.githubusercontent.com/22125581/81513866-9dca1500-92f9-11ea-8646-5f503634e382.gif)
