### PR TITLE
Fixes #358, #364, #366 BridgeWizardActivity UI, Rotation + Network Bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,7 +104,10 @@
             android:name=".ui.onboarding.OnboardingActivity"
             android:configChanges="orientation|screenSize|screenLayout" />
 
-        <activity android:name=".ui.onboarding.BridgeWizardActivity" />
+        <activity
+            android:name=".ui.onboarding.BridgeWizardActivity"
+            android:configChanges="orientation|screenSize" />
+
         <activity
             android:name=".ui.onboarding.MoatActivity"
             android:windowSoftInputMode="stateHidden" />

--- a/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
@@ -29,12 +29,14 @@ public class BridgeWizardActivity extends AppCompatActivity {
 
     private static int MOAT_REQUEST_CODE = 666;
 
-    private TextView mTvStatus;
+    private static TextView mTvStatus;
     private RadioButton mBtDirect;
     private RadioButton mBtObfs4;
     private RadioButton mBtMeek;
     private RadioButton mBtCustom;
 
+    private static final String BUNDLE_KEY_TV_STATUS_VISIBILITY = "visibility";
+    private static final String BUNDLE_KEY_TV_STATUS_TEXT = "text";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,7 +51,12 @@ public class BridgeWizardActivity extends AppCompatActivity {
         }
 
         mTvStatus = findViewById(R.id.lbl_bridge_test_status);
-        mTvStatus.setVisibility(View.GONE);
+        if (savedInstanceState == null) {
+            mTvStatus.setVisibility(View.GONE);
+        } else {
+            mTvStatus.setVisibility(savedInstanceState.getInt(BUNDLE_KEY_TV_STATUS_VISIBILITY, View.GONE));
+            mTvStatus.setText(savedInstanceState.getString(BUNDLE_KEY_TV_STATUS_TEXT, ""));
+        }
 
         setTitle(getString(R.string.bridges));
 
@@ -86,7 +93,6 @@ public class BridgeWizardActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-
         evaluateBridgeListState();
     }
 
@@ -117,8 +123,7 @@ public class BridgeWizardActivity extends AppCompatActivity {
             else {
                 evaluateBridgeListState();
             }
-        }
-        else {
+        } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
     }
@@ -165,12 +170,18 @@ public class BridgeWizardActivity extends AppCompatActivity {
             // Post Code
             if (result) {
                 mTvStatus.setText(R.string.testing_bridges_success);
-
             } else {
                 mTvStatus.setText(R.string.testing_bridges_fail);
-
             }
         }
+    }
+
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putInt(BUNDLE_KEY_TV_STATUS_VISIBILITY, mTvStatus.getVisibility());
+        savedInstanceState.putString(BUNDLE_KEY_TV_STATUS_TEXT, mTvStatus.getText().toString());
+        super.onSaveInstanceState(savedInstanceState);
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -185,8 +196,7 @@ public class BridgeWizardActivity extends AppCompatActivity {
                 connected = true;
                 socket.close();
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
 
@@ -198,14 +208,11 @@ public class BridgeWizardActivity extends AppCompatActivity {
 
         if (!Prefs.bridgesEnabled()) {
             mBtDirect.setChecked(true);
-        }
-        else if (Prefs.getBridgesList().equals("meek")) {
+        } else if (Prefs.getBridgesList().equals("meek")) {
             mBtMeek.setChecked(true);
-        }
-        else if (Prefs.getBridgesList().equals("obfs4")) {
+        } else if (Prefs.getBridgesList().equals("obfs4")) {
             mBtObfs4.setChecked(true);
-        }
-        else {
+        } else {
             mBtCustom.setChecked(true);
         }
     }

--- a/app/src/main/res/layout/activity_custom_bridges.xml
+++ b/app/src/main/res/layout/activity_custom_bridges.xml
@@ -91,7 +91,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="12dp"
-                android:text="@string/get_bridges_email" />
+                android:text="@string/get_bridges_email_request" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/content_bridge_wizard.xml
+++ b/app/src/main/res/layout/content_bridge_wizard.xml
@@ -67,6 +67,14 @@
 
         </RadioGroup>
 
+        <Button
+            android:id="@+id/btnConfigureCustomBridges"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="12dp"
+            android:text="@string/configure_custom_bridges"
+            android:visibility="gone" />
+
         <TextView
             android:id="@+id/lbl_bridge_test_status"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="bridge_mode">Request New Bridge</string>
 
     <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email_request">Request Bridges via Email</string>
     <string name="get_bridges_web">Web</string>
 
     <string name="activate">Activate</string>
@@ -242,7 +243,9 @@
     <string name="pref_disable_ipv4_summary">Tells exits not to connect to IPv4 addresses</string>
     <string name="app_shortcuts">Tor-Enabled Apps</string>
     <string name="testing_bridges">Testing bridge connection to Tor....</string>
+    <string name="testing_tor_direct">Testing connection to Tor...</string>
     <string name="testing_bridges_success">Success. Bridge configuration is good!</string>
+    <string name="testing_tor_direct_success">Success. Tor connection is good!</string>
     <string name="testing_bridges_fail">FAILED. Try another option</string>
     <string name="bridge_direct_connect">Connect directly to Tor (Best)</string>
     <string name="bridge_community">Connect through community servers</string>
@@ -270,7 +273,8 @@
     <!-- BridgeWizardActivity -->
     <string name="request_bridges_from_torproject">Request Bridges from torproject.org</string>
     <string name="custom_bridges">Custom Bridges</string>
-    
+    <string name="configure_custom_bridges">Configure Custom Bridges</string>
+
     <!-- CustomBridgesActivity -->
     <string name="use_custom_bridges">Use Custom Bridges</string>
     <string name="in_a_browser">In a browser, visit %s and tap "Get Bridges" > "Just Give Me Bridges!"</string>


### PR DESCRIPTION
The async `HostTester` will continue to update the UI in the BridgeWizard even after the device is rotated. On device rotation, the visibility and text values of the TextView `mTvStatus` are written to a `Bundle`. Furthermore, only one `HostTest` is allowed to run at a time, previously multiple were fired off each time a RadioButton was checked. This could confuse the user. Finally, network requests will not continue to be made to the hosts in question once the `BridgeWizardActivity` is closed or when it opens the `CustomBridgesActivity`. 