### PR TITLE
enable lint checking with fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
 assembleDebug:
   stage: build
   script:
-    - ./gradlew assembleDebug
+    - ./gradlew assembleDebug lint
   artifacts:
     paths:
     - app/build/outputs/

--- a/.weblate
+++ b/.weblate
@@ -1,0 +1,3 @@
+[weblate]
+url = https://hosted.weblate.org/api/
+translation = guardianproject/orbot

--- a/app-mini/src/main/res/values-es-rAR/strings.xml
+++ b/app-mini/src/main/res/values-es-rAR/strings.xml
@@ -59,7 +59,7 @@
   <string name="your_reachableaddresses_settings_caused_an_exception_">La configuración de las direcciones alcanzables causó una excepción.</string>
   <string name="your_relay_settings_caused_an_exception_">Su configuración de retransmisión provocó una excepción.</string>
   <string name="exit_nodes">nodos de salida</string>
-  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">huellas dactilares, apodos, paises y direcciones para el ultimo salto</string>
+  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">huellas dactilares, apodos, paises y direcciones para el último salto</string>
   <string name="enter_exit_nodes">ingrese nodos de salida</string>
   <string name="exclude_nodes">excluir nodos</string>
   <string name="fingerprints_nicks_countries_and_addresses_to_exclude">huellas digitales, usuarios, paises y direcciones para excluir</string>

--- a/app-mini/src/main/res/values-pt-rBR/poestrings.xml
+++ b/app-mini/src/main/res/values-pt-rBR/poestrings.xml
@@ -9,7 +9,7 @@
     <string name="action_vpn_choose">ESCOLHA OS APLICATIVOS</string>
 
     <string name="hello">Olá</string>
-    <string name="welcome">Seja bem vindo ao Tor para dispositivos móveis.</string>
+    <string name="welcome">Seja bem-vindo ao Tor para dispositivos móveis.</string>
 
     <string name="browser_the_internet">Navegue na Internet como você espera.</string>
     <string name="no_tracking">Sem rastreamento. Sem censura.</string>

--- a/app-mini/src/main/res/values-pt/strings.xml
+++ b/app-mini/src/main/res/values-pt/strings.xml
@@ -74,7 +74,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Pontes Atualizadas</string>
   <string name="menu_qr">Códigos QR</string>
