### PR TITLE
Fixes #329 Tor Wont Fully Stop With VPN Enabled

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -31,7 +31,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnLongClickListener;
 import android.view.animation.AccelerateInterpolator;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -61,6 +60,7 @@ import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.vpn.VpnConstants;
 import org.torproject.android.service.vpn.VpnPrefs;
+import org.torproject.android.service.vpn.VpnUtils;
 import org.torproject.android.settings.Languages;
 import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.settings.SettingsPreferences;
@@ -96,10 +96,8 @@ import static org.torproject.android.service.TorServiceConstants.ACTION_START;
 import static org.torproject.android.service.TorServiceConstants.ACTION_START_VPN;
 import static org.torproject.android.service.TorServiceConstants.ACTION_STOP_VPN;
 import static org.torproject.android.service.vpn.VpnPrefs.PREFS_KEY_TORIFIED;
-import static org.torproject.android.service.vpn.VpnUtils.getSharedPrefs;
 
-public class OrbotMainActivity extends AppCompatActivity
-        implements OrbotConstants, OnLongClickListener {
+public class OrbotMainActivity extends AppCompatActivity implements OrbotConstants {
 
     /* Useful UI bits */
     private TextView lblStatus = null; //the main text display widget
@@ -203,7 +201,7 @@ public class OrbotMainActivity extends AppCompatActivity
         }
 
         // Resets previous DNS Port to the default.
-        getSharedPrefs(getApplicationContext()).edit().putInt(VpnPrefs.PREFS_DNS_PORT,
+        VpnUtils.getSharedPrefs(getApplicationContext()).edit().putInt(VpnPrefs.PREFS_DNS_PORT,
                 VpnConstants.TOR_DNS_PORT_DEFAULT).apply();
 
     }
@@ -215,9 +213,7 @@ public class OrbotMainActivity extends AppCompatActivity
     }
 
     private void stopTor() {
-
-//        requestTorStatus();
-
+        if (mBtnVPN.isChecked()) mBtnVPN.setChecked(false); // indirectly closes tun2socks interface
         Intent intent = new Intent(OrbotMainActivity.this, OrbotService.class);
         stopService(intent);
 
@@ -309,7 +305,13 @@ public class OrbotMainActivity extends AppCompatActivity
         lblPorts = findViewById(R.id.lblPorts);
 
         imgStatus = findViewById(R.id.imgStatus);
-        imgStatus.setOnLongClickListener(this);
+        imgStatus.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                toggleTor();
+                return true;
+            }
+        });
 
         downloadText = findViewById(R.id.trafficDown);
         uploadText = findViewById(R.id.trafficUp);
@@ -322,14 +324,7 @@ public class OrbotMainActivity extends AppCompatActivity
         mBtnStart.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-
-                if (torStatus.equals(TorServiceConstants.STATUS_OFF)) {
-                    lblStatus.setText(getString(R.string.status_starting_up));
-                    startTor();
-                } else {
-                    lblStatus.setText(getString(R.string.status_shutting_down));
-                    stopTor();
-                }
+                toggleTor();
             }
         });
 
@@ -367,7 +362,16 @@ public class OrbotMainActivity extends AppCompatActivity
         setCountrySpinner();
 
         mPulsator = findViewById(R.id.pulsator);
+    }
 
+    private void toggleTor() { // UI entry point for  (dis)connecting to Tor
+        if (torStatus.equals(TorServiceConstants.STATUS_OFF)) {
+            lblStatus.setText(getString(R.string.status_starting_up));
+            startTor();
+        } else {
+            lblStatus.setText(getString(R.string.status_shutting_down));
+            stopTor();
+        }
     }
 
     private void setCountrySpinner() {
@@ -885,7 +889,6 @@ public class OrbotMainActivity extends AppCompatActivity
         }
         else if (request == REQUEST_VPN && response == RESULT_CANCELED) {
             mBtnVPN.setChecked(false);
-            Prefs.putUseVpn(false);
         }
 
         IntentResult scanResult = IntentIntegrator.parseActivityResult(request, response, data);
@@ -1136,20 +1139,6 @@ public class OrbotMainActivity extends AppCompatActivity
         return false;
     }
 
