### PR TITLE
Use smaller androidx dependencies in orbotservice

### DIFF
--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -42,8 +42,6 @@ android {
 
 dependencies {
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-
     implementation 'org.torproject:tor-android-binary:0.4.3.6-actual'
 
     implementation 'info.pluggabletransports.aptds:apt-dispatch-library:1.0.9'
@@ -52,6 +50,8 @@ dependencies {
 
     implementation 'com.jaredrummler:android-shell:1.0.0'
     implementation fileTree(dir: 'libs', include: ['.so'])
+    implementation 'androidx.core:core:1.3.2'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     testImplementation 'junit:junit:4.13'
 
     implementation 'com.offbynull.portmapper:portmapper:2.0.5'


### PR DESCRIPTION
We were over importing androidx stuff. Just using the modules we need reduces APK size by ~ .2 megabytes 