-  <string name="get_bridges_email">Correio Eletrónico</string>
+  <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="activate">Ativar</string>
   <string name="send_email">Enviar Mensagem</string>
     <string name="hidden_services">Serviços ocultos</string>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,9 +52,13 @@ android {
     }
     lintOptions {
         checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
-        abortOnError false
+        abortOnError true
+
+        htmlReport true
+        xmlReport false
+        textReport false
+
+        lintConfig file("../lint.xml")
     }
     buildTypes {
         release {

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -703,7 +703,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
 
                 if (urlString != null) {
 
-                    if (urlString.toLowerCase().startsWith("bridge://")) {
+                    if (urlString.toLowerCase(Locale.ENGLISH).startsWith("bridge://")) {
                         String newBridgeValue = urlString.substring(9); //remove the bridge protocol piece
                         try {
                             newBridgeValue = URLDecoder.decode(newBridgeValue, "UTF-8"); //decode the value here

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -3,6 +3,7 @@
 
 package org.torproject.android;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.content.BroadcastReceiver;
@@ -1186,6 +1187,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         llBoxShortcuts.addView(tv);
     }
 
+    @SuppressLint("SetWorldReadable")
     @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     private void exportTorData() {
         File fileTorData;

--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/ClientCookiesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/ClientCookiesActivity.java
@@ -32,6 +32,7 @@ import org.torproject.android.ui.hiddenservices.dialogs.CookieActionsDialog;
 import org.torproject.android.ui.hiddenservices.providers.CookieContentProvider;
 
 import java.io.File;
+import java.util.Locale;
 
 public class ClientCookiesActivity extends AppCompatActivity {
     public static final String BUNDLE_KEY_ID = "_id",
@@ -115,7 +116,7 @@ public class ClientCookiesActivity extends AppCompatActivity {
         File backupDir = DiskUtils.getOrCreateLegacyBackupDir();
 
         try {
-            File[] files = backupDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".json"));
+            File[] files = backupDir.listFiles((dir, name) -> name.toLowerCase(Locale.ENGLISH).endsWith(".json"));
             if (files != null) {
                 if (files.length == 0) {
                     Toast.makeText(this, R.string.create_a_backup_first, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/org/torproject/android/ui/hiddenservices/HiddenServicesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/hiddenservices/HiddenServicesActivity.java
@@ -31,6 +31,7 @@ import org.torproject.android.ui.hiddenservices.permissions.PermissionManager;
 import org.torproject.android.ui.hiddenservices.providers.HSContentProvider;
 
 import java.io.File;
+import java.util.Locale;
 
 public class HiddenServicesActivity extends AppCompatActivity {
     public static final String BUNDLE_KEY_ID = "_id",
@@ -111,7 +112,7 @@ public class HiddenServicesActivity extends AppCompatActivity {
 
     private void doRestoreLegacy() { // API 16, 17, 18
         File backupDir = DiskUtils.getOrCreateLegacyBackupDir();
-        File[] files = backupDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".zip"));
+        File[] files = backupDir.listFiles((dir, name) -> name.toLowerCase(Locale.ENGLISH).endsWith(".zip"));
         if (files != null) {
             if (files.length == 0) {
                 Toast.makeText(this, R.string.create_a_backup_first, Toast.LENGTH_LONG).show();

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -58,7 +58,7 @@
   <string name="your_reachableaddresses_settings_caused_an_exception_">La configuración de las direcciones alcanzables causó una excepción.</string>
   <string name="your_relay_settings_caused_an_exception_">Su configuración de retransmisión provocó una excepción.</string>
   <string name="exit_nodes">nodos de salida</string>
-  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">huellas dactilares, apodos, paises y direcciones para el ultimo salto</string>
+  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">huellas dactilares, apodos, paises y direcciones para el último salto</string>
   <string name="enter_exit_nodes">ingrese nodos de salida</string>
   <string name="exclude_nodes">excluir nodos</string>
   <string name="fingerprints_nicks_countries_and_addresses_to_exclude">huellas digitales, usuarios, paises y direcciones para excluir</string>

--- a/app/src/main/res/values-pt-rBR/poestrings.xml
+++ b/app/src/main/res/values-pt-rBR/poestrings.xml
@@ -9,7 +9,7 @@
     <string name="action_vpn_choose">ESCOLHA OS APLICATIVOS</string>
 
     <string name="hello">Olá</string>
-    <string name="welcome">Seja bem vindo ao Tor para dispositivos móveis.</string>
+    <string name="welcome">Seja bem-vindo ao Tor para dispositivos móveis.</string>
 
     <string name="browser_the_internet">Navegue na Internet como você espera.</string>
     <string name="no_tracking">Sem rastreamento. Sem censura.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -44,7 +44,7 @@
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_dnsport_title">Porta DNS Tor</string>
     <string name="menu_qr">Códigos QR</string>
-    <string name="get_bridges_email">Correio Eletrónico</string>
+    <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="send_email">Enviar Mensagem</string>
     <string name="save">Guardar</string>
     <string name="name">Nome</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -70,7 +70,7 @@
     <string name="pref_dnsport_title">Porta DNS Tor</string>
     <string name="bridges_updated">Pontes Atualizadas</string>
     <string name="menu_qr">Códigos QR</string>
-    <string name="get_bridges_email">Correio Eletrónico</string>
+    <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="send_email">Enviar Mensagem</string>
     <string name="hidden_services">Serviços ocultos</string>
     <string name="title_activity_hidden_services">Serviços ocultos</string>

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!-- Our translations are crowd-sourced -->
+    <issue id="MissingTranslation" severity="ignore"/>
+
+    <!-- These could be fixed, then warning can be error -->
+    <issue id="HardcodedText" severity="warning"/>
+    <issue id="InlinedApi" severity="warning"/>
+    <issue id="LongLogTag" severity="warning"/>
+    <issue id="RtlEnabled" severity="warning"/>
+    <issue id="UnusedResources" severity="warning"/>
+    <issue id="WrongConstant" severity="warning"/>
+
+    <!-- These are important to us, so promote from warning to error -->
+    <issue id="AppCompatMethod" severity="error"/>
+    <issue id="DefaultLocale" severity="error"/>
+    <issue id="GetInstance" severity="error"/>
+    <issue id="HardwareIds" severity="error"/>
+    <issue id="ImpliedQuantity" severity="error"/>
+    <issue id="InvalidPackage" severity="error"/>
+    <issue id="NestedScrolling" severity="error"/>
+    <issue id="NewApi" severity="error"/>
+    <issue id="PackageManagerGetSignatures" severity="error"/>
+    <issue id="PluralsCandidate" severity="error"/>
+    <issue id="ProtectedPermissions" severity="error"/>
+    <issue id="RtlCompat" severity="error"/>
+    <issue id="SetWorldReadable" severity="error"/>
+    <issue id="SimpleDateFormat" severity="error"/>
+    <issue id="StringFormatCount" severity="error"/>
+    <issue id="TrustAllX509TrustManager" severity="error"/>
+    <issue id="Typos" severity="error"/>
+    <issue id="UnsafeProtectedBroadcastReceiver" severity="error"/>
+
+    <!-- both the correct and deprecated locales need to be present for
+         them to be recognized on all devices -->
+    <issue id="LocaleFolder" severity="error">
+        <ignore path="src/main/res/values-he"/>
+        <ignore path="src/main/res/values-id"/>
+    </issue>
+</lint>

--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -31,7 +31,14 @@ android {
     }
 
     lintOptions {
-        abortOnError false
+        checkReleaseBuilds false
+        abortOnError true
+
+        htmlReport true
+        xmlReport false
+        textReport false
+
+        lintConfig file("../lint.xml")
     }
 
     packagingOptions {

--- a/orbotservice/src/main/java/org/torproject/android/service/util/CustomNativeLoader.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/CustomNativeLoader.java
@@ -1,5 +1,6 @@
 package org.torproject.android.service.util;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.os.Build;
@@ -16,6 +17,7 @@ public class CustomNativeLoader {
 
     private final static String TAG = "CNL";
 
+    @SuppressLint("SetWorldReadable")
     private static boolean loadFromZip(Context context, String libname, File destLocalFile, String arch) {
 
 

--- a/orbotservice/src/main/java/org/torproject/android/service/util/NativeLoader.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/NativeLoader.java
@@ -1,5 +1,6 @@
 package org.torproject.android.service.util;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
 import android.util.Log;
@@ -15,6 +16,7 @@ public class NativeLoader {
 
     private final static String TAG = "TorNativeLoader";
 
+    @SuppressLint("SetWorldReadable")
     private static boolean loadFromZip(Context context, String libName, File destLocalFile, String folder) {
 
 

--- a/orbotservice/src/main/res/values-nb/strings.xml
+++ b/orbotservice/src/main/res/values-nb/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Orbot</string>
-  <string name="app_description">Orbot er en gratis proxy app som gjør det mulig for andre apps å bruke internett mer sikkert. Orbot bruker Tor for å kryptere din Internettrafikk, og skjuler da din trafikk ved å sende trafikken gjennom en lang rekke datamaskiner over hele verden. Tor er et gratis dataprogram, og et åpent nettverk som hjelper deg å forsvare deg mot en form for nettverksovervåking som truer din personlige frihet og privatliv, konfidensiell bedriftsvirksomhet og relasjoner, og statlig sikkerhet kjent som trafikkanalyse.</string>
+  <string name="app_description">Orbot er en gratis proxy app som gjør det mulig for andre apps å bruke Internett mer sikkert. Orbot bruker Tor for å kryptere din Internettrafikk, og skjuler da din trafikk ved å sende trafikken gjennom en lang rekke datamaskiner over hele verden. Tor er et gratis dataprogram, og et åpent nettverk som hjelper deg å forsvare deg mot en form for nettverksovervåking som truer din personlige frihet og privatliv, konfidensiell bedriftsvirksomhet og relasjoner, og statlig sikkerhet kjent som trafikkanalyse.</string>
     <string name="status_starting_up">Orbot starter...</string>
   <string name="status_activated">Koblet til Tor-nettverket</string>
   <string name="status_disabled">Orbot er deaktivert</string>


### PR DESCRIPTION
This enables useful lint checks, turns less useful ones to warnings, and makes `./gradlew lint` fail when lint reports an error.  This adds lint to the GitLab CI build:

https://gitlab.com/eighthave/orbot/-/jobs/929875017