### PR TITLE
Fixes #360 "Click again for backup"

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/ClientCookiesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/ClientCookiesActivity.java
@@ -9,7 +9,6 @@ import android.database.ContentObserver;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.os.Handler;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
@@ -42,14 +41,13 @@ public class ClientCookiesActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.layout_activity_client_cookies);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         mResolver = getContentResolver();
 
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
-        fab.setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.fab).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 AddCookieDialog dialog = new AddCookieDialog();
@@ -66,7 +64,7 @@ public class ClientCookiesActivity extends AppCompatActivity {
                 CookieContentProvider.CONTENT_URI, true, new HSObserver(new Handler())
         );
 
-        ListView cookies = (ListView) findViewById(R.id.clien_cookies_list);
+        ListView cookies = findViewById(R.id.clien_cookies_list);
         cookies.setAdapter(mAdapter);
 
         cookies.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -94,7 +92,7 @@ public class ClientCookiesActivity extends AppCompatActivity {
 
                 CookieActionsDialog dialog = new CookieActionsDialog();
                 dialog.setArguments(arguments);
-                dialog.show(getSupportFragmentManager(), "CookieActionsDialog");
+                dialog.show(getSupportFragmentManager(), CookieActionsDialog.class.getSimpleName());
             }
         });
 
@@ -149,7 +147,10 @@ public class ClientCookiesActivity extends AppCompatActivity {
                 break;
             }
             case CookieActionsDialog.WRITE_EXTERNAL_STORAGE_FROM_COOKIE_ACTION_DIALOG: {
-                Toast.makeText(this, R.string.click_again_for_backup, Toast.LENGTH_LONG).show();
+                try {
+                    CookieActionsDialog activeDialog = (CookieActionsDialog) getSupportFragmentManager().findFragmentByTag(CookieActionsDialog.class.getSimpleName());
+                    activeDialog.doBackup();
+                } catch (ClassCastException e) {}
                 break;
             }
         }

--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/HiddenServicesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/HiddenServicesActivity.java
@@ -8,10 +8,13 @@ import android.database.ContentObserver;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.os.Handler;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.core.view.MenuItemCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -19,7 +22,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Spinner;
-import android.widget.Toast;
+
 import org.torproject.android.R;
 import org.torproject.android.settings.LocaleHelper;
 import org.torproject.android.ui.hiddenservices.adapters.OnionListAdapter;
@@ -42,13 +45,13 @@ public class HiddenServicesActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.layout_hs_list_view);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         mResolver = getContentResolver();
 
-        fab = (FloatingActionButton) findViewById(R.id.fab);
+        fab = findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -69,7 +72,7 @@ public class HiddenServicesActivity extends AppCompatActivity {
                 HSContentProvider.CONTENT_URI, true, new HSObserver(new Handler())
         );
 
-        ListView onion_list = (ListView) findViewById(R.id.onion_list);
+        ListView onion_list = findViewById(R.id.onion_list);
         onion_list.setAdapter(mAdapter);
 
         onion_list.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -101,12 +104,12 @@ public class HiddenServicesActivity extends AppCompatActivity {
 
                 HSActionsDialog dialog = new HSActionsDialog();
                 dialog.setArguments(arguments);
-                dialog.show(getSupportFragmentManager(), "HSActionsDialog");
+                dialog.show(getSupportFragmentManager(), HSActionsDialog.class.getSimpleName());
             }
         });
     }
 
-
+    
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(LocaleHelper.onAttach(base));
@@ -185,7 +188,11 @@ public class HiddenServicesActivity extends AppCompatActivity {
                 break;
             }
             case HSActionsDialog.WRITE_EXTERNAL_STORAGE_FROM_ACTION_DIALOG: {
-                Toast.makeText(this, R.string.click_again_for_backup, Toast.LENGTH_LONG).show();
+                try {
+                    HSActionsDialog activeDialog = (HSActionsDialog) getSupportFragmentManager().findFragmentByTag(HSActionsDialog.class.getSimpleName());
+                    activeDialog.doBackup();
+                } catch (ClassCastException e) {
+                }
                 break;
             }
         }

--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/dialogs/CookieActionsDialog.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/dialogs/CookieActionsDialog.java
@@ -1,6 +1,5 @@
 package org.torproject.android.ui.hiddenservices.dialogs;
 
-
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -10,7 +9,6 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.appcompat.app.AlertDialog;
 import android.view.View;
-import android.widget.Button;
 import android.widget.Toast;
 import org.torproject.android.R;
 import org.torproject.android.ui.hiddenservices.backup.BackupUtils;
