### PR TITLE
Fixes #354 MOAT Solution Textfield UI Quirks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,11 +74,6 @@
             android:theme="@android:style/Theme.Translucent" />
 
         <activity
-            android:name=".ui.VPNEnableActivity"
-            android:exported="false"
-            android:label="@string/app_name" />
-
-        <activity
             android:name=".settings.SettingsPreferences"
             android:label="@string/app_name" />
 
@@ -107,7 +102,9 @@
 
         <activity android:name=".ui.onboarding.OnboardingActivity" />
         <activity android:name=".ui.onboarding.BridgeWizardActivity" />
-        <activity android:name=".ui.onboarding.MoatActivity" />
+        <activity
+            android:name=".ui.onboarding.MoatActivity"
+            android:windowSoftInputMode="stateHidden" />
         <activity android:name=".ui.onboarding.CustomBridgesActivity" />
 
         <provider
@@ -164,12 +161,12 @@
             android:name=".service.OrbotService"
             android:enabled="true"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:stopWithTask="false" >
+            android:stopWithTask="false">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
-        
+
     </application>
 
 </manifest>

--- a/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/MoatActivity.java
@@ -135,6 +135,7 @@ public class MoatActivity extends AppCompatActivity implements View.OnClickListe
                 mProgressBar.setVisibility(View.GONE);
                 mIvCaptcha.setImageBitmap(BitmapFactory.decodeByteArray(mCaptcha, 0, mCaptcha.length));
                 mRequestInProgress = false;
+                mEtSolution.setEnabled(true);
             }
         }
         else {

--- a/app/src/main/res/layout/activity_moat.xml
+++ b/app/src/main/res/layout/activity_moat.xml
@@ -65,6 +65,7 @@
                 android:layout_height="wrap_content"
                 android:autofillHints=""
                 android:ems="10"
+                android:enabled="false"
                 android:hint="@string/enter_characters_from_image"
                 android:imeOptions="actionSend"
                 android:inputType="textShortMessage|text"


### PR DESCRIPTION
- Moat Solution textfield is **only** enabled when there's something to type 
- Don't automatically open the soft keyboard when the Activity is open (and there's nothing to type) 