### PR TITLE
Bridge Wizard UI is Cut off in Landscape 

### DIFF
--- a/app/src/main/res/layout/content_bridge_wizard.xml
+++ b/app/src/main/res/layout/content_bridge_wizard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,65 +9,72 @@
     tools:context="org.torproject.android.ui.onboarding.BridgeWizardActivity"
     tools:showIn="@layout/activity_bridge_wizard">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-
-        android:text="@string/if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_"
-        android:textColor="@color/panel_background_main"
-        android:textSize="16sp"
-        android:textStyle="bold" />
-
-    <Button
-        android:id="@+id/btnMoat"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:text="@string/request_bridges_from_torproject" />
-
-    <RadioGroup
+    <LinearLayout
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <RadioButton
-            android:id="@+id/btnBridgesDirect"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="12dp"
-            android:text="@string/bridge_direct_connect" />
 
-        <RadioButton
-            android:id="@+id/btnBridgesObfs4"
-            android:layout_width="wrap_content"
+            android:text="@string/if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_"
+            android:textColor="@color/panel_background_main"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/btnMoat"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="12dp"
-            android:text="@string/bridge_community" />
+            android:text="@string/request_bridges_from_torproject" />
 
-        <RadioButton
-            android:id="@+id/btnBridgesMeek"
-            android:layout_width="wrap_content"
+        <RadioGroup
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:id="@+id/btnBridgesDirect"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:text="@string/bridge_direct_connect" />
+
+            <RadioButton
+                android:id="@+id/btnBridgesObfs4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:text="@string/bridge_community" />
+
+            <RadioButton
+                android:id="@+id/btnBridgesMeek"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:text="@string/bridge_cloud" />
+
+            <RadioButton
+                android:id="@+id/btnCustomBridges"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:text="@string/custom_bridges" />
+
+        </RadioGroup>
+
+        <TextView
+            android:id="@+id/lbl_bridge_test_status"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="12dp"
-            android:text="@string/bridge_cloud" />
-
-        <RadioButton
-            android:id="@+id/btnCustomBridges"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="12dp"
-            android:text="@string/custom_bridges"/>
-
-    </RadioGroup>
-
-    <TextView
-        android:id="@+id/lbl_bridge_test_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:gravity="center"
-        android:textColor="@color/bright_green"
-        android:textSize="16sp"
-        android:textStyle="bold" />
-</LinearLayout>
+            android:gravity="center"
+            android:textColor="@color/bright_green"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Recently the Bridge Wizard had its layout extended and these new changes can very likely cut off the UI if Orbot is in landscape. This was fixed by adding a `ScrollView` to the root of `content_bridge_wizard.xml`.

Before:
![bad](https://user-images.githubusercontent.com/22125581/81514256-074b2300-92fc-11ea-86bc-f65785f73fb4.png)

After:
![fix](https://user-images.githubusercontent.com/22125581/81514261-0adeaa00-92fc-11ea-96b4-92fb1338dd03.jpg)