@@ -18,6 +16,7 @@ import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 
 public class CookieActionsDialog extends DialogFragment {
     public static final int WRITE_EXTERNAL_STORAGE_FROM_COOKIE_ACTION_DIALOG = 4;
+    private AlertDialog actionDialog;
 
     @NonNull
     @Override
@@ -25,55 +24,18 @@ public class CookieActionsDialog extends DialogFragment {
         final Bundle arguments = getArguments();
 
         final View dialog_view = getActivity().getLayoutInflater().inflate(R.layout.layout_cookie_actions, null);
-        final AlertDialog actionDialog = new AlertDialog.Builder(getActivity())
+        actionDialog = new AlertDialog.Builder(getActivity())
                 .setView(dialog_view)
                 .setTitle(R.string.client_cookies)
                 .create();
 
-        Button backup = (Button) dialog_view.findViewById(R.id.btn_cookie_backup);
-        backup.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_cookie_backup).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                Context mContext = v.getContext();
-
-                if (PermissionManager.isLollipopOrHigher()
-                        && !PermissionManager.hasExternalWritePermission(mContext)) {
-
-                    PermissionManager.requestExternalWritePermissions(
-                            getActivity(), WRITE_EXTERNAL_STORAGE_FROM_COOKIE_ACTION_DIALOG);
-
-                    return;
-                }
-
-                BackupUtils backup_utils = new BackupUtils(mContext);
-                String backupPath = backup_utils.createCookieBackup(
-                        arguments.getString("domain"),
-                        arguments.getString("auth_cookie_value"),
-                        arguments.getInt("enabled")
-                );
-
-                if (backupPath == null || backupPath.length() < 1) {
-                    Toast.makeText(mContext, R.string.error, Toast.LENGTH_LONG).show();
-                    actionDialog.dismiss();
-                    return;
-                }
-
-                Toast.makeText(mContext, R.string.backup_saved_at_external_storage, Toast.LENGTH_LONG).show();
-
-                Uri selectedUri = Uri.parse(backupPath.substring(0, backupPath.lastIndexOf("/")));
-                Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setDataAndType(selectedUri, "resource/folder");
-
-                if (intent.resolveActivityInfo(mContext.getPackageManager(), 0) != null) {
-                    startActivity(intent);
-                } else {
-                    Toast.makeText(mContext, R.string.filemanager_not_available, Toast.LENGTH_LONG).show();
-                }
-                actionDialog.dismiss();
+                doBackup();
             }
         });
 
-        Button delete = (Button) dialog_view.findViewById(R.id.btn_cookie_delete);
-        delete.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_cookie_delete).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 CookieDeleteDialog dialog = new CookieDeleteDialog();
                 dialog.setArguments(arguments);
@@ -82,8 +44,7 @@ public class CookieActionsDialog extends DialogFragment {
             }
         });
 
-        Button cancel = (Button) dialog_view.findViewById(R.id.btn_cookie_cancel);
-        cancel.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_cookie_cancel).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 actionDialog.dismiss();
             }
@@ -91,4 +52,50 @@ public class CookieActionsDialog extends DialogFragment {
 
         return actionDialog;
     }
+
+    public void doBackup() {
+        Context mContext = getContext();
+        Bundle arguments = getArguments();
+
+        if (PermissionManager.isLollipopOrHigher()
+                && !PermissionManager.hasExternalWritePermission(mContext)) {
+
+            PermissionManager.requestExternalWritePermissions(
+                    getActivity(), WRITE_EXTERNAL_STORAGE_FROM_COOKIE_ACTION_DIALOG);
+
+            return;
+        }
+
+        BackupUtils backup_utils = new BackupUtils(mContext);
+        String backupPath;
+        try {
+            backupPath = backup_utils.createCookieBackup(
+                    arguments.getString("domain"),
+                    arguments.getString("auth_cookie_value"),
+                    arguments.getInt("enabled")
+            );
+        } catch (NullPointerException npe) {
+            backupPath = null;
+        }
+
+        if (backupPath == null || backupPath.length() < 1) {
+            Toast.makeText(mContext, R.string.error, Toast.LENGTH_LONG).show();
+            actionDialog.dismiss();
+            return;
+        }
+
+        Toast.makeText(mContext, R.string.backup_saved_at_external_storage, Toast.LENGTH_LONG).show();
+
+        Uri selectedUri = Uri.parse(backupPath.substring(0, backupPath.lastIndexOf("/")));
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(selectedUri, "resource/folder");
+
+        if (intent.resolveActivityInfo(mContext.getPackageManager(), 0) != null) {
+            startActivity(intent);
+        } else {
+            Toast.makeText(mContext, R.string.filemanager_not_available, Toast.LENGTH_LONG).show();
+        }
+        actionDialog.dismiss();
+    }
+
 }

