### PR TITLE
When tor stops, stop showing wrong bandwidth stats

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -308,9 +308,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         downloadText = findViewById(R.id.trafficDown);
         uploadText = findViewById(R.id.trafficUp);
 
-        String zero = String.format("%s / %s", formatCount(0), formatTotal(0));
-        downloadText.setText(zero);
-        uploadText.setText(zero);
+        resetBandwidthStatTextviews();
 
         mBtnStart = findViewById(R.id.btnStart);
         mBtnStart.setOnClickListener(v -> toggleTor());
@@ -338,6 +336,12 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         setCountrySpinner();
 
         mPulsator = findViewById(R.id.pulsator);
+    }
+
+    private void resetBandwidthStatTextviews() {
+        String zero = String.format("%s / %s", formatCount(0), formatTotal(0));
+        downloadText.setText(zero);
+        uploadText.setText(zero);
     }
 
     private void toggleTor() { // UI entry point for  (dis)connecting to Tor
@@ -1033,6 +1037,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
                 lblStatus.setText(String.format("Tor v%s", OrbotService.BINARY_TOR_VERSION));
                 mBtnStart.setText(R.string.menu_start);
                 mPulsator.start();
+                resetBandwidthStatTextviews();
 
                 break;
         }


### PR DESCRIPTION
Normally after you stop tor Orbot will still show the last active bandwidth information in its UI. This resets the UI when the tor connection is dropped.