### PR TITLE
Fixes #304 Onboarding text and slide position are preserved on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,7 +100,10 @@
                 android:value=".OrbotMainActivity" />
         </activity>
 
-        <activity android:name=".ui.onboarding.OnboardingActivity" />
+        <activity
+            android:name=".ui.onboarding.OnboardingActivity"
+            android:configChanges="orientation|screenSize|screenLayout" />
+
         <activity android:name=".ui.onboarding.BridgeWizardActivity" />
         <activity
             android:name=".ui.onboarding.MoatActivity"

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomSlideBigText.java
@@ -15,36 +15,28 @@ import org.torproject.android.R;
 
 public class CustomSlideBigText extends Fragment {
 
-    private static final String ARG_LAYOUT_RES_ID = "layoutResId";
     private int layoutResId;
     private String mTitle;
     private String mButtonText;
     private String mSubTitle;
     private View.OnClickListener mButtonListener;
-    private TextView bigTextSub, title;
-    private Button button;
 
+    private static final String BUNDLE_KEY_LAYOUT_RES_ID = "layoutResId";
     private static final String BUNDLE_KEY_TITLE = "Title";
     private static final String BUNDLE_KEY_SUBTITLE = "Subtitle";
-    private static final String BUNDLE_KEY_BUTTON_TEXT = "ButtonText";
 
+    public static CustomSlideBigText newInstance(int layoutResId, String title) {
+        return newInstance(layoutResId, title, null);
+    }
 
-    public static CustomSlideBigText newInstance(int layoutResId) {
-        CustomSlideBigText sampleSlide = new CustomSlideBigText();
-
+    public static CustomSlideBigText newInstance(int layoutResId, String title, String subtitle) {
+        CustomSlideBigText newSlide = new CustomSlideBigText();
         Bundle args = new Bundle();
-        args.putInt(ARG_LAYOUT_RES_ID, layoutResId);
-        sampleSlide.setArguments(args);
-
-        return sampleSlide;
-    }
-
-    public void setTitle(String title) {
-        mTitle = title;
-    }
-
-    public void setSubTitle(String subTitle) {
-        mSubTitle = subTitle;
+        args.putInt(BUNDLE_KEY_LAYOUT_RES_ID, layoutResId);
+        args.putString(BUNDLE_KEY_TITLE, title);
+        if (subtitle != null) args.putString(BUNDLE_KEY_SUBTITLE, subtitle);
+        newSlide.setArguments(args);
+        return newSlide;
     }
 
     public void showButton(String buttonText, View.OnClickListener buttonListener) {
@@ -55,57 +47,30 @@ public class CustomSlideBigText extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (getArguments() != null && getArguments().containsKey(ARG_LAYOUT_RES_ID)) {
-            layoutResId = getArguments().getInt(ARG_LAYOUT_RES_ID);
-        }
+        Bundle args = getArguments();
+        if (args == null) return;
+        layoutResId = args.getInt(BUNDLE_KEY_LAYOUT_RES_ID);
+        mTitle = args.getString(BUNDLE_KEY_TITLE);
+        mSubTitle = args.getString(BUNDLE_KEY_SUBTITLE);
     }
 
-    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-                             @Nullable Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(layoutResId, container, false);
-        title = view.findViewById(R.id.custom_slide_big_text);
+        TextView title = view.findViewById(R.id.custom_slide_big_text);
         title.setText(mTitle);
-        bigTextSub = view.findViewById(R.id.custom_slide_big_text_sub);
         if (!TextUtils.isEmpty(mSubTitle)) {
+            TextView bigTextSub = view.findViewById(R.id.custom_slide_big_text_sub);
             bigTextSub.setText(mSubTitle);
             bigTextSub.setVisibility(View.VISIBLE);
         }
 
-        if (mButtonText != null) {
-            button = view.findViewById(R.id.custom_slide_button);
+        if (!TextUtils.isEmpty(mButtonText)) {
+            Button button = view.findViewById(R.id.custom_slide_button);
             button.setVisibility(View.VISIBLE);
             button.setText(mButtonText);
             button.setOnClickListener(mButtonListener);
         }
         return view;
     }
-
-    //Restoring the data
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        if (savedInstanceState != null) {
-            title.setText(savedInstanceState.getString(BUNDLE_KEY_TITLE));
-            bigTextSub.setText(BUNDLE_KEY_SUBTITLE);
-            if (mButtonText != null) {
-                button.setText(savedInstanceState.getString(BUNDLE_KEY_BUTTON_TEXT));
-            }
-
-        }
-    }
-
-    //Saving the data
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString(BUNDLE_KEY_TITLE, mTitle);
-        outState.putString(BUNDLE_KEY_SUBTITLE, mSubTitle);
-        if (mButtonText != null) {
-            outState.putString(BUNDLE_KEY_BUTTON_TEXT, mButtonText);
-        }
-    }
-
 }