--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/dialogs/HSActionsDialog.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/dialogs/HSActionsDialog.java
@@ -8,18 +8,22 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.appcompat.app.AlertDialog;
+
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
+
 import org.torproject.android.R;
 import org.torproject.android.ui.hiddenservices.backup.BackupUtils;
 import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 
 public class HSActionsDialog extends DialogFragment {
     public static final int WRITE_EXTERNAL_STORAGE_FROM_ACTION_DIALOG = 2;
+    private AlertDialog actionDialog;
 
     @NonNull
     @Override
@@ -27,51 +31,18 @@ public class HSActionsDialog extends DialogFragment {
         final Bundle arguments = getArguments();
 
         final View dialog_view = getActivity().getLayoutInflater().inflate(R.layout.layout_hs_actions, null);
-        final AlertDialog actionDialog = new AlertDialog.Builder(getActivity())
+        actionDialog = new AlertDialog.Builder(getActivity())
                 .setView(dialog_view)
                 .setTitle(R.string.hidden_services)
                 .create();
 
-        Button backup = (Button) dialog_view.findViewById(R.id.btn_hs_backup);
-        backup.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_hs_backup).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                Context mContext = v.getContext();
-
-                if (PermissionManager.isLollipopOrHigher()
-                        && !PermissionManager.hasExternalWritePermission(mContext)) {
-
-                    PermissionManager.requestExternalWritePermissions(
-                            getActivity(), WRITE_EXTERNAL_STORAGE_FROM_ACTION_DIALOG);
-
-                    return;
-                }
-
-                BackupUtils hsutils = new BackupUtils(mContext);
-                String backupPath = hsutils.createZipBackup(Integer.parseInt(arguments.getString("port")));
-
-                if (backupPath == null || backupPath.length() < 1) {
-                    Toast.makeText(mContext, R.string.error, Toast.LENGTH_LONG).show();
-                    actionDialog.dismiss();
-                    return;
-                }
-
-                Toast.makeText(mContext, R.string.backup_saved_at_external_storage, Toast.LENGTH_LONG).show();
-
-                Uri selectedUri = Uri.parse(backupPath.substring(0, backupPath.lastIndexOf("/")));
-                Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setDataAndType(selectedUri, "resource/folder");
-
-                if (intent.resolveActivityInfo(mContext.getPackageManager(), 0) != null) {
-                    startActivity(intent);
-                } else {
-                    Toast.makeText(mContext, R.string.filemanager_not_available, Toast.LENGTH_LONG).show();
-                }
-                actionDialog.dismiss();
+                doBackup();
             }
         });
 
-        Button copy = (Button) dialog_view.findViewById(R.id.btn_hs_clipboard);
-        copy.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_hs_clipboard).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 Context mContext = v.getContext();
                 ClipboardManager clipboard = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
@@ -82,8 +53,7 @@ public class HSActionsDialog extends DialogFragment {
             }
         });
 
-        Button showAuth = (Button) dialog_view.findViewById(R.id.bt_hs_show_auth);
-        showAuth.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.bt_hs_show_auth).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 String auth_cookie_value = arguments.getString("auth_cookie_value");
 
@@ -107,8 +77,7 @@ public class HSActionsDialog extends DialogFragment {
             }
         });
 
-        Button delete = (Button) dialog_view.findViewById(R.id.btn_hs_delete);
-        delete.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_hs_delete).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 HSDeleteDialog dialog = new HSDeleteDialog();
                 dialog.setArguments(arguments);
@@ -117,13 +86,46 @@ public class HSActionsDialog extends DialogFragment {
             }
         });
 
-        Button cancel = (Button) dialog_view.findViewById(R.id.btn_hs_cancel);
-        cancel.setOnClickListener(new View.OnClickListener() {
+        dialog_view.findViewById(R.id.btn_hs_cancel).setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 actionDialog.dismiss();
             }
         });
 
         return actionDialog;
