### PR TITLE
Limited MOAT Solution Length to spec's 20 byte limit

### DIFF
--- a/app/src/main/res/layout/activity_moat.xml
+++ b/app/src/main/res/layout/activity_moat.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="@color/dark_purple"
+    android:orientation="vertical"
     tools:context=".ui.onboarding.MoatActivity">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -29,7 +29,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" >
+            android:orientation="vertical">
 
             <TextView
                 android:layout_width="match_parent"
@@ -67,7 +67,8 @@
                 android:ems="10"
                 android:hint="@string/enter_characters_from_image"
                 android:imeOptions="actionSend"
-                android:inputType="textShortMessage|text" />
+                android:inputType="textShortMessage|text"
+                android:maxLength="20" />
 
             <Button
                 android:id="@+id/requestBt"


### PR DESCRIPTION
this is a small UI adjustment, the MOAT spec limits solution size to 20 bytes so I set a `maxLength` of 20 on it


From: https://gitweb.torproject.org/bridgedb.git/tree/README.rst#n391

```

Responding to a CAPTCHA challenge
"""""""""""""""""""""""""""""""""

To propose a solution to a CAPTCHA, the client MUST send a request for ``POST
/moat/check``, where the body of the request contains the following JSON::

    {
      "data": [{
        "id": "2",
        "type": "moat-solution",
        "version": "0.1.0",
        "transport": "TRANSPORT",
        "challenge": "CHALLENGE",
        "solution": "SOLUTION",
        "qrcode": "BOOLEAN",
      }]
    }


where:

* ``TRANSPORT`` is the agreed upon transport which will be distributed,
* ``CHALLENGE`` is a base64-encoded CAPTCHA challenge which MUST be
  later passed back to the server along with the proposed solution.
* ``SOLUTION`` is a valid unicode string, up to 20 bytes in length,
  containing the client's answer (i.e. what characters the CAPTCHA
  image displayed).  The solution is *not* case-sensitive.
* ``BOOLEAN`` is ``"true"`` if the client wants a qrcode containing the bridge
  lines to be generated and returned; ``"false"`` otherwise.
```