### PR TITLE
Removed "Tor-Enabled Apps" UI from devices < Lollipop 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -1175,8 +1175,10 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
     }
 
     private void drawAppShortcuts(boolean showSelectedApps) {
-
-        if (!PermissionManager.isLollipopOrHigher()) return;
+        if (!PermissionManager.isLollipopOrHigher()) {
+            findViewById(R.id.boxVpnStatus).setVisibility(View.GONE);
+            return;
+        }
 
         LinearLayout llBoxShortcuts = findViewById(R.id.boxAppShortcuts);
 
@@ -1205,14 +1207,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
                         params.setMargins(3, 3, 3, 3);
                         iv.setLayoutParams(params);
                         iv.setImageDrawable(pMgr.getApplicationIcon(pkgId));
-
-                        iv.setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                openBrowser(URL_TOR_CHECK, false, pkgId);
-                            }
-                        });
-
+                        iv.setOnClickListener(v -> openBrowser(URL_TOR_CHECK, false, pkgId));
                         llBoxShortcuts.addView(iv);
                         appsAdded++;
                     } catch (Exception e) {

--- a/app/src/main/res/layout/layout_main.xml
+++ b/app/src/main/res/layout/layout_main.xml
@@ -1,342 +1,341 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:gravity="center_vertical|center_horizontal"
-	xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
 
-	android:orientation="vertical"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/dark_purple"
 
-	android:background="@color/dark_purple"
-	xmlns:app="http://schemas.android.com/apk/res-auto">
-    
-     <androidx.appcompat.widget.Toolbar
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize" />
+
     <androidx.drawerlayout.widget.DrawerLayout
-    android:id="@+id/drawer_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
+        android:id="@+id/drawer_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
         <ScrollView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content">
-<RelativeLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
 
-	<FrameLayout
-	    	android:layout_width="match_parent"
-		android:layout_height="250dp"
-		android:id="@+id/frameMain"
-		android:visibility="visible"	
-		 android:orientation="vertical"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_margin="3dp"
-        android:background="#11CCCCCC"
-		android:weightSum="1">
-        <pl.bclogic.pulsator4droid.library.PulsatorLayout
-            android:id="@+id/pulsator"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="20dp"
-            app:pulse_count="4"
-            app:pulse_duration="2000"
-            app:pulse_repeat="0"
-            app:pulse_color="@color/dark_green"
-            app:pulse_startFromScratch="false"
-            app:pulse_interpolator="Linear">
-		       <ImageView
-				android:id="@+id/imgStatus"
-				android:layout_width="match_parent"
-				android:layout_height="225dp"
-				   android:padding="0dp"
-				android:layout_margin="0dp"
-				android:src="@drawable/toroff" />
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-        </pl.bclogic.pulsator4droid.library.PulsatorLayout>
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/btnStart"
-            android:text="@string/menu_start"
-            android:layout_gravity="center"
-            android:background="@android:color/transparent"
-            android:layout_marginTop="20dp"
-            />
-    </FrameLayout>
+                <FrameLayout
+                    android:id="@+id/frameMain"
+                    android:layout_width="match_parent"
+                    android:layout_height="250dp"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentLeft="true"
+                    android:layout_margin="3dp"
+                    android:background="#11CCCCCC"
+                    android:orientation="vertical"
+                    android:visibility="visible"
+                    android:weightSum="1">
 
-    <TextView
-        android:id="@+id/lblStatus"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="14sp"
-        android:fontFamily="sans-serif-light"
-        android:lines="1"
-        android:text="[             ]"
-        android:maxLines="1"
-        android:layout_margin="12dp"
-        android:ellipsize="end"
-        android:layout_gravity="top|center"
-        android:gravity="center"
-        android:layout_below="@+id/frameMain"
-        />
+                    <pl.bclogic.pulsator4droid.library.PulsatorLayout
+                        android:id="@+id/pulsator"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:paddingTop="20dp"
+                        app:pulse_color="@color/dark_green"
+                        app:pulse_count="4"
+                        app:pulse_duration="2000"
+                        app:pulse_interpolator="Linear"
+                        app:pulse_repeat="0"
+                        app:pulse_startFromScratch="false">
 
-    <TextView
-        android:id="@+id/lblPorts"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="14sp"
-        android:fontFamily="sans-serif-light"
-        android:lines="1"
-        android:text="@string/default_socks_http"
-        android:maxLines="1"
-        android:layout_margin="12dp"
-        android:ellipsize="end"
-        android:layout_gravity="top|center"
-        android:gravity="center"
-        android:layout_below="@+id/lblStatus"
-        />
+                        <ImageView
+                            android:id="@+id/imgStatus"
+                            android:layout_width="match_parent"
+                            android:layout_height="225dp"
+                            android:layout_margin="0dp"
+                            android:padding="0dp"
+                            android:src="@drawable/toroff" />
 
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_below="@+id/lblPorts"
-    android:id="@+id/controls"
+                    </pl.bclogic.pulsator4droid.library.PulsatorLayout>
 
-    >
+                    <Button
+                        android:id="@+id/btnStart"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="20dp"
+                        android:background="@android:color/transparent"
+                        android:text="@string/menu_start" />
+                </FrameLayout>
 
-    <LinearLayout
-        android:layout_gravity="center"
-        android:orientation="vertical"
-        android:layout_width="170dp"
-        android:layout_height="50dp"
-        android:background="#11CCCCCC"
-        android:layout_margin="3dp"
-        android:layout_weight="1"
-        >
-        <!--
-<TextView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:text="Select Region"
-    android:layout_margin="12dp"
+                <TextView
+                    android:id="@+id/lblStatus"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/frameMain"
+                    android:layout_gravity="top|center"
+                    android:layout_margin="12dp"
+                    android:ellipsize="end"
+                    android:fontFamily="sans-serif-light"
+                    android:gravity="center"
+                    android:lines="1"
+                    android:maxLines="1"
+                    android:text="[             ]"
+                    android:textSize="14sp" />
 
-    />-->
-    <Spinner
-        android:id="@+id/spinnerCountry"
-        android:layout_width="165dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="9dp"
+                <TextView
+                    android:id="@+id/lblPorts"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/lblStatus"
+                    android:layout_gravity="top|center"
+                    android:layout_margin="12dp"
+                    android:ellipsize="end"
+                    android:fontFamily="sans-serif-light"
+                    android:gravity="center"
+                    android:lines="1"
+                    android:maxLines="1"
+                    android:text="@string/default_socks_http"
+                    android:textSize="14sp" />
 
-        />
+                <LinearLayout
+                    android:id="@+id/controls"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/lblPorts"
+                    android:orientation="horizontal"
 
-    </LinearLayout>
+                    >
 
+                    <LinearLayout
+                        android:layout_width="170dp"
+                        android:layout_height="50dp"
+                        android:layout_gravity="center"
+                        android:layout_margin="3dp"
+                        android:layout_weight="1"
+                        android:background="#11CCCCCC"
+                        android:orientation="vertical">
+                        <!--
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Select Region"
+                    android:layout_margin="12dp"
 
-    <LinearLayout
-        android:layout_gravity="center"
-        android:orientation="vertical"
-        android:layout_width="170dp"
-        android:layout_height="50dp"
-        android:background="#11CCCCCC"
-        android:layout_margin="3dp"
-        android:layout_weight="1"
+                    />-->
+                        <Spinner
+                            android:id="@+id/spinnerCountry"
+                            android:layout_width="165dp"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="9dp"
 
-        >
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/btnVPN"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/apps_mode"
-            android:layout_margin="9dp"
-            android:layout_gravity="center"
-            app:switchPadding="3dp"
+                            />
 
-            />
-    </LinearLayout>
-
-</LinearLayout>
+                    </LinearLayout>
 
 
+                    <LinearLayout
+                        android:layout_width="170dp"
+                        android:layout_height="50dp"
+                        android:layout_gravity="center"
+                        android:layout_margin="3dp"
+                        android:layout_weight="1"
+                        android:background="#11CCCCCC"
+                        android:orientation="vertical"
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_below="@+id/controls"
-        android:id="@+id/traffic"
+                        >
 
-        >
+                        <androidx.appcompat.widget.SwitchCompat
+                            android:id="@+id/btnVPN"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_margin="9dp"
+                            android:text="@string/apps_mode"
+                            app:switchPadding="3dp"
 
-        <LinearLayout
-            android:layout_gravity="center"
-            android:orientation="horizontal"
-            android:layout_width="170dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="3dp"
-            android:layout_weight="1"
-            >
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_layout_download"
-                android:gravity="center"
-                android:fontFamily="sans-serif-light"
-                android:layout_margin="3dp"
-                android:lines="1"
+                            />
+                    </LinearLayout>
 
-                />
+                </LinearLayout>
 
 
-            <TextView
-                android:id="@+id/trafficDown"
-                android:layout_width="100dp"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:fontFamily="sans-serif-light"
-                android:text="0kbps"
-                android:layout_margin="3dp"
-                android:lines="1"
+                <LinearLayout
+                    android:id="@+id/traffic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/controls"
+                    android:orientation="horizontal"
 
-                />
-        </LinearLayout>
+                    >
 
+                    <LinearLayout
+                        android:layout_width="170dp"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_margin="3dp"
+                        android:layout_weight="1"
+                        android:orientation="horizontal">
 
-        <LinearLayout
-            android:layout_gravity="center"
-            android:orientation="horizontal"
-            android:layout_width="170dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="3dp"
-            android:layout_weight="1"
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="3dp"
+                            android:fontFamily="sans-serif-light"
+                            android:gravity="center"
+                            android:lines="1"
+                            android:text="@string/main_layout_download"
 
-            >
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_layout_upload"
-                android:gravity="center_vertical"
-                android:fontFamily="sans-serif-light"
-                android:layout_margin="3dp"
-                />
-
-            <TextView
-                android:id="@+id/trafficUp"
-                android:layout_width="100dp"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:fontFamily="sans-serif-light"
-                android:text="0kbps"
-                android:layout_margin="3dp"
-                android:lines="1"
-
-                />
-
-        </LinearLayout>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/row_bridges"
-        android:gravity="center_horizontal"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="40dp"
-        android:background="#11CCCCCC"
-        android:layout_margin="3dp"
-        android:layout_weight="1"
-        android:layout_below="@+id/traffic"
-        >
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:fontFamily="sans-serif-light"
-            android:text="@string/trouble_connecting"
-            android:layout_margin="3dp"
-            android:lines="1"
-
-            />
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/btnBridges"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/use_bridges"
-            android:layout_margin="3dp"
-            app:switchPadding="3dp"
-            android:layout_marginTop="10dp"
-            android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
-            />
-    </LinearLayout>
-    <LinearLayout
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:background="#55CCCCCC"
-        android:layout_margin="3dp"
-        android:layout_weight="1"
-        android:layout_below="@+id/row_bridges"
-        >
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:fontFamily="sans-serif-light"
-            android:text="@string/app_shortcuts"
-            android:layout_margin="3dp"
-            android:lines="1"
-            />
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:id="@+id/boxAppShortcuts"
-            android:gravity="center"
-            android:padding="3dp"
-            >
-        </LinearLayout>
-    </LinearLayout>
+                            />
 
 
-</RelativeLayout>
+                        <TextView
+                            android:id="@+id/trafficDown"
+                            android:layout_width="100dp"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="3dp"
+                            android:fontFamily="sans-serif-light"
+                            android:gravity="center_vertical"
+                            android:lines="1"
+                            android:text="0kbps"
+
+                            />
+                    </LinearLayout>
+
+
+                    <LinearLayout
+                        android:layout_width="170dp"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_margin="3dp"
+                        android:layout_weight="1"
+                        android:orientation="horizontal"
+
+                        >
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="3dp"
+                            android:fontFamily="sans-serif-light"
+                            android:gravity="center_vertical"
+                            android:text="@string/main_layout_upload" />
+
+                        <TextView
+                            android:id="@+id/trafficUp"
+                            android:layout_width="100dp"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="3dp"
+                            android:fontFamily="sans-serif-light"
+                            android:gravity="center_vertical"
+                            android:lines="1"
+                            android:text="0kbps"
+
+                            />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/row_bridges"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_below="@+id/traffic"
+                    android:layout_margin="3dp"
+                    android:layout_weight="1"
+                    android:background="#11CCCCCC"
+                    android:gravity="center_horizontal"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="3dp"
+                        android:fontFamily="sans-serif-light"
+                        android:gravity="center_vertical"
+                        android:lines="1"
+                        android:text="@string/trouble_connecting"
+
+                        />
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/btnBridges"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:layout_centerVertical="true"
+                        android:layout_margin="3dp"
+                        android:layout_marginTop="10dp"
+                        android:text="@string/use_bridges"
+                        app:switchPadding="3dp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/boxVpnStatus"
+                    android:layout_width="match_parent"
+                    android:layout_height="80dp"
+                    android:layout_below="@+id/row_bridges"
+                    android:layout_margin="3dp"
+                    android:layout_weight="1"
+                    android:background="#55CCCCCC"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="3dp"
+                        android:fontFamily="sans-serif-light"
+                        android:gravity="center_vertical"
+                        android:lines="1"
+                        android:text="@string/app_shortcuts" />
+
+                    <LinearLayout
+                        android:id="@+id/boxAppShortcuts"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="horizontal"
+                        android:padding="3dp"/>
+                </LinearLayout>
+
+
+            </RelativeLayout>
         </ScrollView>
 
-	    
-	 <LinearLayout
-    android:layout_width="320dp"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-         android:layout_gravity="end"
-    android:background="#333333"
-         android:padding="6dp"
-     >
-         <TextView
-             android:layout_width="wrap_content"
-             android:layout_height="wrap_content"
-             android:text="@string/menu_log"
-             android:textAppearance="?android:attr/textAppearanceMedium"
-             />
-    	<TextView
-			android:id="@+id/orbotLog"
-			android:textSize="12sp"
-			android:gravity="start"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:layout_alignParentLeft="true"
-			android:layout_marginTop="10dp"
-			android:textIsSelectable="true"
-			android:fontFamily="monospace"
-			 />
-    </LinearLayout>
-	
-	</androidx.drawerlayout.widget.DrawerLayout>
+
+        <LinearLayout
+            android:layout_width="320dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:background="#333333"
+            android:orientation="vertical"
+            android:padding="6dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/menu_log"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                android:id="@+id/orbotLog"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_marginTop="10dp"
+                android:fontFamily="monospace"
+                android:gravity="start"
+                android:textIsSelectable="true"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+    </androidx.drawerlayout.widget.DrawerLayout>
 
 </LinearLayout>
 


### PR DESCRIPTION
The VPN is either on ("full device") or not so there's no need to show users running these devices stuff about "tor-enabled" apps ~ this is extra information that could confuse users running older versions of Android

Before:
![image](https://user-images.githubusercontent.com/22125581/89326032-a95a7d00-d657-11ea-876b-02f3df7f4057.png)


After:
![image](https://user-images.githubusercontent.com/22125581/89325912-7adca200-d657-11ea-8c50-e074ada29503.png)