+    }
+
+    public void doBackup() {
+        Context mContext = getActivity();
+        if (PermissionManager.isLollipopOrHigher()
+                && !PermissionManager.hasExternalWritePermission(getActivity())) {
+
+            PermissionManager.requestExternalWritePermissions(
+                    getActivity(), WRITE_EXTERNAL_STORAGE_FROM_ACTION_DIALOG);
+
+            return;
+        }
+
+        BackupUtils hsutils = new BackupUtils(mContext);
+        String backupPath = hsutils.createZipBackup(Integer.parseInt(getArguments().getString("port")));
+
+        if (backupPath == null || backupPath.length() < 1) {
+            Toast.makeText(mContext, R.string.error, Toast.LENGTH_LONG).show();
+            actionDialog.dismiss();
+            return;
+        }
+
+        Toast.makeText(mContext, R.string.backup_saved_at_external_storage, Toast.LENGTH_LONG).show();
+
+        Uri selectedUri = Uri.parse(backupPath.substring(0, backupPath.lastIndexOf("/")));
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(selectedUri, "resource/folder");
+
+        if (intent.resolveActivityInfo(mContext.getPackageManager(), 0) != null) {
+            startActivity(intent);
+        } else {
+            Toast.makeText(mContext, R.string.filemanager_not_available, Toast.LENGTH_LONG).show();
+        }
+        actionDialog.dismiss();
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -163,8 +163,7 @@
   <string name="fields_can_t_be_empty">لا يمكن ترك الحقول فارغة</string>
   <string name="start_tor_again_for_finish_the_process">قم بتشغيل تور ثانيةً لإنهاء العملية</string>
   <string name="confirm_service_deletion">تأكيد حذف الخدمة</string>
-  <string name="click_again_for_backup">قم بالنقر ثانية للقيام بالنسخ الإحتياطي</string>
-  <string name="service_type">نوع الخدمة</string>
+    <string name="service_type">نوع الخدمة</string>
   <string name="auth_cookie">كعكة المصادقة</string>
   <string name="copy_cookie_to_clipboard">نسخ الكعكة إلى الحافظة</string>
   <string name="auth_cookie_was_not_configured">لم يتم إعداد كعكة المصادقة</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Janiw kunas ch\'usäñapakiti</string>
   <string name="start_tor_again_for_finish_the_process">Tukuyañatakix Tor mayamp naktayam</string>
   <string name="confirm_service_deletion">Lurañanakax pichsutäniwa</string>
-  <string name="click_again_for_backup">Imat luratanak utjañapatak mayamp limt\'am</string>
-  <string name="service_type">Kunayman lurañanaka</string>
+    <string name="service_type">Kunayman lurañanaka</string>
   <string name="auth_cookie">Chiqat k\'arich uk katjir cookie</string>
   <string name="copy_cookie_to_clipboard">Cookie waruqañawjar imam</string>
   <string name="auth_cookie_was_not_configured">Chiqat k\'arich uk katjir cookiex janiw mayjt\'ayatäkiti</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Палі не могуць быць пустымі</string>
   <string name="start_tor_again_for_finish_the_process">Запусціце Tor ізноў для завяршэння працэсу</string>
   <string name="confirm_service_deletion">Пацверджанне выдалення службы</string>
-  <string name="click_again_for_backup">Націсніце яшчэ раз для рэзервавання</string>
-  <string name="service_type">Тып службы</string>
+    <string name="service_type">Тып службы</string>
   <string name="auth_cookie">Аўтарызучыя cookie</string>
   <string name="copy_cookie_to_clipboard">Капіяваць cookie у буфер памену</string>
   <string name="auth_cookie_was_not_configured">Аўтарызучыя cookie не наладжаны</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Els camps no poden estar buits</string>
   <string name="start_tor_again_for_finish_the_process">Torna a iniciar Tor per acabar el procés</string>
   <string name="confirm_service_deletion">Confirma la supressió del servei</string>
-  <string name="click_again_for_backup">Feu clic novament per fer còpia de seguretat</string>
-  <string name="service_type">Tipus de servei</string>
+    <string name="service_type">Tipus de servei</string>
   <string name="auth_cookie">Auth cookie</string>
   <string name="copy_cookie_to_clipboard">Copieu les galetes al porta-retalls</string>
   <string name="auth_cookie_was_not_configured">No s\'ha configurat l\'Auth cookie</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Felder dürfen nicht leer sein</string>
   <string name="start_tor_again_for_finish_the_process">Tor neu starten, um den Vorgang abzuschließen</string>
   <string name="confirm_service_deletion">Löschen des Dienst bestätigen</string>
-  <string name="click_again_for_backup">Zum Sichern noch einmal klicken</string>
-  <string name="service_type">Dienst-Typ</string>
+    <string name="service_type">Dienst-Typ</string>
   <string name="auth_cookie">Authentifikationscookie</string>
   <string name="copy_cookie_to_clipboard">Cookie in die Zwischenablage kopieren</string>
   <string name="auth_cookie_was_not_configured">Es wurde kein Authentifikationscookie festgelegt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Τα πεδία δεν μπορεί να είναι κενά</string>
   <string name="start_tor_again_for_finish_the_process">Έναρξη ξανά τού Tor για τον τερματισμό της ενέργειας</string>
   <string name="confirm_service_deletion">Επιβεβαίωση διαγραφής υπηρεσίας</string>
-  <string name="click_again_for_backup">Πατήστε ξανά για το αντίγραφο ασφαλείας</string>
-  <string name="service_type">Τύπος υπηρεσίας</string>
+    <string name="service_type">Τύπος υπηρεσίας</string>
   <string name="auth_cookie">Αναγνωριστικό cookie</string>
   <string name="copy_cookie_to_clipboard">Αντιγραφή τού cookie στο πρόχειρο</string>
   <string name="auth_cookie_was_not_configured">Το αναγνωριστικό cookie δεν διαμορφώθηκε</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,8 +166,7 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="fields_can_t_be_empty">Los campos no pueden estar vacíos</string>
   <string name="start_tor_again_for_finish_the_process">Inicie Tor de nuevo para finalizar el proceso</string>
   <string name="confirm_service_deletion">Confirme el borrado del servicio</string>
-  <string name="click_again_for_backup">Pulse de nuevo para realizar copia de seguridad</string>
-  <string name="service_type">Tipo de servicio</string>
+    <string name="service_type">Tipo de servicio</string>
   <string name="auth_cookie">Cookie de autentificación</string>
   <string name="copy_cookie_to_clipboard">Copiar cookie al portapapeles</string>
   <string name="auth_cookie_was_not_configured">La cookie de autentificación no fue configurada</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Eremuak ezin dira hutsik egon</string>
   <string name="start_tor_again_for_finish_the_process">Hasi Tor berriro prozesua amaitzeko</string>
   <string name="confirm_service_deletion">Berretsi zerbitzua ezabatzea</string>
-  <string name="click_again_for_backup">Egin klik berriro babeskopiarako</string>
-  <string name="service_type">Zerbitzu mota</string>
+    <string name="service_type">Zerbitzu mota</string>
   <string name="auth_cookie">Autentifikazio cookie-a</string>
   <string name="copy_cookie_to_clipboard">Kopiatu cookie-a arbelera</string>
   <string name="auth_cookie_was_not_configured">Ez da autentifikazio cookie-a konfiguratu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">زمینه‌ها نباید خالی باشند</string>
   <string name="start_tor_again_for_finish_the_process">برای پایان روند کار ، دوباره تور را آغاز کنید</string>
   <string name="confirm_service_deletion">حذف سرویس را تایید کنید</string>
-  <string name="click_again_for_backup">برای بک‌آپ، دوباره کلیک کنید</string>
-  <string name="service_type">نوع سرویس</string>
+    <string name="service_type">نوع سرویس</string>
   <string name="auth_cookie">کوکی Auth</string>
   <string name="copy_cookie_to_clipboard">کپی کردن کوکی به کلیپ بورد</string>
   <string name="auth_cookie_was_not_configured">کوکی احراز هویت پیکربندی نشده بود</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Les champs ne peuvent pas être vides</string>
   <string name="start_tor_again_for_finish_the_process">Redémarrer Tor pour terminer le processus</string>
   <string name="confirm_service_deletion">Confirmer la suppression du service</string>
-  <string name="click_again_for_backup">Recliquer pour sauvegarder</string>
-  <string name="service_type">Type de service</string>
+    <string name="service_type">Type de service</string>
   <string name="auth_cookie">Témoin auth</string>
   <string name="copy_cookie_to_clipboard">Copier le témoin vers le presse-papiers</string>
   <string name="auth_cookie_was_not_configured">Le témoin auth n’est pas configuré</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Os campos non poden estar baldeiros</string>
   <string name="start_tor_again_for_finish_the_process">Inicie Tor de novo para rematar o proceso</string>
   <string name="confirm_service_deletion">Confirme a eliminación do servizo</string>
-  <string name="click_again_for_backup">Pulse de novo para respaldar</string>
-  <string name="service_type">Tipo de servizo</string>
+    <string name="service_type">Tipo de servizo</string>
   <string name="auth_cookie">Testemuño de autorización</string>
   <string name="copy_cookie_to_clipboard">Copie o testemuño ao portapapeis</string>
   <string name="auth_cookie_was_not_configured">Non estableceu un testemuño de autorización</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">שדות אינם יכולים להיות ריקים</string>
   <string name="start_tor_again_for_finish_the_process">הפעל את Tor שוב כדי לסיים את התהליך</string>
   <string name="confirm_service_deletion">אשר מחיקת שירות</string>
-  <string name="click_again_for_backup">לחץ שוב לגיבוי</string>
-  <string name="service_type">סוג שירות</string>
+    <string name="service_type">סוג שירות</string>
   <string name="auth_cookie">עוגיית אימות</string>
   <string name="copy_cookie_to_clipboard">העתק עוגייה ללוח עריכה</string>
   <string name="auth_cookie_was_not_configured">עוגיית אימות לא הוגדרה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -166,8 +166,7 @@
   <string name="fields_can_t_be_empty">फ़ील्ड रिक्त नहीं हो सकते</string>
   <string name="start_tor_again_for_finish_the_process">प्रक्रिया को खत्म करने के लिए Tor पुन: प्रारंभ करें</string>
   <string name="confirm_service_deletion">सेवा हटाने की पुष्टि करें</string>
-  <string name="click_again_for_backup">बैकअप के लिए फिर से क्लिक करें</string>
-  <string name="service_type">सेवा प्रकार</string>
+    <string name="service_type">सेवा प्रकार</string>
   <string name="auth_cookie">Auth कुकी</string>
   <string name="copy_cookie_to_clipboard">क्लिपबोर्ड पर कुकी कॉपी करें</string>
   <string name="auth_cookie_was_not_configured">Auth कुकी कॉन्फ़िगर नहीं की गई थी</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">A mezők nem lehetnek üresek</string>
   <string name="start_tor_again_for_finish_the_process">Indítsa el a Tor-t még egyszer a befejezéshez</string>
   <string name="confirm_service_deletion">Szolgáltatás törlés jóváhagyása</string>
-  <string name="click_again_for_backup">Kattintson még egyszer a mentéshez</string>
-  <string name="service_type">Szolgáltatás típus</string>
+    <string name="service_type">Szolgáltatás típus</string>
   <string name="auth_cookie">Azonosító süti</string>
   <string name="copy_cookie_to_clipboard">Süti másolása vágólapra</string>
   <string name="auth_cookie_was_not_configured">Azonosító süti nem konfigurált</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Gagnasvið mega ekki vera auð</string>
   <string name="start_tor_again_for_finish_the_process">Ræstu Tor aftur til að ljúka ferlinu</string>
   <string name="confirm_service_deletion">Staðfestu eyðingu á þjónustu</string>
-  <string name="click_again_for_backup">Smelltu aftur fyrir öryggisafrit</string>
-  <string name="service_type">Tegund þjónustu</string>
+    <string name="service_type">Tegund þjónustu</string>
   <string name="auth_cookie">Auðkenningar-vefkaka</string>
   <string name="copy_cookie_to_clipboard">Afrita vefköku á klippispjald</string>
   <string name="auth_cookie_was_not_configured">Auðkenningar-vefkaka var ekki stillt</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">I campi non possono essere vuoti</string>
   <string name="start_tor_again_for_finish_the_process">Riavvia Tor per finire il processo</string>
   <string name="confirm_service_deletion">Conferma l\'eliminazione del servizio</string>
-  <string name="click_again_for_backup">Clicca ancora per eseguire il backup</string>
-  <string name="service_type">Tipo di servizio</string>
+    <string name="service_type">Tipo di servizio</string>
   <string name="auth_cookie">Cookie autenticazione</string>
   <string name="copy_cookie_to_clipboard">Copia cookie negli appunti</string>
   <string name="auth_cookie_was_not_configured">Cookie di autenticazione non configurato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">フィールドを空にしておくことはできません</string>
   <string name="start_tor_again_for_finish_the_process">プロセスを完了するには、Torを再起動して下さい。</string>
   <string name="confirm_service_deletion">サービス削除を確認</string>
-  <string name="click_again_for_backup">バックアップ作成に再クリック</string>
-  <string name="service_type">サービスタイプ</string>
+    <string name="service_type">サービスタイプ</string>
   <string name="auth_cookie">Cookie 認証</string>
   <string name="copy_cookie_to_clipboard">Cookie をクリップボードにコピー</string>
   <string name="auth_cookie_was_not_configured">Authクッキーは設定されませんでした</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Полињата не можат да бидат празни</string>
   <string name="start_tor_again_for_finish_the_process">Стартувај го Tor повторно да го заврши процесот</string>
   <string name="confirm_service_deletion">Потврди бришење на услугата</string>
-  <string name="click_again_for_backup">Кликни повторно за резервна копија</string>
-  <string name="service_type">Тип на услуга</string>
+    <string name="service_type">Тип на услуга</string>
   <string name="auth_cookie">Автентично колаче</string>
   <string name="copy_cookie_to_clipboard">Копирај колаче за залепување</string>
   <string name="auth_cookie_was_not_configured">Автентичното колаче не е прилагодено</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -156,8 +156,7 @@
   <string name="fields_can_t_be_empty">Felter kan ikke stå tomme</string>
   <string name="start_tor_again_for_finish_the_process">Start Tor igjen for å fullføre prosessen</string>
   <string name="confirm_service_deletion">Bekreft sletting av tjeneste</string>
-  <string name="click_again_for_backup">Klikk igjen for å sikkerhetskopiere</string>
-  <string name="service_type">Tjenestetype</string>
+    <string name="service_type">Tjenestetype</string>
   <string name="copy_cookie_to_clipboard">Kopier kake til utklippstavle</string>
   <string name="please_restart_Orbot_to_enable_the_changes">Gjør omstart av Orbot før endringer trer i kraft</string>
   <string name="client_cookies">Klientinformasjonskapsler</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Velden kunnen niet leeg zijn</string>
   <string name="start_tor_again_for_finish_the_process">Start Tor opnieuw om het proces te voltooien</string>
   <string name="confirm_service_deletion">Bevestig verwijderen van dienst</string>
-  <string name="click_again_for_backup">Klik opnieuw voor back-up</string>
-  <string name="service_type">Diensttype</string>
+    <string name="service_type">Diensttype</string>
   <string name="auth_cookie">Authenticatiecookie</string>
   <string name="copy_cookie_to_clipboard">Cookie kopiëren naar klembord</string>
   <string name="auth_cookie_was_not_configured">Authenticatiecookie is niet ingesteld</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -164,8 +164,7 @@
   <string name="name_can_t_be_empty">O campo Nome não pode ser vazio</string>
   <string name="fields_can_t_be_empty">Campos não podem ser vazios</string>
   <string name="confirm_service_deletion">Confirmar a remoção do serviço</string>
-  <string name="click_again_for_backup">Clique novamente para backup</string>
-  <string name="service_type">Tipo do Serviço</string>
+    <string name="service_type">Tipo do Serviço</string>
   <string name="auth_cookie">Cookie de autenticação</string>
   <string name="copy_cookie_to_clipboard">Copiar cookie para a area de transferência</string>
   <string name="please_restart_Orbot_to_enable_the_changes">Por favor reinicie Orbot para habilitar as mundanças</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Поля не могут быть пустыми</string>
   <string name="start_tor_again_for_finish_the_process">Запустите Tor снова для завершения процесса</string>
   <string name="confirm_service_deletion">Подтверждение удаления службы</string>
-  <string name="click_again_for_backup">Нажмите ещё раз для резервирования</string>
-  <string name="service_type">Тип службы</string>
+    <string name="service_type">Тип службы</string>
   <string name="auth_cookie">Авторизирующие cookie</string>
   <string name="copy_cookie_to_clipboard">Копировать cookie в буфер обмена</string>
   <string name="auth_cookie_was_not_configured">Авторизирующие cookie не настроены</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -163,8 +163,7 @@
   <string name="fields_can_t_be_empty">Поља не могу бити празна</string>
   <string name="start_tor_again_for_finish_the_process">Поново покрените Тор да бисте довршили процес</string>
   <string name="confirm_service_deletion">Потрврди брисанје услуге</string>
-  <string name="click_again_for_backup">Кликните поново за резервну копију</string>
-  <string name="service_type">Тип Услуге</string>
+    <string name="service_type">Тип Услуге</string>
   <string name="please_restart_Orbot_to_enable_the_changes">Молимо покрените поново Орбот ради примењивања промена</string>
   <string name="client_cookies">Колачићи клијента</string>
   <string name="onion">.onion</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Fält kan inte vara tomma</string>
   <string name="start_tor_again_for_finish_the_process">Starta Tor igen för att avsluta processen</string>
   <string name="confirm_service_deletion">Bekräfta tjänst borttagning</string>
-  <string name="click_again_for_backup">Klicka igen för säkerhetskopiering</string>
-  <string name="service_type">Typ av tjänst</string>
+    <string name="service_type">Typ av tjänst</string>
   <string name="auth_cookie">Auth kaka</string>
   <string name="copy_cookie_to_clipboard">Kopiera kaka till urklipp</string>
   <string name="auth_cookie_was_not_configured">Auth kaka var inte konfigurerad</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">ปล่อยเขตข้อมูลให้ว่างไม่ได้</string>
   <string name="start_tor_again_for_finish_the_process">เริ่มทำงาน Tor อีกครั้งเพื่อจบกระบวนการ</string>
   <string name="confirm_service_deletion">ยืนยันการลบบริการ</string>
-  <string name="click_again_for_backup">กดอีกครั้งเพื่อเรียกข้อมูลสำรอง</string>
-  <string name="service_type">ประเภทของบริการ</string>
+    <string name="service_type">ประเภทของบริการ</string>
   <string name="auth_cookie">คุกกี้ที่ได้รับอนุญาต</string>
   <string name="copy_cookie_to_clipboard">คัดลอกคุกกี้ลงในคลิปบอร์ด</string>
   <string name="auth_cookie_was_not_configured">ยังไม่ได้กำหนดค่าคุกกี้ที่ได้รับอนุญาต</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Alanlar boş bırakılamaz</string>
   <string name="start_tor_again_for_finish_the_process">İşlemi tamamlamak için Tor uygulamasını yeniden başlatın</string>
   <string name="confirm_service_deletion">Hizmeti Silmeyi Onayla</string>
-  <string name="click_again_for_backup">Yedeklemek için yeniden tıklayın</string>
-  <string name="service_type">Hizmet Türü</string>
+    <string name="service_type">Hizmet Türü</string>
   <string name="auth_cookie">Kimlik Doğrulama Çerezi</string>
   <string name="copy_cookie_to_clipboard">Çerezi panoya kopyala</string>
   <string name="auth_cookie_was_not_configured">Kimlik doğrulama çerezi yapılandırılmamış</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">Поля не можуть бути порожніми</string>
   <string name="start_tor_again_for_finish_the_process">Запустіть Tor знову для завершення процесу</string>
   <string name="confirm_service_deletion">Підтвердьте видалення сервісу</string>
-  <string name="click_again_for_backup">Ще раз натисніть щоби копіювати в резерв</string>
-  <string name="service_type">Тип сервісу</string>
+    <string name="service_type">Тип сервісу</string>
   <string name="auth_cookie">Авторизація реп\'яшків </string>
   <string name="copy_cookie_to_clipboard">Копіювати реп\'яшки в буфер обміну</string>
   <string name="auth_cookie_was_not_configured">Авторизація реп\'яшків не налаштована</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -165,8 +165,7 @@
   <string name="fields_can_t_be_empty">欄位不可空白</string>
   <string name="start_tor_again_for_finish_the_process">再次開啟 Tor  以完成此過程</string>
   <string name="confirm_service_deletion">確認服務刪除</string>
-  <string name="click_again_for_backup">再次點選以進行備份</string>
-  <string name="service_type">服務類型</string>
+    <string name="service_type">服務類型</string>
   <string name="auth_cookie">Auth cookie</string>
   <string name="copy_cookie_to_clipboard">複製 Cookie 到剪貼簿</string>
   <string name="auth_cookie_was_not_configured">Auth cookie 未設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,7 +206,6 @@
     <string name="fields_can_t_be_empty">Fields can\'t be empty</string>
     <string name="start_tor_again_for_finish_the_process">Start Tor again for finish the process</string>
     <string name="confirm_service_deletion">Confirm service deletion</string>
-    <string name="click_again_for_backup">Click again for backup</string>
     <string name="service_type">Service type</string>
     <string name="auth_cookie">Auth cookie</string>
     <string name="copy_cookie_to_clipboard">Copy cookie to clipboard</string>


### PR DESCRIPTION
This makes it so that the user doesn't need to reclick the button to backup their cookies or hidden services after granting Orbot permissions to write to external storage. 

These UI flows are a little rough still and still fail under certain cases without displaying much information to the user, all this PR merely preserves the backup functionality of the `CookieActionsDialog` and `HSActionsDialog` without making the user need to click the same button twice. 

Additionally, this catches a NPE that could be thrown in the `CookieActionsDialog` when attempting to build a backup directory which previously crashed Orbot.

Finally the XML String `click_again_for_backup` is removed from every locale of the app since it was only ever used in these two dialogs. 