### PR TITLE
Fixes #368 VPN Priviliges Revoked + Other Disconnections 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -274,6 +274,10 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
 
                     break;
                 }
+                case ACTION_STOP_VPN: {
+                    mBtnVPN.setChecked(false);
+                    break;
+                }
             }
         }
     };

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -880,7 +880,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         super.onResume();
 
         mBtnBridges.setChecked(Prefs.bridgesEnabled());
-        mBtnVPN.setChecked(Prefs.useVpn());
+        refreshVpnState();
 
         setCountrySpinner();
 
@@ -896,6 +896,22 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         //now you can handle the intents properly
         handleIntents();
 
+    }
+
+    /**
+     * After granting VPN permissions in Orbot it's possible to revoke them outside of the app
+     * This method ensures that VPN permissions are still granted and if not it updates the state
+     * of the UI accordingly. see: https://github.com/guardianproject/orbot/issues/368
+     */
+    private void refreshVpnState() {
+        if (Prefs.useVpn()) {
+            Intent enableVpnIntent = VpnService.prepare(this);
+            // don't start the Intent, just update Orbot to say that VPN privileges are gone
+            if (enableVpnIntent != null) {
+                Prefs.putUseVpn(false);
+            }
+        }
+        mBtnVPN.setChecked(Prefs.useVpn());
     }
 
     AlertDialog aDialog = null;

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -1913,13 +1913,22 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
     @Override
     public IBinder onBind(Intent intent) {
         Log.e( TAG, "onBind" );
-        handleIntent( intent );
-        return null;
+        handleIntent(intent);
+        return super.onBind(intent); // invoking super class will call onRevoke() when appropriate
+    }
+
+    // system calls this method when VPN disconnects (either by the user or another VPN app)
+    @Override
+    public void onRevoke() {
+        Prefs.putUseVpn(false);
+        mVpnManager.handleIntent(new Builder(), new Intent(ACTION_STOP_VPN));
+        // tell UI, if it's open, to update immediately (don't wait for onResume() in Activity...)
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_STOP_VPN));
     }
 
     private void handleIntent( Intent intent ) {
         if( intent != null && intent.getAction() != null ) {
-            Log.e( TAG, intent.getAction().toString() );
+            Log.e( TAG, intent.getAction());
         }
     }
 


### PR DESCRIPTION
Firstly, if a user chooses to remove Orbot's VPN permission, the app is updated with the VPN switch off. When the user turns on VPN mode again they will have to regrant the privileges. Previously the app would still appear to be in VPN mode.

![vpnafter](https://user-images.githubusercontent.com/22125581/88020439-bcb70580-caf9-11ea-81f9-164cdd8f5048.gif)

Secondly, if the user opts to disconnect Orbot (while still retaining the already granted VPN priviliges) or if another app uses `VpnService.prepare(Context)` Orbot will reflect this by turning off VPN Mode. Like the last case, the app used to appear to still be in VPN mode.

![after](https://user-images.githubusercontent.com/22125581/88021750-0e608f80-cafc-11ea-98e7-9981d3664575.gif)

*i put a more detailed write up of these issues in the page for #368*