--- a/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/OnboardingActivity.java
@@ -17,56 +17,25 @@ import org.torproject.android.ui.AppManagerActivity;
 import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 
 public class OnboardingActivity extends AppIntro {
-    private CustomSlideBigText welcome, intro2, cs2, cs3;
-
-    private static final String BUNDLE_KEY_WELCOME_FRAGMENT = "Welcome";
-    private static final String BUNDLE_KEY_INTRO_2_FRAGMENT = "Intro2";
-    private static final String BUNDLE_KEY_CS2_FRAGMENT = "CS2";
-    private static final String BUNDLE_KEY_CS3_FRAGMENT = "CS3";
-
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState != null) { // Restoring the fragments
-            welcome = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_WELCOME_FRAGMENT);
-            intro2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_INTRO_2_FRAGMENT);
-            cs2 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_CS2_FRAGMENT);
-            if (PermissionManager.isLollipopOrHigher())
-                cs3 = (CustomSlideBigText) getSupportFragmentManager().getFragment(savedInstanceState, BUNDLE_KEY_CS3_FRAGMENT);
+        addSlide(CustomSlideBigText.newInstance(R.layout.custom_slide_big_text, getString(R.string.hello), getString(R.string.welcome)));
+        addSlide(CustomSlideBigText.newInstance(R.layout.custom_slide_big_text, getString(R.string.browser_the_internet), getString(R.string.no_tracking)));
 
-        } else {
-            // Instead of fragments, you can also use our default slide
-            // Just set a title, description, background and image. AppIntro will do the rest.
-            welcome = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-            welcome.setTitle(getString(R.string.hello));
-            welcome.setSubTitle(getString(R.string.welcome));
-            addSlide(welcome);
+        CustomSlideBigText cs2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text, getString(R.string.bridges_sometimes));
+        cs2.showButton(getString(R.string.action_more), v -> startActivity(new Intent(OnboardingActivity.this, BridgeWizardActivity.class)));
+        cs2.showButton(getString(R.string.action_more), v -> startActivity(new Intent(OnboardingActivity.this, BridgeWizardActivity.class)));
+        addSlide(cs2);
 
-            intro2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-            intro2.setTitle(getString(R.string.browser_the_internet));
-            intro2.setSubTitle(getString(R.string.no_tracking));
-            addSlide(intro2);
-
-            cs2 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-            cs2.setTitle(getString(R.string.bridges_sometimes));
-            cs2.showButton(getString(R.string.action_more), v -> startActivity(new Intent(OnboardingActivity.this, BridgeWizardActivity.class)));
-            addSlide(cs2);
-
-            if (PermissionManager.isLollipopOrHigher()) {
-
-                cs3 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text);
-                cs3.setTitle(getString(R.string.vpn_setup));
-                cs3.setSubTitle(getString(R.string.vpn_setup_sub));
-                cs3.showButton(getString(R.string.action_vpn_choose), v -> startActivityForResult(new Intent(OnboardingActivity.this, AppManagerActivity.class), 9999));
-                addSlide(cs3);
-
-            }
+        if (PermissionManager.isLollipopOrHigher()) {
+            CustomSlideBigText cs3 = CustomSlideBigText.newInstance(R.layout.custom_slide_big_text, getString(R.string.vpn_setup), getString(R.string.vpn_setup_sub));
+            cs3.showButton(getString(R.string.action_vpn_choose), v -> startActivity(new Intent(OnboardingActivity.this, AppManagerActivity.class)));
+            addSlide(cs3);
         }
 
-
-        // OPTIONAL METHODS
         // Override bar/separator color.
         setBarColor(getResources().getColor(R.color.dark_purple));
         setSeparatorColor(getResources().getColor(R.color.panel_background_main));
@@ -89,26 +58,5 @@ public class OnboardingActivity extends AppIntro {
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(LocaleHelper.onAttach(base));
-    }
-
-    @Override
-    protected void onSaveInstanceState(Bundle outState) { //Saving the fragments
-        super.onSaveInstanceState(outState);
-
-        //Save the fragment's instance
-        int count = 0;
-        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
-            count++;
-        }
-
-        //Should check if the fragment exists in the fragment manager or else it'll flag error
-        if (count >= 1)
-            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_WELCOME_FRAGMENT, welcome);
-        if (count >= 2)
-            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_INTRO_2_FRAGMENT, intro2);
-        if (count >= 3)
-            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_CS2_FRAGMENT, cs2);
-        if (count >= 4 && PermissionManager.isLollipopOrHigher())
-            getSupportFragmentManager().putFragment(outState, BUNDLE_KEY_CS3_FRAGMENT, cs3);
     }
 }


### PR DESCRIPTION
Makes the system preserve the `OnboardingActivity` on device rotation so that we don't need to do any work to preserve state. This fixes a recurring bug where that Activity would close or be in the wrong state on device rotation:

![fix](https://user-images.githubusercontent.com/22125581/88684903-59157500-d0c3-11ea-8582-1784f2c64feb.gif)
