### PR TITLE
Users can't select Orbot itself through the VPN app manager

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -1220,8 +1220,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
                     for (final String pkgId : pkgIds) {
                         try {
                             ApplicationInfo aInfo = getPackageManager().getApplicationInfo(pkgId, 0);
-                            // skip disabled packages
-                            if (!aInfo.enabled) continue;
+                            if (!AppManagerActivity.includeAppInUi(aInfo)) continue;
                             ImageView iv = new ImageView(this);
                             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
                             params.setMargins(3, 3, 3, 3);

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -27,6 +27,8 @@ import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
+import org.torproject.android.BuildConfig;
 import org.torproject.android.R;
 import org.torproject.android.service.OrbotConstants;
 import org.torproject.android.service.util.Prefs;
@@ -229,8 +231,7 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
         while (itAppInfo.hasNext())
         {
             aInfo = itAppInfo.next();
-            // don't include apps user has disabled, often these ship with the device
-            if (!aInfo.enabled) continue;
+            if (!includeAppInUi(aInfo)) continue;
             app = new TorifiedApp();
 
 
@@ -246,7 +247,6 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
                             app.setUsesInternet(true);
                         }
                     }
-
                 }
 
 
@@ -339,4 +339,12 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
             saveAppSettings();
         }
     }
+
+    // returns true if the given app is enabled and not orbot
+    public static boolean includeAppInUi(ApplicationInfo applicationInfo) {
+        if (!applicationInfo.enabled) return false;
+        if (BuildConfig.APPLICATION_ID.equals(applicationInfo.packageName)) return false;
+        return true;
+    }
+
 }


### PR DESCRIPTION
Removes Orbot from the list of apps to "torify" - clicking it won't do anything but confuse users. When it's clicked it shows up on the main screen's "Tor Enabled" apps view which I think especially confusing 