### PR TITLE
gitignore ndk-build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# compiled NDK binary artifacts 
+orbotservice/src/main/libs/
+
 # auto-generated files from Android builds
 build.xml
 ant.properties


### PR DESCRIPTION
Makes it so that devs don't accidentally commit build artifacts and see this output when they run `git status`:

```
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	orbotservice/src/main/libs/

nothing added to commit but untracked files present (use "git add" to track)
```