-    public boolean onLongClick(View view) {
-
-        if (torStatus.equals(TorServiceConstants.STATUS_OFF)) {
-            lblStatus.setText(getString(R.string.status_starting_up));
-            startTor();
-        } else {
-            lblStatus.setText(getString(R.string.status_shutting_down));
-
-            stopTor();
-        }
-
-        return true;
-
-    }
 
     // this is what takes messages or values from the callback threads or other non-mainUI threads
 //and passes them back into the main UI thread for display to the user

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -28,9 +28,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.net.VpnService;
 import android.os.Build;
-import android.os.Debug;
 import android.os.IBinder;
-import android.os.RemoteException;
 import android.provider.BaseColumns;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
@@ -1198,20 +1196,16 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
 
     }
 
-    private int getControlPort ()
-    {
+    private int getControlPort () {
         int result = -1;
 
-        try
-        {
-            if (fileControlPort.exists())
-            {
+        try {
+            if (fileControlPort.exists()) {
                 debug("Reading control port config file: " + fileControlPort.getCanonicalPath());
                 BufferedReader bufferedReader = new BufferedReader(new FileReader(fileControlPort));
                 String line = bufferedReader.readLine();
 
-                if (line != null)
-                {
+                if (line != null) {
                     String[] lineParts = line.split(":");
                     result = Integer.parseInt(lineParts[1]);
                 }
@@ -1222,30 +1216,22 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                 //store last valid control port
                 SharedPreferences prefs = Prefs.getSharedPrefs(getApplicationContext());
                 prefs.edit().putInt("controlport", result).commit();
-
             }
-            else
-            {
+            else {
                 debug("Control Port config file does not yet exist (waiting for tor): " + fileControlPort.getCanonicalPath());
-
             }
-
-
         }
-        catch (FileNotFoundException e)
-        {
+        catch (FileNotFoundException e) {
             debug("unable to get control port; file not found");
         }
-        catch (Exception e)
-        {
+        catch (Exception e) {
             debug("unable to read control port config file");
         }
 
         return result;
     }
 
-    public void addEventHandler () throws Exception
-    {
+    public void addEventHandler () throws Exception {
            // We extend NullEventHandler so that we don't need to provide empty
            // implementations for all the events we don't care about.
            // ...
@@ -1258,14 +1244,12 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         conn.setEventHandler(mEventHandler);
 
         logNotice( "SUCCESS added control port event handler");
-
-
     }
 
         /**
          * Returns the port number that the HTTP proxy is running on
          */
-        public int getHTTPPort() throws RemoteException {
+        public int getHTTPPort() {
             return mPortHTTP;
         }
 
@@ -1273,10 +1257,9 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         /**
          * Returns the port number that the HTTP proxy is running on
          */
-        public int getSOCKSPort() throws RemoteException {
+        public int getSOCKSPort() {
             return mPortSOCKS;
         }
-
 
         public String getInfo (String key) {
             try {


### PR DESCRIPTION
I posted an explanation about the root of this bug on the issue page for #329. Essentially a `Service` can't be destroyed with an open `ParcelFileDescriptor` interface which is what `OrbotService` uses for Tun2Socks when VPN is enabled.

There's no other functionality here beyond the bug fix, but I modified code as I was working in related areas to improve readability & decrease code size:
- I consolidated duplicate UI code in `OrbotMainActivity` that is responsible for starting/stopping Tor.
- Removed unused imports 
- Changed inner classes like `Builder` to `VPNService.Builder`. This makes the link between the `ParcelFileDescriptor` and `OrbotService` a bit clearer.

Since turning on the VPN without tor on also turns on tor, I made it such that turning off tor with the VPN sets the VPN switch to the off position. **@n8fr8 i'm not sure if it would make more sense here to keep the VPN switch in the on position while turning off Tor...**

Before:
![untitled](https://user-images.githubusercontent.com/22125581/82714861-9b9f7900-9c5e-11ea-9419-2b86248a3d9c.gif)


After:
![untitled](https://user-images.githubusercontent.com/22125581/82714320-08fdda80-9c5c-11ea-9245-6a07b3c920dc.gif)

