### PR TITLE
Removed Barebones Bridge Config in Orbot -> Settings

### DIFF
--- a/app-mini/src/main/res/values-ar/strings.xml
+++ b/app-mini/src/main/res/values-ar/strings.xml
@@ -120,8 +120,7 @@
   <string name="mb">ميغابايت</string>
   <string name="bridges_updated">تم تحديث الجسور</string>
   <string name="restart_orbot_to_use_this_bridge_">الرجاء إعادة تشغيل أوربوت لتفعيل التعديلات</string>
-  <string name="menu_qr">رمز كيو آر</string>
-  <string name="get_bridges_email">البريد الإلكتروني</string>
+    <string name="get_bridges_email">البريد الإلكتروني</string>
     <string name="activate">تفعيل</string>
   <string name="apps_mode">وضع الـ VPN</string>
   <string name="send_email">أرسل بريد الكتروني</string>

--- a/app-mini/src/main/res/values-ay/strings.xml
+++ b/app-mini/src/main/res/values-ay/strings.xml
@@ -123,8 +123,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Jichhaptayat jalakipañanaka</string>
   <string name="restart_orbot_to_use_this_bridge_">Mayjt\'ayatanak aqtayañatak Orbot mayamp qhant\'ayam, amp suma</string>
-  <string name="menu_qr">QR chimpunaka</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Jawsañ apnaqirinakax Tor jark\'antañ yatipk ukjax \'Jalakipañ yanapiri\' mantañatak apnaqarakismawa. Yant\'añataki, mayjt\'ayañatakix AJLLT\'AM...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Jawsañ apnaqirinakax Tor jark\'antañ yatipk ukjax \'Jalakipañ yanapiri\' mantañatak apnaqarakismawa. Yant\'añataki, mayjt\'ayañatakix AJLLT\'AM...</string>
   <string name="get_bridges_email">Imaylu (Email)</string>
   <string name="activate">Qhantayaña</string>
   <string name="apps_mode">VPN</string>

--- a/app-mini/src/main/res/values-az/strings.xml
+++ b/app-mini/src/main/res/values-az/strings.xml
@@ -120,8 +120,7 @@ LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="mb">MB</string>
   <string name="bridges_updated">Körpülər yeniləndi</string>
   <string name="restart_orbot_to_use_this_bridge_">Lütfən, Orbotu söndürün və yenidən yandırın ki, dəyişikliklər tətbiq edilsin.</string>
-  <string name="menu_qr">QR kodlar</string>
-  <string name="get_bridges_email">Emeyl</string>
+    <string name="get_bridges_email">Emeyl</string>
     <string name="activate">Aktivləşdir</string>
   <string name="send_email">Emeyl göndərin</string>
   <string name="save">Saxla</string>

--- a/app-mini/src/main/res/values-be/strings.xml
+++ b/app-mini/src/main/res/values-be/strings.xml
@@ -123,8 +123,7 @@
   <string name="mb">МБ</string>
   <string name="bridges_updated">Масты абноўлены</string>
   <string name="restart_orbot_to_use_this_bridge_">Калі ласка, перазапусціце Orbot для ўступу змены ў сілу</string>
-  <string name="menu_qr">QR-коды</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Калі ваша мабільная сетка актыўна блакуе Tor, вы можаце выкарыстоўваць масты Tor для доступу да сеткі. Абярыце адзін з варыянтаў для налады і тэставання:</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Калі ваша мабільная сетка актыўна блакуе Tor, вы можаце выкарыстоўваць масты Tor для доступу да сеткі. Абярыце адзін з варыянтаў для налады і тэставання:</string>
   <string name="get_bridges_email">Эл. пошта</string>
   <string name="activate">Актывацыя</string>
   <string name="apps_mode">VPN-рэжым</string>

--- a/app-mini/src/main/res/values-bg/strings.xml
+++ b/app-mini/src/main/res/values-bg/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Мостове включени!</string>
   <string name="restart_orbot_to_use_this_bridge_">Моля, рестартирай Orbot, за да влязат в действие промените</string>
-  <string name="menu_qr">QR Кодове</string>
-  <string name="get_bridges_email">Имейл</string>
+    <string name="get_bridges_email">Имейл</string>
     <string name="activate">Активирай</string>
   <string name="send_email">Изпрати имейл</string>
   <string name="hidden_services">Скрити услуги</string>

--- a/app-mini/src/main/res/values-ca/strings.xml
+++ b/app-mini/src/main/res/values-ca/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">S\'han actualitzat els ponts</string>
   <string name="restart_orbot_to_use_this_bridge_">Reinicieu l\'Orbot per aplicar els canvis</string>
-  <string name="menu_qr">Codis QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si la teva xarxa mòbil boqueja activament Tor, pots utilitzar un \'Servidor pont\' com a via alternativa. SELECCIONA una de les opcions per configurar i provar.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si la teva xarxa mòbil boqueja activament Tor, pots utilitzar un \'Servidor pont\' com a via alternativa. SELECCIONA una de les opcions per configurar i provar.</string>
   <string name="get_bridges_email">Correu-e</string>
   <string name="activate">Activa</string>
   <string name="apps_mode">Mode VPN</string>

--- a/app-mini/src/main/res/values-cs-rCZ/strings.xml
+++ b/app-mini/src/main/res/values-cs-rCZ/strings.xml
@@ -118,8 +118,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridge aktualizovány</string>
   <string name="restart_orbot_to_use_this_bridge_">Pro projevení změn restartujte Orbot</string>
-  <string name="menu_qr">QR kódy</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktivovat</string>
   <string name="send_email">Pošli email</string>
   <string name="save">Uložit</string>

--- a/app-mini/src/main/res/values-de/strings.xml
+++ b/app-mini/src/main/res/values-de/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Brücken Aktualisiert</string>
   <string name="restart_orbot_to_use_this_bridge_">Bitte Tor Erneut Starten um die Änderungen wirksam werden zu lassen</string>
-  <string name="menu_qr">QR Codes</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Wenn Ihr mobiles Netzwerk Tor blockiert, können Sie einen \"Brücken-Server\" als alternativen Weg verwenden. Wählen Sie eine der Optionen zum Konfigurieren und Testen ..,.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Wenn Ihr mobiles Netzwerk Tor blockiert, können Sie einen \"Brücken-Server\" als alternativen Weg verwenden. Wählen Sie eine der Optionen zum Konfigurieren und Testen ..,.</string>
   <string name="get_bridges_email">E-Mail</string>
   <string name="activate">Aktivieren</string>
   <string name="apps_mode">VPN Modus</string>

--- a/app-mini/src/main/res/values-el/strings.xml
+++ b/app-mini/src/main/res/values-el/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Οι γέφυρες ενημερώθηκαν</string>
   <string name="restart_orbot_to_use_this_bridge_">Παρακαλούμε επανεκκινήστε το Orbot για να ενεργοποιήσετε τις αλλαγές</string>
-  <string name="menu_qr">Κώδικες QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Αν το δίκτυο κινητής τηλεφωνίας σας μπλοκάρει ενεργά το Tor, μπορείτε να χρησιμοποιήσετε μια γέφυρα για να έχετε πρόσβαση στο δίκτυο. ΕΠΙΛΕΞΤΕ έναν από τους παραπάνω τύπους γέφυρας για να ενεργοποιήσετε τις γέφυρες.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Αν το δίκτυο κινητής τηλεφωνίας σας μπλοκάρει ενεργά το Tor, μπορείτε να χρησιμοποιήσετε μια γέφυρα για να έχετε πρόσβαση στο δίκτυο. ΕΠΙΛΕΞΤΕ έναν από τους παραπάνω τύπους γέφυρας για να ενεργοποιήσετε τις γέφυρες.</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Ενεργοποίηση</string>
   <string name="apps_mode">Λειτουργία VPN</string>

--- a/app-mini/src/main/res/values-es/strings.xml
+++ b/app-mini/src/main/res/values-es/strings.xml
@@ -125,8 +125,7 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridges actualizados</string>
   <string name="restart_orbot_to_use_this_bridge_">Por favor, reinicie Orbot para habilitar los cambios</string>
-  <string name="menu_qr">Códigos QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si su red móvil bloquea Tor activamente, puede usar un \'Servidor Puente\' como alternativa para acceder. SELECCIONE una de las opciones a configurar y probar...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si su red móvil bloquea Tor activamente, puede usar un \'Servidor Puente\' como alternativa para acceder. SELECCIONE una de las opciones a configurar y probar...</string>
   <string name="get_bridges_email">Correo electrónico</string>
   <string name="activate">Activar</string>
   <string name="apps_mode">Modo VPN</string>

--- a/app-mini/src/main/res/values-eu/strings.xml
+++ b/app-mini/src/main/res/values-eu/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Zubiak eguneratuta</string>
   <string name="restart_orbot_to_use_this_bridge_">Berrabiarazi Orbot aldaketak aplikatzeko</string>
-  <string name="menu_qr">QR Kodeak</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Zure sare mugikorrak Tor nahita blokeatzen badu, \'Zubi zerbitzaria\' erabili dezakezu ordezko sarbide gisa. HAUTATU konfiguratzeko aukera bat eta probatu...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Zure sare mugikorrak Tor nahita blokeatzen badu, \'Zubi zerbitzaria\' erabili dezakezu ordezko sarbide gisa. HAUTATU konfiguratzeko aukera bat eta probatu...</string>
   <string name="get_bridges_email">E-mail</string>
   <string name="activate">Aktibatu</string>
   <string name="apps_mode">VPN modua</string>

--- a/app-mini/src/main/res/values-fa/strings.xml
+++ b/app-mini/src/main/res/values-fa/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridges به روز شدند</string>
   <string name="restart_orbot_to_use_this_bridge_">برای فعال کردن تغییرات لطفا Orbot را راه اندازی مجدد کنید</string>
-  <string name="menu_qr">کدهای QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">اگر شبکه همراهتان به صورت مرتب تور را مسدود می‌کند، می‌توانید از یک «کارساز پل» به عنوان راهی جایگزین برای ورود استفاده کنید. برای پیکربندی و تست، یکی از گزینه‌ها را انتخاب کنید…</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">اگر شبکه همراهتان به صورت مرتب تور را مسدود می‌کند، می‌توانید از یک «کارساز پل» به عنوان راهی جایگزین برای ورود استفاده کنید. برای پیکربندی و تست، یکی از گزینه‌ها را انتخاب کنید…</string>
   <string name="get_bridges_email">ایمیل</string>
   <string name="activate">فعال</string>
   <string name="apps_mode">حالت VPN</string>

--- a/app-mini/src/main/res/values-fi/strings.xml
+++ b/app-mini/src/main/res/values-fi/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">Mt</string>
   <string name="bridges_updated">Sillat päivitetty</string>
   <string name="restart_orbot_to_use_this_bridge_">Käynnistä Orbot uudelleen ottaaksesi muutokset käyttöön</string>
-  <string name="menu_qr">QR-koodit</string>
-  <string name="get_bridges_email">Sähköposti</string>
+    <string name="get_bridges_email">Sähköposti</string>
     <string name="activate">Ota käyttöön</string>
   <string name="send_email">Lähetä sähköpostia</string>
   <string name="hidden_services">Piilopalvelut</string>

--- a/app-mini/src/main/res/values-fr-rFR/strings.xml
+++ b/app-mini/src/main/res/values-fr-rFR/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">Mo</string>
   <string name="bridges_updated">Ponts mis à jour</string>
   <string name="restart_orbot_to_use_this_bridge_">Veuillez redémarrer Orbot pour activer les changements</string>
-  <string name="menu_qr">Codes QR</string>
-  <string name="get_bridges_email">Courriel</string>
+    <string name="get_bridges_email">Courriel</string>
     <string name="activate">Activer</string>
   <string name="send_email">Envoyer un courriel</string>
   <string name="save">Enregistrer</string>

--- a/app-mini/src/main/res/values-fr/strings.xml
+++ b/app-mini/src/main/res/values-fr/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">Mo</string>
   <string name="bridges_updated">Ponts mis à jour</string>
   <string name="restart_orbot_to_use_this_bridge_">Veuillez redémarrer Orbot pour activer les changements</string>
-  <string name="menu_qr">Codes QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si votre réseau mobile bloque Tor activement, vous pouvez utiliser un serveur-pont comme moyen de remplacement. CHOISIR une des options pour configurer et tester…</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si votre réseau mobile bloque Tor activement, vous pouvez utiliser un serveur-pont comme moyen de remplacement. CHOISIR une des options pour configurer et tester…</string>
   <string name="get_bridges_email">Courriel</string>
   <string name="activate">Activer</string>
   <string name="apps_mode">Mode RPV</string>

--- a/app-mini/src/main/res/values-gl/strings.xml
+++ b/app-mini/src/main/res/values-gl/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Pontes actualizadas</string>
   <string name="restart_orbot_to_use_this_bridge_">Por favor, reinicie Orbot para activar os cambios</string>
-  <string name="menu_qr">Códigod QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si a súa rede móbil bloquea Tor de xeito activo, pode utilizar un \'Servidor Ponte\' como modo alternativo. ESCOLL unha das opcións para configurar e probar...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si a súa rede móbil bloquea Tor de xeito activo, pode utilizar un \'Servidor Ponte\' como modo alternativo. ESCOLL unha das opcións para configurar e probar...</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Activar</string>
   <string name="apps_mode">Modo VPN</string>

--- a/app-mini/src/main/res/values-he/strings.xml
+++ b/app-mini/src/main/res/values-he/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">מ\"ב</string>
   <string name="bridges_updated">גשרים עודכנו</string>
   <string name="restart_orbot_to_use_this_bridge_">אנא הפעל מחדש את Orbot כדי לאפשר את השינויים</string>
-  <string name="menu_qr">קודי QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">אם פעילות הרשת הניידת שלך חוסמת את Tor, אתה יכול להשתמש ב\'שרת גשר\' כדרך חלופית להיכנס. בחר אחת מאפשרויות כדי להגדיר ולבחון...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">אם פעילות הרשת הניידת שלך חוסמת את Tor, אתה יכול להשתמש ב\'שרת גשר\' כדרך חלופית להיכנס. בחר אחת מאפשרויות כדי להגדיר ולבחון...</string>
   <string name="get_bridges_email">דוא\"ל</string>
   <string name="activate">הפעל</string>
   <string name="apps_mode">מצב VPN</string>

--- a/app-mini/src/main/res/values-hi/strings.xml
+++ b/app-mini/src/main/res/values-hi/strings.xml
@@ -125,8 +125,7 @@
   <string name="mb">मब </string>
   <string name="bridges_updated">पुल अपडेटेड </string>
   <string name="restart_orbot_to_use_this_bridge_">परिवर्तन सक्षम करने के लिए Orbot पुनः प्रारंभ करें</string>
-  <string name="menu_qr">QR कोड</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">यदि आपका मोबाइल नेटवर्क सक्रिय रूप से टो को ब्लॉक करता है, तो आप \'पुल सर्वर\' को एक वैकल्पिक तरीके से उपयोग कर सकते हैं। कॉन्फ़िगर और परीक्षण करने के लिए विकल्पों में से एक का चयन करें ..,।</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">यदि आपका मोबाइल नेटवर्क सक्रिय रूप से टो को ब्लॉक करता है, तो आप \'पुल सर्वर\' को एक वैकल्पिक तरीके से उपयोग कर सकते हैं। कॉन्फ़िगर और परीक्षण करने के लिए विकल्पों में से एक का चयन करें ..,।</string>
   <string name="get_bridges_email">ईमेल</string>
   <string name="activate">सक्रिय</string>
   <string name="apps_mode">वीपीएन मोड</string>

--- a/app-mini/src/main/res/values-hr/strings.xml
+++ b/app-mini/src/main/res/values-hr/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Mostova ažurirano</string>
   <string name="restart_orbot_to_use_this_bridge_">Ponovno pokrenite Orbot da bi omogućili promjene</string>
-  <string name="menu_qr">QR kodovi</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktiviraj</string>
   <string name="send_email">Pošalji email</string>
   <string name="save">Spremi</string>

--- a/app-mini/src/main/res/values-hu/strings.xml
+++ b/app-mini/src/main/res/values-hu/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Hidak frissítve</string>
   <string name="restart_orbot_to_use_this_bridge_">Kérlek indítsd újra az Orbot-ot a változások engedélyezéséhez</string>
-  <string name="menu_qr">QR kódok</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ha a mobil hálózata aktívan blokkolja a Tor-t, akkor választhatja a \'Híd szerver\'-t, mint alternatív utat. VÁLASSZON egyet a lehetőségek közül és tesztelje....</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ha a mobil hálózata aktívan blokkolja a Tor-t, akkor választhatja a \'Híd szerver\'-t, mint alternatív utat. VÁLASSZON egyet a lehetőségek közül és tesztelje....</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Aktiválás</string>
   <string name="apps_mode">VPN Mód</string>

--- a/app-mini/src/main/res/values-id/strings.xml
+++ b/app-mini/src/main/res/values-id/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridge Telah Diperbarui</string>
   <string name="restart_orbot_to_use_this_bridge_">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>
-  <string name="menu_qr">Kode QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktivasi</string>
   <string name="send_email">Kirim Email</string>
   <string name="save">Simpan</string>

--- a/app-mini/src/main/res/values-in-rID/strings.xml
+++ b/app-mini/src/main/res/values-in-rID/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridge Telah Diperbarui</string>
   <string name="restart_orbot_to_use_this_bridge_">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>
-  <string name="menu_qr">Kode QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktivasi</string>
   <string name="send_email">Kirim Email</string>
   <string name="please_restart_Orbot_to_enable_the_changes">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>

--- a/app-mini/src/main/res/values-is/strings.xml
+++ b/app-mini/src/main/res/values-is/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Brýr uppfærðar</string>
   <string name="restart_orbot_to_use_this_bridge_">Endurræstu Orbot til að breytingarnar taki gildi</string>
-  <string name="menu_qr">QR-kóðar</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ef farsímanetið þitt er virkt í að loka á Tor, geturðu notað \'Brúarþjón\' sem varaleið inn. VELDU einn af valkostunum til að setja upp og prófa...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ef farsímanetið þitt er virkt í að loka á Tor, geturðu notað \'Brúarþjón\' sem varaleið inn. VELDU einn af valkostunum til að setja upp og prófa...</string>
   <string name="get_bridges_email">Tölvupóstur</string>
   <string name="activate">Virkja</string>
   <string name="apps_mode">VPN-hamur</string>

--- a/app-mini/src/main/res/values-it/strings.xml
+++ b/app-mini/src/main/res/values-it/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridge attivati</string>
   <string name="restart_orbot_to_use_this_bridge_">Per favore riavvia Orbot per rendere effettive le modifiche</string>
-  <string name="menu_qr">Codici QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se la tua rete mobile blocca attivamente Tor, puoi usare un \'Server Bridge\' come via alternativa. SELEZIONA una delle opzioni per configurare e testare...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se la tua rete mobile blocca attivamente Tor, puoi usare un \'Server Bridge\' come via alternativa. SELEZIONA una delle opzioni per configurare e testare...</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Attiva</string>
   <string name="apps_mode">Modalità VPN</string>

--- a/app-mini/src/main/res/values-iw/strings.xml
+++ b/app-mini/src/main/res/values-iw/strings.xml
@@ -96,8 +96,7 @@
   <string name="pref_dnsport_title">Tor DNS Port</string>
   <string name="kb">KB</string>
   <string name="mb">MB</string>
-  <string name="menu_qr">קוד QR</string>
-  <string name="get_bridges_email">דוא\"ל</string>
+    <string name="get_bridges_email">דוא\"ל</string>
     <string name="activate">הפעל</string>
   <string name="send_email">שלח דוא\"ל</string>
 </resources>

--- a/app-mini/src/main/res/values-ja/strings.xml
+++ b/app-mini/src/main/res/values-ja/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">ブリッジを更新しました</string>
   <string name="restart_orbot_to_use_this_bridge_">変更を有効にするにはOrbotを再起動してください</string>
-  <string name="menu_qr">QRコード</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">モバイルネットワークが頻繁にTorをブロックする場合、別の方法として \'ブリッジサーバー\'を使用することができます。オプションを１つ選択して、設定とテストを行ってください。</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">モバイルネットワークが頻繁にTorをブロックする場合、別の方法として \'ブリッジサーバー\'を使用することができます。オプションを１つ選択して、設定とテストを行ってください。</string>
   <string name="get_bridges_email">メール</string>
   <string name="activate">アクティブ化</string>
   <string name="apps_mode">VPN モード</string>

--- a/app-mini/src/main/res/values-ko/strings.xml
+++ b/app-mini/src/main/res/values-ko/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">브릿지가 업데이트되었습니다</string>
   <string name="restart_orbot_to_use_this_bridge_">변경을 완료하려면 Orbot을 재시작하세요</string>
-  <string name="menu_qr">QR 코드</string>
-  <string name="get_bridges_email">이메일</string>
+    <string name="get_bridges_email">이메일</string>
     <string name="activate">활성화</string>
   <string name="send_email">이메일 보내기</string>
   <string name="save">저장</string>

--- a/app-mini/src/main/res/values-lv/strings.xml
+++ b/app-mini/src/main/res/values-lv/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Tilti ir atjaunināti</string>
   <string name="restart_orbot_to_use_this_bridge_">Lūdzu pārstartējiet Orbot, lai iespējotu izmaiņas</string>
-  <string name="menu_qr">QR kodi</string>
-  <string name="get_bridges_email">E-pasts</string>
+    <string name="get_bridges_email">E-pasts</string>
     <string name="activate">Aktivizēt</string>
   <string name="send_email">Nosūtīt e-pastu</string>
   <string name="hidden_services">Slēptie pakalpojumi</string>

--- a/app-mini/src/main/res/values-mk/strings.xml
+++ b/app-mini/src/main/res/values-mk/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Ажурирани мостови</string>
   <string name="restart_orbot_to_use_this_bridge_">Ве молиме повторно стартувајте го Orbot за да се овозможат промените</string>
-  <string name="menu_qr">QR-кодови</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако вашата мобилна мрежа активно го блокира Tor, можете да користите „Мост сервер“ како алтернативен пристап. ОДБЕРЕТЕ една од опциите за поставување и тестирање...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако вашата мобилна мрежа активно го блокира Tor, можете да користите „Мост сервер“ како алтернативен пристап. ОДБЕРЕТЕ една од опциите за поставување и тестирање...</string>
   <string name="get_bridges_email">Е-пошта</string>
   <string name="activate">Активирај</string>
   <string name="apps_mode">VPN мод</string>

--- a/app-mini/src/main/res/values-nb/strings.xml
+++ b/app-mini/src/main/res/values-nb/strings.xml
@@ -121,8 +121,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Broer oppdatert</string>
   <string name="restart_orbot_to_use_this_bridge_">Gjør omstart av Orbot før endringer trer i kraft</string>
-  <string name="menu_qr">QR-koder</string>
-  <string name="get_bridges_email">E-post</string>
+    <string name="get_bridges_email">E-post</string>
     <string name="activate">Aktiver</string>
   <string name="apps_mode">VPN-modus</string>
   <string name="send_email">Send e-post</string>

--- a/app-mini/src/main/res/values-nl/strings.xml
+++ b/app-mini/src/main/res/values-nl/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridges bijgewerkt</string>
   <string name="restart_orbot_to_use_this_bridge_">Herstart Orbot om de wijzigingen in te schakelen</string>
-  <string name="menu_qr">QR-codes</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Als je mobiele netwerk Tor actief blokkeert, kan je een \'bridge-server\' gebruiken als alternatieve toegang. SELECTEER een van de opties om te configureren en te testen..,.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Als je mobiele netwerk Tor actief blokkeert, kan je een \'bridge-server\' gebruiken als alternatieve toegang. SELECTEER een van de opties om te configureren en te testen..,.</string>
   <string name="get_bridges_email">E-mail</string>
   <string name="activate">Activeren</string>
   <string name="apps_mode">VPN-modus</string>

--- a/app-mini/src/main/res/values-pl/strings.xml
+++ b/app-mini/src/main/res/values-pl/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Zaktualizowane Bridges</string>
   <string name="restart_orbot_to_use_this_bridge_">Proszę zrestartować Orbot, aby zmiany mogły wejść w życie</string>
-  <string name="menu_qr">Kody QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktywuj</string>
   <string name="apps_mode">Tryb VPN</string>
   <string name="send_email">Wyślij Email</string>

--- a/app-mini/src/main/res/values-pt-rBR/strings.xml
+++ b/app-mini/src/main/res/values-pt-rBR/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Pontes Atualizadas</string>
   <string name="restart_orbot_to_use_this_bridge_">Por favor reinicie Orbot para habilitar as mundanças</string>
-  <string name="menu_qr">QR Codes</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. SELECIONE umas das opções para configurar e testar..,.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. SELECIONE umas das opções para configurar e testar..,.</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Atvar</string>
   <string name="apps_mode">Modo VPN</string>

--- a/app-mini/src/main/res/values-pt-rPT/strings.xml
+++ b/app-mini/src/main/res/values-pt-rPT/strings.xml
@@ -49,8 +49,7 @@
   <string name="pref_dnsport_title">Porta DNS do Tor</string>
   <string name="kb">KB</string>
   <string name="mb">MB</string>
-  <string name="menu_qr">Códigos QR</string>
-  <string name="get_bridges_email">E-mail</string>
+    <string name="get_bridges_email">E-mail</string>
     <string name="activate">Ativar</string>
   <string name="send_email">Enviar Mensagem</string>
     <string name="save">Guardar</string>

--- a/app-mini/src/main/res/values-pt/strings.xml
+++ b/app-mini/src/main/res/values-pt/strings.xml
@@ -73,8 +73,7 @@
   <string name="kb">KB</string>
   <string name="mb">MB</string>
   <string name="bridges_updated">Pontes Atualizadas</string>
-  <string name="menu_qr">Códigos QR</string>
-  <string name="get_bridges_email">Correio Eletrônico</string>
+    <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="activate">Ativar</string>
   <string name="send_email">Enviar Mensagem</string>
     <string name="hidden_services">Serviços ocultos</string>

--- a/app-mini/src/main/res/values-ro/strings.xml
+++ b/app-mini/src/main/res/values-ro/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Punţi activate</string>
   <string name="restart_orbot_to_use_this_bridge_">Vă rugăm reporniţi Orbot pentru a aplica modificările</string>
-  <string name="menu_qr">Coduri QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Activează</string>
   <string name="send_email">Trimite email</string>
   <string name="hidden_services">Servicii ascunse</string>

--- a/app-mini/src/main/res/values-ru/strings.xml
+++ b/app-mini/src/main/res/values-ru/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">МБ</string>
   <string name="bridges_updated">Мосты обновлены</string>
   <string name="restart_orbot_to_use_this_bridge_">Пожалуйста, перезапустите Orbot для вступления изменения в силу</string>
-  <string name="menu_qr">QR-коды</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Если ваша мобильная сеть активно блокирует Tor, вы можете использовать мосты Tor для доступа к сети. Выберите один из вариантов для настройки и тестирования:</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Если ваша мобильная сеть активно блокирует Tor, вы можете использовать мосты Tor для доступа к сети. Выберите один из вариантов для настройки и тестирования:</string>
   <string name="get_bridges_email">Эл. почта</string>
   <string name="activate">Активация</string>
   <string name="apps_mode">VPN-режим</string>

--- a/app-mini/src/main/res/values-sk/strings.xml
+++ b/app-mini/src/main/res/values-sk/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Premostenia aktualizované</string>
   <string name="restart_orbot_to_use_this_bridge_">Prosím reštartujte Orbot, aby sa aktivovali zmeny</string>
-  <string name="menu_qr">QR kódy</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Aktivovať</string>
   <string name="send_email">Poslať email</string>
   <string name="save">Uložiť</string>

--- a/app-mini/src/main/res/values-sr/strings.xml
+++ b/app-mini/src/main/res/values-sr/strings.xml
@@ -122,8 +122,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridges Ажурирање</string>
   <string name="restart_orbot_to_use_this_bridge_">Молимо покрените поново Орбот ради примењивања промена</string>
-  <string name="menu_qr">QR Кодови</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако ваша мобилна мрежа активно блокира Тор, можете премошћивати сервером као алтернативни начин уласка.ОДАБЕРИ једну од опција за конфигурацију и тестирање....</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако ваша мобилна мрежа активно блокира Тор, можете премошћивати сервером као алтернативни начин уласка.ОДАБЕРИ једну од опција за конфигурацију и тестирање....</string>
   <string name="get_bridges_email">Е-пошта</string>
     <string name="activate">Активирати</string>
   <string name="apps_mode">VPN Мод</string>

--- a/app-mini/src/main/res/values-sv/strings.xml
+++ b/app-mini/src/main/res/values-sv/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bryggor uppdaterade</string>
   <string name="restart_orbot_to_use_this_bridge_">Vänligen starta om Orbot för att aktivera ändringarna</string>
-  <string name="menu_qr">QR-koder</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Om ditt mobilnät aktivt blockerar Tor kan du använda en \"Bridge Server\" som ett alternativt sätt. VÄLJ ett av alternativen att konfigurera och testa.,.</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Om ditt mobilnät aktivt blockerar Tor kan du använda en \"Bridge Server\" som ett alternativt sätt. VÄLJ ett av alternativen att konfigurera och testa.,.</string>
   <string name="get_bridges_email">E-post</string>
   <string name="activate">Aktivera</string>
   <string name="apps_mode">VPN-läge</string>

--- a/app-mini/src/main/res/values-th/strings.xml
+++ b/app-mini/src/main/res/values-th/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">เมกะไบต์</string>
   <string name="bridges_updated">ปรับปรุง Bridges แล้ว</string>
   <string name="restart_orbot_to_use_this_bridge_">กรุณาเริ่ม Orbot ใหม่เพื่อให้การเปลี่ยนแปลงใช้งานได้</string>
-  <string name="menu_qr">รหัสคิวอาร์</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">หากเครือข่ายโทรศัพท์ของคุณปิดกั้น Tor คุณสามารถใช้ \'เซิร์ฟเวอร์ Bridge\' เป็นตัวเลือกในการเข้าถึงได้ เลือกตัวเลือกหนึ่งเพื่อกำหนดค่าและทดสอบ...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">หากเครือข่ายโทรศัพท์ของคุณปิดกั้น Tor คุณสามารถใช้ \'เซิร์ฟเวอร์ Bridge\' เป็นตัวเลือกในการเข้าถึงได้ เลือกตัวเลือกหนึ่งเพื่อกำหนดค่าและทดสอบ...</string>
   <string name="get_bridges_email">อีเมล</string>
   <string name="activate">เปิดใช้งาน</string>
   <string name="apps_mode">โหมด VPN</string>

--- a/app-mini/src/main/res/values-tr/strings.xml
+++ b/app-mini/src/main/res/values-tr/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Köprüler Güncellendi</string>
   <string name="restart_orbot_to_use_this_bridge_">Değişiklikleri etkinleştirmek için Orbot uygulamasını yeniden başlatın</string>
-  <string name="menu_qr">QR Kodları</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Tor kullanımı mobil ağınızda etkin olarak engelleniyorsa, Tor ağına erişmek için bir \'Köprü Sunucusu\' kullanabilirsiniz. Yapılandırmak ve denemek için aşağıdaki seçeneklerden birini seçin...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Tor kullanımı mobil ağınızda etkin olarak engelleniyorsa, Tor ağına erişmek için bir \'Köprü Sunucusu\' kullanabilirsiniz. Yapılandırmak ve denemek için aşağıdaki seçeneklerden birini seçin...</string>
   <string name="get_bridges_email">E-posta</string>
   <string name="activate">Etkinleştir</string>
   <string name="apps_mode">VPN Kipi</string>

--- a/app-mini/src/main/res/values-uk/strings.xml
+++ b/app-mini/src/main/res/values-uk/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Мости оновлено</string>
   <string name="restart_orbot_to_use_this_bridge_">Будь ласка, перезапустіть Orbot, щоб зміни ввійшли в силу</string>
-  <string name="menu_qr">QR-коди</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Якщо ваша мобільна мережа активно блокує Tor, ви можете використовувати \'Bridge Server\' як альтернативний спосіб входу. ВИБЕРИ один із параметрів для налаштування та тестування...</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Якщо ваша мобільна мережа активно блокує Tor, ви можете використовувати \'Bridge Server\' як альтернативний спосіб входу. ВИБЕРИ один із параметрів для налаштування та тестування...</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">Активувати</string>
   <string name="apps_mode">VPN Спосіб</string>

--- a/app-mini/src/main/res/values-vi/strings.xml
+++ b/app-mini/src/main/res/values-vi/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">Bridge được cập nhật</string>
   <string name="restart_orbot_to_use_this_bridge_">Vui lòng khởi động lại Orbot để áp dụng thay đổi</string>
-  <string name="menu_qr">Mã QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
     <string name="activate">Kích hoạt</string>
   <string name="send_email">Gửi email</string>
   <string name="save">Lưu</string>

--- a/app-mini/src/main/res/values-zh-rCN/strings.xml
+++ b/app-mini/src/main/res/values-zh-rCN/strings.xml
@@ -119,8 +119,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">网桥已更新</string>
   <string name="restart_orbot_to_use_this_bridge_">请重启 Orbot 以使变更生效</string>
-  <string name="menu_qr">QR码</string>
-  <string name="get_bridges_email">电子邮件</string>
+    <string name="get_bridges_email">电子邮件</string>
     <string name="activate">激活</string>
   <string name="apps_mode">VPN 模式</string>
   <string name="send_email">发送电子邮件</string>

--- a/app-mini/src/main/res/values-zh-rTW/strings.xml
+++ b/app-mini/src/main/res/values-zh-rTW/strings.xml
@@ -124,8 +124,7 @@
   <string name="mb">MB</string>
   <string name="bridges_updated">網橋已更新</string>
   <string name="restart_orbot_to_use_this_bridge_">請重新啟動 Orbot 來讓設定生效。</string>
-  <string name="menu_qr">QR 碼</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">如果行動網路主動地封鎖 Tor 可以使用\"橋接伺服器\"作為替代方式.選擇一個選項作設定和測試</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">如果行動網路主動地封鎖 Tor 可以使用\"橋接伺服器\"作為替代方式.選擇一個選項作設定和測試</string>
   <string name="get_bridges_email">Email</string>
   <string name="activate">啟用</string>
   <string name="apps_mode">VPN 模式</string>

--- a/app-mini/src/main/res/values/strings.xml
+++ b/app-mini/src/main/res/values/strings.xml
@@ -155,8 +155,6 @@
 
     <string name="restart_orbot_to_use_this_bridge_">Please restart Orbot to enable the changes</string>
 
-    <string name="menu_qr">QR Codes</string>
-
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">If your mobile network actively blocks Tor, you can use a \'Bridge Server\' as an alternate way in. SELECT one of the options to configure and test...</string>
 
     <string name="get_bridges_email">Email</string>

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -51,10 +51,6 @@ import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-import com.google.zxing.integration.android.IntentIntegrator;
-import com.google.zxing.integration.android.IntentResult;
-
-import org.json.JSONArray;
 import org.torproject.android.core.Languages;
 import org.torproject.android.core.LocaleHelper;
 import org.torproject.android.core.ui.Rotate3dAnimation;
@@ -79,7 +75,6 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -421,10 +416,6 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 
-    /*
-     * Create the UI Options Menu (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -444,25 +435,6 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
             doExit(); // exit app
         } else if (item.getItemId() == R.id.menu_about) {
             new AboutDialogFragment().show(getSupportFragmentManager(), AboutDialogFragment.TAG);
-        } else if (item.getItemId() == R.id.menu_scan) {
-            IntentIntegrator integrator = new IntentIntegrator(OrbotMainActivity.this);
-            integrator.initiateScan();
-        } else if (item.getItemId() == R.id.menu_share_bridge) {
-
-            String bridges = Prefs.getBridgesList();
-
-            if (bridges != null && bridges.length() > 0) {
-                try {
-                    bridges = "bridge://" + URLEncoder.encode(bridges, "UTF-8");
-
-                    IntentIntegrator integrator = new IntentIntegrator(OrbotMainActivity.this);
-                    integrator.shareText(bridges);
-
-                } catch (UnsupportedEncodingException e) {
-                    e.printStackTrace();
-                }
-            }
-
         } else if (item.getItemId() == R.id.menu_hidden_services) {
             startActivity(new Intent(this, HiddenServicesActivity.class));
         } else if (item.getItemId() == R.id.menu_client_cookies) {
@@ -807,45 +779,6 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         } else if (request == REQUEST_VPN && response == RESULT_CANCELED) {
             mBtnVPN.setChecked(false);
         }
-
-        IntentResult scanResult = IntentIntegrator.parseActivityResult(request, response, data);
-        if (scanResult != null) {
-            // handle scan result
-
-            String results = scanResult.getContents();
-
-            if (results != null && results.length() > 0) {
-                try {
-
-                    int urlIdx = results.indexOf("://");
-
-                    if (urlIdx != -1) {
-                        results = URLDecoder.decode(results, "UTF-8");
-                        results = results.substring(urlIdx + 3);
-
-                        showAlert(getString(R.string.bridges_updated), getString(R.string.restart_orbot_to_use_this_bridge_) + results, false);
-
-                        setNewBridges(results);
-                    } else {
-                        JSONArray bridgeJson = new JSONArray(results);
-                        StringBuilder bridgeLines = new StringBuilder();
-
-                        for (int i = 0; i < bridgeJson.length(); i++) {
-                            String bridgeLine = bridgeJson.getString(i);
-                            bridgeLines.append(bridgeLine).append("\n");
-                        }
-
-                        setNewBridges(bridgeLines.toString());
-                    }
-
-
-                } catch (Exception e) {
-                    Log.e(TAG, "unsupported", e);
-                }
-            }
-
-        }
-
     }
 
     public void promptSetupBridges() {

--- a/app/src/main/res/layout/layout_apps_item.xml
+++ b/app/src/main/res/layout/layout_apps_item.xml
@@ -20,7 +20,6 @@
         android:maxLines="2"
         android:minLines="2"
         android:scrollHorizontally="false"
-        android:text="uid:packages"
         android:textAlignment="center"
         android:textSize="12sp" />
 

--- a/app/src/main/res/menu/orbot_main.xml
+++ b/app/src/main/res/menu/orbot_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 /*
  * Copyright (C) 2008 Esmertec AG.
  * Copyright (C) 2008 The Android Open Source Project
@@ -18,77 +17,47 @@
  */
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:yourapp="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:yourapp="http://schemas.android.com/apk/res-auto">
 
-
-    <item android:id="@+id/menu_newnym"
-        android:title="@string/menu_new_identity"
+    <item
+        android:id="@+id/menu_newnym"
         android:icon="@drawable/ic_refresh_white_24dp"
-        yourapp:showAsAction="always"
-        />
+        android:title="@string/menu_new_identity"
+        yourapp:showAsAction="always" />
 
 
-    <item android:id="@+id/menu_settings"
+    <item
+        android:id="@+id/menu_settings"
+        android:icon="@drawable/ic_action_settings"
         android:title="@string/menu_settings"
-         android:icon="@drawable/ic_action_settings"
-         yourapp:showAsAction="never"
-         />
-
- <item
-        android:title="@string/menu_qr"
-     yourapp:showAsAction="never"
-         >
-  <menu>
-  <item android:id="@+id/menu_scan"
-        android:title="@string/menu_scan"
-      yourapp:showAsAction="never"
-         />
-  
-  <item android:id="@+id/menu_share_bridge"
-        android:title="@string/menu_share_bridge"
-      yourapp:showAsAction="never"
-         />
-  </menu>
- </item>
+        yourapp:showAsAction="never" />
 
     <item
         android:title="@string/menu_hidden_services"
         yourapp:showAsAction="never">
-      <menu>
-        <item android:id="@+id/menu_hidden_services"
-              android:title="@string/hosted_services"
-            yourapp:showAsAction="never"
-               />
+        <menu>
+            <item
+                android:id="@+id/menu_hidden_services"
+                android:title="@string/hosted_services"
+                yourapp:showAsAction="never" />
 
-        <item android:id="@+id/menu_client_cookies"
-              android:title="@string/client_cookies"
-            yourapp:showAsAction="never"
-               />
-      </menu>
+            <item
+                android:id="@+id/menu_client_cookies"
+                android:title="@string/client_cookies"
+                yourapp:showAsAction="never" />
+        </menu>
     </item>
-        
- <!--
-  <item android:id="@+id/menu_promo_apps"
-        android:title="@string/menu_promo_apps"
-         android:icon="@drawable/ic_menu_goto"
-      yourapp:showAsAction="never"
-         
-         />
-         -->
- 
-  <item android:id="@+id/menu_about"
+
+    <item
+        android:id="@+id/menu_about"
+        android:icon="@drawable/ic_menu_about"
         android:title="@string/menu_about"
-         android:icon="@drawable/ic_menu_about"
-      yourapp:showAsAction="never"
-         
-         />
- 
-  <item android:id="@+id/menu_exit"
+        yourapp:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_exit"
+        android:icon="@drawable/ic_menu_exit"
         android:title="@string/menu_exit"
-         android:icon="@drawable/ic_menu_exit"
-      yourapp:showAsAction="never"
-         
-         />
- 
+        yourapp:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -115,7 +115,6 @@
     <string name="pref_torrc_dialog">torrc خاص</string>
     <string name="bridges_updated">تم تحديث الجسور</string>
     <string name="restart_orbot_to_use_this_bridge_">الرجاء إعادة تشغيل أوربوت لتفعيل التعديلات</string>
-    <string name="menu_qr">رمز كيو آر</string>
     <string name="get_bridges_email">البريد الإلكتروني</string>
     <string name="apps_mode">وضع الـ VPN</string>
     <string name="send_email">أرسل بريد الكتروني</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">استخدم فقط تلك النقاط المحددة</string>
     <string name="bridges">الجسور</string>
     <string name="use_bridges">استخدم الجسور</string>
-    <string name="ip_address_and_port_of_bridges">عنوان الانترنت و المنفذ للجسور</string>
-    <string name="enter_bridge_addresses">أدخل عناوين الجسور</string>
     <string name="relays">المرحلات</string>
     <string name="relaying">يرحل</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">اسمح لجهازك ليكون مرحل غير نهائي</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -117,8 +117,7 @@
   <string name="pref_torrc_dialog">Maynipachpatak Torrc kuttayaña</string>
   <string name="bridges_updated">Jichhaptayat jalakipañanaka</string>
   <string name="restart_orbot_to_use_this_bridge_">Mayjt\'ayatanak aqtayañatak Orbot mayamp qhant\'ayam, amp suma</string>
-  <string name="menu_qr">QR chimpunaka</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Jawsañ apnaqirinakax Tor jark\'antañ yatipk ukjax \'Jalakipañ yanapiri\' mantañatak apnaqarakismawa. Yant\'añataki, mayjt\'ayañatakix AJLLT\'AM…</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Jawsañ apnaqirinakax Tor jark\'antañ yatipk ukjax \'Jalakipañ yanapiri\' mantañatak apnaqarakismawa. Yant\'añataki, mayjt\'ayañatakix AJLLT\'AM…</string>
   <string name="get_bridges_email">Imaylu (Email)</string>
   <string name="apps_mode">VPN</string>
   <string name="send_email">Qillqat apayaña</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">Aka sutiñchat puriñawjanakak apnaqam</string>
   <string name="bridges">Jalakipañanaka</string>
   <string name="use_bridges">Jalakipañanak apnaqaña</string>
-  <string name="enable_alternate_entrance_nodes_into_the_tor_network">Tor llika manqhan yaqha mantañanak qhantayaña</string>
-  <string name="ip_address_and_port_of_bridges">IP ukanakamp jalakipañ apayañ thakhinakampi</string>
-  <string name="enter_bridge_addresses">Jalakipañanakan chiqawjanakap qillqantam</string>
   <string name="relays">Ch\'iqiyirinaka</string>
   <string name="relaying">Apayat ch\'iqiyaña</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Jan uñstir ch\'iqiyirïñapatak dispositivo aqtayam</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">*Yalnız* bu xüsusi kəsişmələri istifadə et</string>
   <string name="bridges">Körpülər</string>
   <string name="use_bridges">Körpü İstifadə Et</string>
-    <string name="ip_address_and_port_of_bridges">Körpülərin IP ünvanı və portu</string>
-  <string name="enter_bridge_addresses">Körpü Ünvanlarını Daxil et</string>
   <string name="relays">Keçidlər</string>
   <string name="relaying">Keçidləmə</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Cihazının son-keçid funksiyasını aktivləşdir</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -115,8 +115,7 @@ LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="pref_torrc_dialog">Custom Torrc</string>
   <string name="bridges_updated">Körpülər yeniləndi</string>
   <string name="restart_orbot_to_use_this_bridge_">Lütfən, Orbotu söndürün və yenidən yandırın ki, dəyişikliklər tətbiq edilsin.</string>
-  <string name="menu_qr">QR kodlar</string>
-  <string name="get_bridges_email">Emeyl</string>
+    <string name="get_bridges_email">Emeyl</string>
   <string name="send_email">Emeyl göndərin</string>
   <string name="save">Saxla</string>
   <string name="name">Ad</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">Выкарыстоўваць *толькі* гэтыя зададзеныя вузлы</string>
   <string name="bridges">Масты</string>
   <string name="use_bridges">Выкарыстоўваць масты</string>
-  <string name="enable_alternate_entrance_nodes_into_the_tor_network">Уключыць альтэрнатыўныя ўваходныя вузлы ў сетку Tor</string>
-  <string name="ip_address_and_port_of_bridges">IP-адрасы і парты мастоў</string>
-  <string name="enter_bridge_addresses">Увядзіце адрасы мастоў</string>
   <string name="relays">Рэтранслятары</string>
   <string name="relaying">Рэтрансляцыя</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Дазволіць вашай прыладзе быць невыходным рэтранслятарам</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -117,8 +117,7 @@
   <string name="pref_torrc_dialog">Карыстальніцкі Torrc</string>
   <string name="bridges_updated">Масты абноўлены</string>
   <string name="restart_orbot_to_use_this_bridge_">Калі ласка, перазапусціце Orbot для ўступу змены ў сілу</string>
-  <string name="menu_qr">QR-коды</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Калі ваша мабільная сетка актыўна блакуе Tor, вы можаце выкарыстоўваць масты Tor для доступу да сеткі. Абярыце адзін з варыянтаў для налады і тэставання:</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Калі ваша мабільная сетка актыўна блакуе Tor, вы можаце выкарыстоўваць масты Tor для доступу да сеткі. Абярыце адзін з варыянтаў для налады і тэставання:</string>
   <string name="get_bridges_email">Эл. пошта</string>
   <string name="apps_mode">VPN-рэжым</string>
   <string name="send_email">Адправіць ліст</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Използвай *само* изброените node-ве</string>
   <string name="bridges">Бриджове</string>
   <string name="use_bridges">Използвай Бриджове</string>
-    <string name="ip_address_and_port_of_bridges">IP адрес и порт на бриджове</string>
-  <string name="enter_bridge_addresses">Въведи адреси на бриджове</string>
   <string name="relays">Препращачи(Relays)</string>
   <string name="relaying">Препращане</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Разреши устройството ти да бъде не изходен препращач</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Ръчно настроен Torrc</string>
   <string name="bridges_updated">Мостове включени!</string>
   <string name="restart_orbot_to_use_this_bridge_">Моля, рестартирай Orbot, за да влязат в действие промените</string>
-  <string name="menu_qr">QR Кодове</string>
-  <string name="get_bridges_email">Имейл</string>
+    <string name="get_bridges_email">Имейл</string>
   <string name="send_email">Изпрати имейл</string>
   <string name="hidden_services">Скрити услуги</string>
   <string name="title_activity_hidden_services">Скрити услуги</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc personalitzat</string>
     <string name="bridges_updated">S\'han actualitzat els ponts</string>
     <string name="restart_orbot_to_use_this_bridge_">Reinicieu l\'Orbot per aplicar els canvis</string>
-    <string name="menu_qr">Codis QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si la teva xarxa mòbil boqueja activament Tor, pots utilitzar un \'Servidor pont\' com a via alternativa. SELECCIONA una de les opcions per configurar i provar.</string>
     <string name="get_bridges_email">Correu-e</string>
     <string name="apps_mode">Mode VPN</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Utilitza *només* aquests nodes especificats</string>
     <string name="bridges">Ponts</string>
     <string name="use_bridges">Utilitza ponts</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Activar entrades alternes a la xarxa Tor</string>
-    <string name="ip_address_and_port_of_bridges">Adreça IP i port dels ponts</string>
-    <string name="enter_bridge_addresses">Introduïu les adreces del pont</string>
     <string name="relays">Reemissors</string>
     <string name="relaying">Reemissió</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Activa el vostre dispositiu per ser un reemissor sense sortida</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -112,8 +112,7 @@
   <string name="pref_torrc_dialog">Vlastní Torrs</string>
   <string name="bridges_updated">Bridge aktualizovány</string>
   <string name="restart_orbot_to_use_this_bridge_">Pro projevení změn restartujte Orbot</string>
-  <string name="menu_qr">QR kódy</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Pošli email</string>
   <string name="save">Uložit</string>
   <string name="name">Jméno</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Použít *pouze* tyto specifické nody</string>
   <string name="bridges">Bridge</string>
   <string name="use_bridges">Použít bridge</string>
-    <string name="ip_address_and_port_of_bridges">IP adresy a porty bridgů</string>
-  <string name="enter_bridge_addresses">Zadejte adresy bridgů</string>
   <string name="relays">Relé</string>
   <string name="relaying">Používání relé</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Spuštění zařízení jako neodchozího relé</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -65,8 +65,6 @@
   <string name="use_only_these_specified_nodes">Brug *kun* disse specificerede punkter</string>
   <string name="bridges">Broer</string>
   <string name="use_bridges">Brug broer</string>
-    <string name="ip_address_and_port_of_bridges">IP adresser og porte på broer</string>
-  <string name="enter_bridge_addresses">Indtast bro-adresser</string>
   <string name="relays">Relæer</string>
   <string name="relaying">Relæfunktion</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Lad denne enhed være et ikke-udgangs relæ</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">*Nur* diese angegebenen Netzknoten nutzen</string>
     <string name="bridges">Brücken</string>
     <string name="use_bridges">Brücken benutzen</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Alternative Zugangswege ins Tor-Netzwerk aktivieren</string>
-    <string name="ip_address_and_port_of_bridges">IP-Adresse und Port der Brücken</string>
-    <string name="enter_bridge_addresses">Brückenadressen eingeben</string>
     <string name="relays">Relais</string>
     <string name="relaying">Weiterleitung</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Ihr Gerät als Nichtausgangsrelais aktivieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Benutzerdefinierter Torrc</string>
     <string name="bridges_updated">Brücken Aktualisiert</string>
     <string name="restart_orbot_to_use_this_bridge_">Bitte Orbot neu starten, damit die Änderungen wirksam werden</string>
-    <string name="menu_qr">QR-Codes</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Wenn Ihr mobiles Netzwerk Tor blockiert, können Sie einen \"Brücken-Server\" als alternativen Weg verwenden. Wählen Sie eine der Optionen zum Konfigurieren und Testen…</string>
     <string name="get_bridges_email">E-Mail</string>
     <string name="apps_mode">VPN-Modus</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Χρήση *μόνον* αυτών των συγκεκριμένων κόμβων</string>
     <string name="bridges">Γέφυρες</string>
     <string name="use_bridges">Χρήση γεφυρών</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Ενεργοποίηση εναλλακτικών κόμβων εισόδου στο δίκτυο Tor</string>
-    <string name="ip_address_and_port_of_bridges">Διεύθυνση ΙΡ και θύρα των γεφυρών</string>
-    <string name="enter_bridge_addresses">Εισάγετε την διεύθυνση της γέφυρας</string>
     <string name="relays">Αναμεταδότες</string>
     <string name="relaying">Γίνεται αναμετάδοση</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Μετατρέψτε την συσκευή σας σε ένα αναμεταδότη μη-εξόδου</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Προσαρμογή Torrc</string>
     <string name="bridges_updated">Οι γέφυρες ενημερώθηκαν</string>
     <string name="restart_orbot_to_use_this_bridge_">Παρακαλούμε επανεκκινήστε το Orbot για να ενεργοποιήσετε τις αλλαγές</string>
-    <string name="menu_qr">Κώδικες QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Αν το δίκτυο κινητής τηλεφωνίας σας μπλοκάρει ενεργά το Tor, μπορείτε να χρησιμοποιήσετε μια γέφυρα για να έχετε πρόσβαση στο δίκτυο. ΕΠΙΛΕΞΤΕ έναν από τους παραπάνω τύπους γέφυρας για να ενεργοποιήσετε τις γέφυρες.</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">Λειτουργία VPN</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -55,8 +55,7 @@
   <string name="use_only_these_specified_nodes">Uzi *nur* tiujn ĉi nodojn</string>
   <string name="bridges">Pontoj</string>
   <string name="use_bridges">Uzi Pontojn</string>
-  <string name="ip_address_and_port_of_bridges">IP-adresoj kaj pordoj de pontoj</string>
-  <string name="enter_or_port">Entajpu OR-pordon</string>
+    <string name="enter_or_port">Entajpu OR-pordon</string>
   <string name="relay_nickname">Kaŝnomo de la relajso</string>
   <string name="the_nickname_for_your_tor_relay">Kaŝnomo por via Tor-relajso</string>
   <string name="enter_a_custom_relay_nickname">Entajpu propran kaŝnomon de la relajso</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">utilice *solo* estos nodos especificos </string>
   <string name="bridges">puentes</string>
   <string name="use_bridges">usar puentes</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Habilitar entradas alternativas en la red de Tor</string>
-    <string name="ip_address_and_port_of_bridges">direccion IP y puerto de puentes</string>
-  <string name="enter_bridge_addresses">introduzca las direcciones de puente</string>
   <string name="relays">retransmitir</string>
   <string name="relaying">retransmision </string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Habilite su dispositivo para que sea retransmision sin salida</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">torrc personalizado</string>
     <string name="bridges_updated">Bridges actualizados</string>
     <string name="restart_orbot_to_use_this_bridge_">Por favor, reinicie Orbot para habilitar los cambios</string>
-    <string name="menu_qr">Códigos QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si su red móvil bloquea Tor activamente, puede usar un \'Servidor Puente\' como alternativa para acceder. SELECCIONE una de las opciones a configurar y probar…</string>
     <string name="get_bridges_email">Correo electrónico</string>
     <string name="apps_mode">Modo VPN</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Usar *sólo* estos nodos especificados</string>
     <string name="bridges">Bridges (repetidores puente) </string>
     <string name="use_bridges">Usar bridges</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Habilitar entradas alternativas hacia el interior de la red Tor</string>
-    <string name="ip_address_and_port_of_bridges">Direcciones IP y puertos de los bridges</string>
-    <string name="enter_bridge_addresses">Introduzca direcciones de bridge</string>
     <string name="relays">Repetidores</string>
     <string name="relaying">Repetición de tráfico</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Habilitar que su dispositivo no sea repetidor de salida (de la red Tor) </string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -62,8 +62,6 @@
   <string name="use_only_these_specified_nodes">Kasuta *ainult* neid märgitud sõlmi</string>
   <string name="bridges">Sillad</string>
   <string name="use_bridges">Kasuta sildu</string>
-    <string name="ip_address_and_port_of_bridges">Sildade IP aadressid ja pordinumbrid</string>
-  <string name="enter_bridge_addresses">Sisestage silla aadressid</string>
   <string name="relays">Edastajad</string>
   <string name="relaying">Edastamine</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Luba oma seadmel hakata mitte-väljund edastajaks</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc pertsonalizatua</string>
     <string name="bridges_updated">Zubiak eguneratuta</string>
     <string name="restart_orbot_to_use_this_bridge_">Berrabiarazi Orbot aldaketak aplikatzeko</string>
-    <string name="menu_qr">QR Kodeak</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Zure sare mugikorrak Tor nahita blokeatzen badu, \'Zubi zerbitzaria\' erabili dezakezu ordezko sarbide gisa. HAUTATU konfiguratzeko aukera bat eta probatu…</string>
     <string name="get_bridges_email">E-mail</string>
     <string name="apps_mode">VPN modua</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Erabili *bakarrik* zehaztutako nodo hauek</string>
     <string name="bridges">Zubiak</string>
     <string name="use_bridges">Erabili zubiak</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Gaitu ordezko sarrerak Tor sarera</string>
-    <string name="ip_address_and_port_of_bridges">Zubien IP helbidea eta ataka</string>
-    <string name="enter_bridge_addresses">Sartu zubien helbideak</string>
     <string name="relays">Erreleak</string>
     <string name="relaying">Erreleatzea</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Gaitu zure gailua ez-irteerako errelea izatea</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">فقط * از این گره های مشخص شده استفاده کنید* </string>
     <string name="bridges">Bridges</string>
     <string name="use_bridges">از پل Bridges کن</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">ورودی‌های جایگزین به شبکه تور را فعال کن</string>
-    <string name="ip_address_and_port_of_bridges">آدرس آی پی و پورتِ پل ها</string>
-    <string name="enter_bridge_addresses">آدرس Bridges را وارد کنید</string>
     <string name="relays">بازپخش کننده ها</string>
     <string name="relaying">درحال بازپخش</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">دستگاه خود را برای یک بازپخش کننده غیر-خروجی فعال کنید</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">سفارشی Torrc</string>
     <string name="bridges_updated">Bridges به روز شدند</string>
     <string name="restart_orbot_to_use_this_bridge_">برای فعال کردن تغییرات لطفا Orbot را راه اندازی مجدد کنید</string>
-    <string name="menu_qr">کدهای QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">اگر شبکه همراهتان به صورت مرتب تور را مسدود می‌کند، می‌توانید از یک «کارساز پل» به عنوان راهی جایگزین برای ورود استفاده کنید. برای پیکربندی و تست، یکی از گزینه‌ها را انتخاب کنید…</string>
     <string name="get_bridges_email">ایمیل</string>
     <string name="apps_mode">حالت VPN</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -113,7 +113,6 @@
     <string name="pref_torrc_dialog">Mukautettu torrc</string>
     <string name="bridges_updated">Sillat päivitetty</string>
     <string name="restart_orbot_to_use_this_bridge_">Käynnistä Orbot uudelleen ottaaksesi muutokset käyttöön</string>
-    <string name="menu_qr">QR-koodit</string>
     <string name="get_bridges_email">Sähköposti</string>
     <string name="send_email">Lähetä sähköpostia</string>
     <string name="hidden_services">Piilopalvelut</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">Käytä *vain* näitä solmuja</string>
     <string name="bridges">Sillat</string>
     <string name="use_bridges">Käytä siltoja</string>
-    <string name="ip_address_and_port_of_bridges">Siltojen IP-osoitteet ja portit</string>
-    <string name="enter_bridge_addresses">Kirjoita siltaosoitteet</string>
     <string name="relays">Releet</string>
     <string name="relaying">Releytys</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Ota laitteesi käyttöön välireleenä</string>
@@ -128,7 +126,6 @@
     <string name="disable">Poista käytöstä</string>
     <string name="enable">Ota käyttöön</string>
     <string name="wizard_details_msg">Orbot on avoimen lähdekoodin sovellus, joka sisältää Tor, Obfs4Proxy, BadVPN Tun2Socks, LibEvent ja Polipo. Se tarjoaa paikallisen HTTP-välityspalvelimen (8118) ja SOCKS-välityspalvelimen (9050) Tor-verkkoon. Orbotilla on myös ominaisuus, rootattulla laitteella, lähettää kaiken Internet-liikenteen Torin kautta.</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Ota käyttöön vaihtoehtoiset sisäänkäynnit Tor-verkkoon</string>
     <string name="obfsproxy_version">Obfs4proxy: https://github.com/Yawning/obfs4</string>
     <string name="openssl_version">OpenSSL: http://www.openssl.org</string>
     <string name="hidden_service_request">Sovellus haluaa avata sipulipalvelimen portin %1$s Tor-verkkoon. Tämä on turvallista, jos luotat sovellukseen.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">N’utiliser *que* ces nœuds précis</string>
     <string name="bridges">Ponts</string>
     <string name="use_bridges">Utiliser des ponts</string>
-    <string name="ip_address_and_port_of_bridges">Adresse IP et port des ponts</string>
-    <string name="enter_bridge_addresses">Saisir les adresses des ponts</string>
     <string name="relays">Relais</string>
     <string name="relaying">Relais</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Faire de votre appareil un relais de non-sortie</string>
@@ -122,7 +120,6 @@
     <string name="name">Name</string>
     <string name="please_restart_Orbot_to_enable_the_changes">Veuillez redémarrer Orbot pour activer les changements</string>
     <string name="wizard_details_msg">Orbot est une application à code source ouvert qui comprend Tor, Obfs4Proxy, BadVPN Tun2Socks et LibEvent. Elle fournit un mandataire HTTP local (8118) et un mandataire SOCKS (9050) vers le réseau Tor. Sur un appareil débridé, Orbot peut aussi faire passer tout le trafic Internet par Tor.</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Activer les entrées auxiliaires vers le réseau Tor</string>
     <string name="obfsproxy_version">Obfs4proxy : https://github.com/Yawning/obfs4</string>
     <string name="openssl_version">OpenSSL : http://www.openssl.org</string>
     <string name="hidden_service_request">Une appli veut ouvrir le port %1$s du serveur onion vers le réseau Tor. Cette action est sûre si vous faites confiance à cette appli.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -113,7 +113,6 @@
     <string name="pref_torrc_dialog">Torrc personnalisé</string>
     <string name="bridges_updated">Ponts mis à jour</string>
     <string name="restart_orbot_to_use_this_bridge_">Veuillez redémarrer Orbot pour activer les changements</string>
-    <string name="menu_qr">Codes QR</string>
     <string name="get_bridges_email">Courriel</string>
     <string name="send_email">Envoyer un courriel</string>
     <string name="save">Enregistrer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -117,8 +117,7 @@
   <string name="pref_torrc_dialog">Personnaliser Torrc </string>
   <string name="bridges_updated">Ponts mis à jour</string>
   <string name="restart_orbot_to_use_this_bridge_">Veuillez redémarrer Orbot pour activer les changements</string>
-  <string name="menu_qr">Codes QR</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si votre réseau mobile bloque Tor activement, vous pouvez utiliser un serveur-pont comme moyen de remplacement. CHOISIR une des options pour configurer et tester…</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si votre réseau mobile bloque Tor activement, vous pouvez utiliser un serveur-pont comme moyen de remplacement. CHOISIR une des options pour configurer et tester…</string>
   <string name="get_bridges_email">Courriel</string>
   <string name="apps_mode">Mode RPV</string>
     <string name="send_email">Envoyer un courriel</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">Utiliser *uniquement * ces nœuds spécifiés</string>
   <string name="bridges">Ponts</string>
   <string name="use_bridges">Utiliser des ponts</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Activer les entrées de remplacement vers le réseau Tor</string>
-    <string name="ip_address_and_port_of_bridges">Adresse IP et port des ponts</string>
-  <string name="enter_bridge_addresses">Saisir les adresses des ponts</string>
   <string name="relays">Relais</string>
   <string name="relaying">Relais</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Configurez votre appareil pour être un relais de non-sortie</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc personalizado</string>
     <string name="bridges_updated">Pontes actualizadas</string>
     <string name="restart_orbot_to_use_this_bridge_">Por favor, reinicie Orbot para activar os cambios</string>
-    <string name="menu_qr">Códigod QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Si a súa rede móbil bloquea Tor de xeito activo, pode utilizar un \'Servidor Ponte\' como modo alternativo. ESCOLL unha das opcións para configurar e probar…</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">Modo VPN</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Usar *só* este nodos específicos</string>
     <string name="bridges">Pontes</string>
     <string name="use_bridges">Usar Pontes</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Activar entradas alternativas a rede Tor</string>
-    <string name="ip_address_and_port_of_bridges">Dirección IP e porto das pontes</string>
-    <string name="enter_bridge_addresses">Introduza Direccións das Pontes</string>
     <string name="relays">Reenvíos</string>
     <string name="relaying">Reenvío</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Habilite o seu dispositivo para ser un reenvío non de saída</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc מותאם אישית</string>
     <string name="bridges_updated">גשרים עודכנו</string>
     <string name="restart_orbot_to_use_this_bridge_">אנא הפעל מחדש את Orbot כדי לאפשר את השינויים</string>
-    <string name="menu_qr">קודי QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">אם פעילות הרשת הניידת שלך חוסמת את Tor, אפשר להשתמש ב‚שרת גישור’ כדרך חלופית להיכנס. יש לבחור באחת האפשרויות כדי להגדיר ולבחון…</string>
     <string name="get_bridges_email">דוא\"ל</string>
     <string name="apps_mode">מצב VPN</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">השתמש *רק* בצמתים מצוינים אלו</string>
     <string name="bridges">גשרים</string>
     <string name="use_bridges">השתמש בגשרים</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">אפשר כניסות חלופיות לתוך רשת Tor</string>
-    <string name="ip_address_and_port_of_bridges">כתובת IP ופתחה של גשרים</string>
-    <string name="enter_bridge_addresses">הכנס כתובות גשר</string>
     <string name="relays">ממסרים</string>
     <string name="relaying">ממסור</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">אפשר למכשיר שלך להיות תחנת ממסר שאיננה יציאה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -118,7 +118,6 @@
     <string name="pref_torrc_dialog">कस्टम टोररक</string>
     <string name="bridges_updated">पुल अपडेटेड </string>
     <string name="restart_orbot_to_use_this_bridge_">परिवर्तन सक्षम करने के लिए Orbot पुनः प्रारंभ करें</string>
-    <string name="menu_qr">QR कोड</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">यदि आपका मोबाइल नेटवर्क सक्रिय रूप से टो को ब्लॉक करता है, तो आप \'पुल सर्वर\' को एक वैकल्पिक तरीके से उपयोग कर सकते हैं। कॉन्फ़िगर और परीक्षण करने के लिए विकल्पों में से एक का चयन करें ..,।</string>
     <string name="get_bridges_email">ईमेल</string>
     <string name="apps_mode">वीपीएन मोड</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -68,9 +68,6 @@
     <string name="use_only_these_specified_nodes">* केवल * इन निर्दिष्ट नोड्स का उपयोग करें</string>
     <string name="bridges">पुल</string>
     <string name="use_bridges">पुल का उपयोग करें</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">टोरी नेटवर्क में वैकल्पिक प्रवेश द्वार सक्षम करें</string>
-    <string name="ip_address_and_port_of_bridges">आईपी पता और पुल का बंदरगाह</string>
-    <string name="enter_bridge_addresses">ब्रिज पते दर्ज करें</string>
     <string name="relays">रिले</string>
     <string name="relaying">रिलेइंग</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">अपने डिवाइस को गैर-बाहर निकलें रिले होने के लिए सक्षम करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Koristi *samo* ove navedene čvorove</string>
   <string name="bridges">Mostovi</string>
   <string name="use_bridges">Koristi Mostove</string>
-  <string name="ip_address_and_port_of_bridges">IP adresa i port mostova</string>
-  <string name="enter_bridge_addresses">Unesi Adrese Mostova</string>
   <string name="relays">Releji</string>
   <string name="relaying">Prenošenje</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Omogućite svom uređaju da bude ne-izlazni relej</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Prilagođeni Torrc</string>
   <string name="bridges_updated">Mostova ažurirano</string>
   <string name="restart_orbot_to_use_this_bridge_">Ponovno pokrenite Orbot da bi omogućili promjene</string>
-  <string name="menu_qr">QR kodovi</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Pošalji email</string>
   <string name="save">Spremi</string>
   <string name="name">Ime</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">*Csak* ezeknek a megadott csomópontoknak a használata</string>
     <string name="bridges">Hidak</string>
     <string name="use_bridges">Hidak használata</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">A Tor hálózat bejáratok váltogatásának engedélyezése </string>
-    <string name="ip_address_and_port_of_bridges">A hidak IP címe és portja</string>
-    <string name="enter_bridge_addresses">Add meg a híd címeit</string>
     <string name="relays">Átjátszók</string>
     <string name="relaying">Átjátszás</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Engedélyezd az eszközödnek, hogy nem-átjátszó elosztó legyen</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Egyedi Torrc</string>
     <string name="bridges_updated">Hidak frissítve</string>
     <string name="restart_orbot_to_use_this_bridge_">Kérlek indítsd újra az Orbot-ot a változások engedélyezéséhez</string>
-    <string name="menu_qr">QR kódok</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ha a mobil hálózata aktívan blokkolja a Tor-t, akkor választhatja a \'Híd szerver\'-t, mint alternatív utat. VÁLASSZON egyet a lehetőségek közül és tesztelje….</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">VPN Mód</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Pakai *hanya* spesifik node</string>
   <string name="bridges">Bridges</string>
   <string name="use_bridges">Pakai Bridges</string>
-    <string name="ip_address_and_port_of_bridges">Alamat IP dan port bridges</string>
-  <string name="enter_bridge_addresses">Memasuki Alamat Bridge</string>
   <string name="relays">Relays</string>
   <string name="relaying">Sedang me-Relay</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Nyalakan perangkat anda menjadi non-exit relay</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Torrc Custom</string>
   <string name="bridges_updated">Bridge Telah Diperbarui</string>
   <string name="restart_orbot_to_use_this_bridge_">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>
-  <string name="menu_qr">Kode QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Kirim Email</string>
   <string name="save">Simpan</string>
   <string name="name">Nama</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Pakai *hanya* spesifik node</string>
   <string name="bridges">Bridges</string>
   <string name="use_bridges">Pakai Bridges</string>
-    <string name="ip_address_and_port_of_bridges">Alamat IP dan port bridges</string>
-  <string name="enter_bridge_addresses">Memasuki Alamat Bridge</string>
   <string name="relays">Relays</string>
   <string name="relaying">Sedang me-Relay</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Nyalakan perangkat anda menjadi non-exit relay</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Torrc Custom</string>
   <string name="bridges_updated">Bridge Telah Diperbarui</string>
   <string name="restart_orbot_to_use_this_bridge_">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>
-  <string name="menu_qr">Kode QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Kirim Email</string>
   <string name="please_restart_Orbot_to_enable_the_changes">Silakan start ulang Orbot untuk mengaktifkan perubahan</string>
 </resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Sérsniðið Torrc</string>
     <string name="bridges_updated">Brýr uppfærðar</string>
     <string name="restart_orbot_to_use_this_bridge_">Endurræstu Orbot til að breytingarnar taki gildi</string>
-    <string name="menu_qr">QR-kóðar</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ef farsímanetið þitt er virkt í að loka á Tor, geturðu notað \'Brúarþjón\' sem varaleið inn. VELDU einn af valkostunum til að setja upp og prófa…</string>
     <string name="get_bridges_email">Tölvupóstur</string>
     <string name="apps_mode">VPN-hamur</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Nota *aðeins* þessa tilteknu punkta</string>
     <string name="bridges">Brýr</string>
     <string name="use_bridges">Nota brýr</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Virkjaðu varaleiðir inn á Tor-netið</string>
-    <string name="ip_address_and_port_of_bridges">IP-vistfang og brúargáttir</string>
-    <string name="enter_bridge_addresses">Settu inn vistföng fyrir brýr</string>
     <string name="relays">Endurvarpar</string>
     <string name="relaying">Endurvörpun</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Leyfa tækinu þínu að vera útgangslaus endurvarpi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Utilizza *solo* i nodi specificati</string>
     <string name="bridges">Bridge</string>
     <string name="use_bridges">Utilizza i bridge</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Attiva entrate alternate nella rete Tor</string>
-    <string name="ip_address_and_port_of_bridges">Indirizzo IP e porta dei bridge</string>
-    <string name="enter_bridge_addresses">Inserire gli indirizzi dei bridge</string>
     <string name="relays">Relays (Inoltratori)</string>
     <string name="relaying">Relaying (Inoltro)</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Abilita il tuo dispositivo per essere un relay non di uscita</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc personalizzate</string>
     <string name="bridges_updated">Bridge attivati</string>
     <string name="restart_orbot_to_use_this_bridge_">Per favore riavvia Orbot per rendere effettive le modifiche</string>
-    <string name="menu_qr">Codici QR</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se la tua rete mobile blocca attivamente Tor, puoi usare un \'Server Bridge\' come via alternativa. SELEZIONA una delle opzioni per configurare e testare…</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">Modalità VPN</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -90,7 +90,6 @@
   <string name="pref_transport_title">Tor TransProxy Port</string>
   <string name="pref_transport_dialog">הגדרת הפורט של TransProxy</string>
   <string name="pref_dnsport_title">Tor DNS Port</string>
-  <string name="menu_qr">קוד QR</string>
-  <string name="get_bridges_email">דוא\"ל</string>
+    <string name="get_bridges_email">דוא\"ל</string>
   <string name="send_email">שלח דוא\"ל</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -59,8 +59,6 @@
   <string name="use_only_these_specified_nodes">השתמש *רק* בצמתים מצוינים אלו</string>
   <string name="bridges">גשרים</string>
   <string name="use_bridges">השתמש בגשרים</string>
-    <string name="ip_address_and_port_of_bridges">כתובת ה-IP ויציאה של הגשרים</string>
-  <string name="enter_bridge_addresses">הכנס כתובות גשר</string>
   <string name="relays">ממסרים</string>
   <string name="relaying">ממסור</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">אפשר למכשיר שלך להיות תחנת ממסר שאיננה יציאה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">ここに指定したノードのみを使用</string>
     <string name="bridges">ブリッジ</string>
     <string name="use_bridges">ブリッジを使う</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Torネットワークへの代替入口を有効化</string>
-    <string name="ip_address_and_port_of_bridges">ブリッジのIPアドレスとポート</string>
-    <string name="enter_bridge_addresses">ブリッジのアドレスを入力</string>
     <string name="relays">リレー</string>
     <string name="relaying">リレー中</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">この端末を非出口リレーにする</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrcをカスタム</string>
     <string name="bridges_updated">ブリッジを更新しました</string>
     <string name="restart_orbot_to_use_this_bridge_">変更を有効にするにはOrbotを再起動してください</string>
-    <string name="menu_qr">QRコード</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">モバイルネットワークが頻繁にTorをブロックする場合、別の方法として \'ブリッジサーバー\'を使用することができます。オプションを１つ選択して、設定とテストを行ってください。</string>
     <string name="get_bridges_email">メール</string>
     <string name="apps_mode">VPN モード</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">이 특정한 노드*만* 사용합니다.</string>
   <string name="bridges">중계서버</string>
   <string name="use_bridges">중계서버 사용</string>
-    <string name="ip_address_and_port_of_bridges">중계서버의 IP 주소와 </string>
-  <string name="enter_bridge_addresses">중게서버 주소 입력</string>
   <string name="relays">중계서버</string>
   <string name="relaying">중계</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">귀하의 장치를 출구가 아닌 중계서버로 활성화</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">나만의 Torrc</string>
   <string name="bridges_updated">브릿지가 업데이트되었습니다</string>
   <string name="restart_orbot_to_use_this_bridge_">변경을 완료하려면 Orbot을 재시작하세요</string>
-  <string name="menu_qr">QR 코드</string>
-  <string name="get_bridges_email">이메일</string>
+    <string name="get_bridges_email">이메일</string>
   <string name="send_email">이메일 보내기</string>
   <string name="save">저장</string>
   <string name="name">Name</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Pielāgot Torrc</string>
   <string name="bridges_updated">Tilti ir atjaunināti</string>
   <string name="restart_orbot_to_use_this_bridge_">Lūdzu pārstartējiet Orbot, lai iespējotu izmaiņas</string>
-  <string name="menu_qr">QR kodi</string>
-  <string name="get_bridges_email">E-pasts</string>
+    <string name="get_bridges_email">E-pasts</string>
   <string name="send_email">Nosūtīt e-pastu</string>
   <string name="hidden_services">Slēptie pakalpojumi</string>
   <string name="title_activity_hidden_services">Slēptie pakalpojumi</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Izmantojiet *vienīgi* šos norādītos mezglus</string>
   <string name="bridges">Tilti</string>
   <string name="use_bridges">Lietot tiltus</string>
-    <string name="ip_address_and_port_of_bridges">Tiltu ports un IP addrese</string>
-  <string name="enter_bridge_addresses">Ievadiet tiltu adreses</string>
   <string name="relays">Retranslatori</string>
   <string name="relaying">Retranslēšana</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Iespējot Jūsu iekārtu par bezapstājas retranslatoru</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Прилагоден torrc</string>
     <string name="bridges_updated">Ажурирани мостови</string>
     <string name="restart_orbot_to_use_this_bridge_">Ве молиме повторно стартувајте го Orbot за да се овозможат промените</string>
-    <string name="menu_qr">QR-кодови</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако вашата мобилна мрежа активно го блокира Tor, можете да користите „Мост сервер“ како алтернативен пристап. ОДБЕРЕТЕ една од опциите за поставување и тестирање…</string>
     <string name="get_bridges_email">Е-пошта</string>
     <string name="apps_mode">VPN мод</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Користете ги *само* овие наведени јазли</string>
     <string name="bridges">Мостови</string>
     <string name="use_bridges">Користи мостови</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Овозможи алтернативен влезови на Tor мрежата</string>
-    <string name="ip_address_and_port_of_bridges">IP-адреса и порта на мостовите</string>
-    <string name="enter_bridge_addresses">Внесете адреси на мостовите</string>
     <string name="relays">Релеи</string>
     <string name="relaying">Препраќање</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Овозможи го уредот да биде реле без излез</string>

--- a/app/src/main/res/values-ms-rMY/strings.xml
+++ b/app/src/main/res/values-ms-rMY/strings.xml
@@ -60,8 +60,6 @@
   <string name="use_only_these_specified_nodes">Guna *hanya* nod-nod ini</string>
   <string name="bridges">Jambatan</string>
   <string name="use_bridges">Guna Jambatan</string>
-    <string name="ip_address_and_port_of_bridges">Alamat IP dan pelabuhan jambatan</string>
-  <string name="enter_bridge_addresses">Masukkan Alamat Jambatan</string>
   <string name="relays">Relays</string>
   <string name="relaying">Relaying</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Membolehkan peranti anda untuk menjadi geganti bukan keluar</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -52,8 +52,6 @@
   <string name="use_only_these_specified_nodes">Guna *hanya* nod-nod ini</string>
   <string name="bridges">Jambatan</string>
   <string name="use_bridges">Guna Jambatan</string>
-    <string name="ip_address_and_port_of_bridges">Alamat IP dan pelabuhan jambatan</string>
-  <string name="enter_bridge_addresses">Masukkan Alamat Jambatan</string>
   <string name="relays">Relays</string>
   <string name="relaying">Relaying</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Membolehkan peranti anda untuk menjadi geganti bukan keluar</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">Bruk *bare* disse angitte nodene</string>
     <string name="bridges">Broer</string>
     <string name="use_bridges">Bruk broer</string>
-    <string name="ip_address_and_port_of_bridges">IP-adresser og broporter</string>
-    <string name="enter_bridge_addresses">Skriv inn broadresser</string>
     <string name="relays">Reléer</string>
     <string name="relaying">Videresending</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Aktiver enheten din som et rutingsstafettoppsett uten utgående trafikk</string>
@@ -155,7 +153,6 @@
     <string name="full_device_vpn">VPN for hele enheten</string>
     <string name="vpn_disabled">VPN Deaktivert</string>
     <string name="wizard_details_msg">Orbot er et fritt program som inneholder Tor, Obfs4Proxy, BadVPN Tun2Socks, LibEvent og Polipo. Den gir en lokal HTTP-proxy (8118) og en SOCKS-mellomtjener (9050) inn i Tor-nettverket. Orbot har også muligheten til å sende all Internett-trafikk gjennom Tor på enheter med superbrukertilgang.</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Aktiver alternative innganger til Tor-nettverket</string>
     <string name="hidden_service_request">Et program ønsker å åpne løktjenerport %1$s til Tor-nettverket. Dette er trygt såfremt du stoler på programmet.</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Åpne proxy på alle grensesnitt</string>
     <string name="pref_http_title">Tor HTTP</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -115,7 +115,6 @@
     <string name="pref_torrc_dialog">Egendefinert torrc</string>
     <string name="bridges_updated">Broer oppdatert</string>
     <string name="restart_orbot_to_use_this_bridge_">Gjør omstart av Orbot før endringer trer i kraft</string>
-    <string name="menu_qr">QR-koder</string>
     <string name="get_bridges_email">E-post</string>
     <string name="apps_mode">VPN-modus</string>
     <string name="send_email">Send e-post</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Aangepaste Torrc</string>
     <string name="bridges_updated">Bridges bijgewerkt</string>
     <string name="restart_orbot_to_use_this_bridge_">Herstart Orbot om de wijzigingen in te schakelen</string>
-    <string name="menu_qr">QR-codes</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Als je mobiele netwerk Tor actief blokkeert, kan je een \'bridge-server\' gebruiken als alternatieve toegang. SELECTEER een van de opties om te configureren en te testen..,.</string>
     <string name="get_bridges_email">E-mail</string>
     <string name="apps_mode">VPN-modus</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Gebruik *enkel* deze opgegeven nodes</string>
     <string name="bridges">Bridges</string>
     <string name="use_bridges">Gebruik bridges</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Alternatieve toegangen tot het Tor-netwerk inschakelen</string>
-    <string name="ip_address_and_port_of_bridges">IP-adres en poort van bridges</string>
-    <string name="enter_bridge_addresses">Voer bridge-adres in</string>
     <string name="relays">Relays</string>
     <string name="relaying">Relayen</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Stel je toestel in staat om een non-exit relay te zijn</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -113,7 +113,6 @@
     <string name="pref_torrc_dialog">Torrc klienta</string>
     <string name="bridges_updated">Zaktualizowane Bridges</string>
     <string name="restart_orbot_to_use_this_bridge_">Proszę zrestartować Orbot, aby zmiany mogły wejść w życie</string>
-    <string name="menu_qr">Kody QR</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">Tryb VPN</string>
     <string name="send_email">Wyślij Email</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">Użyj *tylko* tych określonych węzłów</string>
     <string name="bridges">Mostki</string>
     <string name="use_bridges">Użyj mostków</string>
-    <string name="ip_address_and_port_of_bridges">Adres IP i port mostków</string>
-    <string name="enter_bridge_addresses">Wpisz adresy mostków</string>
     <string name="relays">Przekaźniki</string>
     <string name="relaying">Przekazywanie</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Pozwól swojemu urządzeniu zostać bezwyjściowym przekaźnikiem</string>
@@ -130,7 +128,6 @@
     <string name="please_restart_Orbot_to_enable_the_changes">Proszę zrestartować Orbot, aby zmiany mogły wejść w życie</string>
     <string name="disable">Wyłącz</string>
     <string name="enable">Włącz</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Włącz alternatywne wejścia do sieci Tor</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Otwórz serwer proxy na wszystkich interfejsach</string>
     <string name="pref_http_dialog">Konfiguracja portu HTTP</string>
     <string name="pref_http_title">Tor HTTP</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc Personalizado</string>
     <string name="bridges_updated">Pontes Atualizadas</string>
     <string name="restart_orbot_to_use_this_bridge_">Por favor reinicie Orbot para habilitar as mundanças</string>
-    <string name="menu_qr">QR Codes</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. SELECIONE umas das opções para configurar e testar…</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">Modo VPN</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Use *somente* estes nós específicos</string>
     <string name="bridges">Pontes</string>
     <string name="use_bridges">Usar Pontes</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Ative as entradas alternativas para a Rede Tor</string>
-    <string name="ip_address_and_port_of_bridges">Endereço IP e as porta das pontes</string>
-    <string name="enter_bridge_addresses">Insira os Endereços das Pontes</string>
     <string name="relays">Retransmissores</string>
     <string name="relaying">Retransmitindo</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Ativar o seu dispositivo para não ser um retransmissor de saída</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -43,7 +43,6 @@
     <string name="set_locale_title">Idioma</string>
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_dnsport_title">Porta DNS Tor</string>
-    <string name="menu_qr">Códigos QR</string>
     <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="send_email">Enviar Mensagem</string>
     <string name="save">Guardar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -111,7 +111,6 @@
     <string name="bridges_updated">Pontes Atualizadas</string>
     <string name="pref_proxy_host_title">Anfitrião Proxy de Saída</string>
     <string name="pref_proxy_host_dialog">Inserir Hospedeiro Proxy</string>
-    <string name="ip_address_and_port_of_bridges">Endereço de IP e porta das pontes</string>
     <string name="pref_proxy_password_summary">Senha do Proxy (Opcional)</string>
     <string name="project_home">Projeto Home(s):</string>
     <string name="pref_proxy_type_title">Tipo de Proxy de Saída</string>
@@ -178,8 +177,6 @@
     <string name="relay_port">Porta Retransmissora</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Ativar o seu aparelho para ser um retransmissor de sem saída</string>
     <string name="relaying">Retransmitindo</string>
-    <string name="enter_bridge_addresses">Insira os Endereços das Pontes</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Ative as entradas alternativas para a Rede Tor</string>
     <string name="strict_nodes">Nós Estritos</string>
     <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Impressões digitais, apelidos, países e endereços para excluir</string>
     <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">Impressões digitais, apelidos, países e endereços para a última etapa</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,7 +47,6 @@
     <string name="error">Erro</string>
     <string name="bridges">Pontes</string>
     <string name="use_bridges">Usar Pontes</string>
-    <string name="ip_address_and_port_of_bridges">Endereço de IP e porta das pontes</string>
     <string name="enter_or_port">Inserir OU porta</string>
     <string name="reachable_ports">Portas alcançáveis</string>
     <string name="ports_reachable_behind_a_restrictive_firewall">Portas alcançáveis por detrás de uma Firewal restritiva</string>
@@ -169,8 +168,6 @@
     <string name="enable_your_device_to_be_a_non_exit_relay">Ativar o seu aparelho para ser um retransmissor de sem saída</string>
     <string name="relaying">Retransmitindo</string>
     <string name="relays">Retransmissores</string>
-    <string name="enter_bridge_addresses">Insira os Endereços das Pontes</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Ative as entradas alternativas para a Rede Tor</string>
     <string name="use_only_these_specified_nodes">Use *somente* estes nós específicos</string>
     <string name="strict_nodes">Nós Estritos</string>
     <string name="enter_exclude_nodes">Digite Nós Excluídos</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -68,7 +68,6 @@
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_dnsport_title">Porta DNS Tor</string>
     <string name="bridges_updated">Pontes Atualizadas</string>
-    <string name="menu_qr">Códigos QR</string>
     <string name="get_bridges_email">Correio Eletrônico</string>
     <string name="send_email">Enviar Mensagem</string>
     <string name="hidden_services">Serviços ocultos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Torrc Personalizat</string>
   <string name="bridges_updated">Punţi activate</string>
   <string name="restart_orbot_to_use_this_bridge_">Vă rugăm reporniţi Orbot pentru a aplica modificările</string>
-  <string name="menu_qr">Coduri QR</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Trimite email</string>
   <string name="hidden_services">Servicii ascunse</string>
   <string name="title_activity_hidden_services">Servicii ascunse</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Foloseste *doar* nodurile specificate</string>
   <string name="bridges">Punţi</string>
   <string name="use_bridges">Foloseşte punţi</string>
-    <string name="ip_address_and_port_of_bridges">Adresa IP şi port pentru punţi</string>
-  <string name="enter_bridge_addresses">Introdu adresa pentru punte</string>
   <string name="relays">Comutatoare</string>
   <string name="relaying">Comutare</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Activeaza dispozitivul sa fie un comutator fara iesire</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Пользовательский Torrc</string>
     <string name="bridges_updated">Мосты обновлены</string>
     <string name="restart_orbot_to_use_this_bridge_">Пожалуйста, перезапустите Orbot для вступления изменения в силу</string>
-    <string name="menu_qr">QR-коды</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Если ваша мобильная сеть активно блокирует Tor, вы можете использовать мосты Tor для доступа к сети. Выберите один из вариантов для настройки и тестирования:</string>
     <string name="get_bridges_email">Эл. почта</string>
     <string name="apps_mode">VPN-режим</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Использовать *только* эти заданные узлы</string>
     <string name="bridges">Мосты</string>
     <string name="use_bridges">Использовать мосты</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Включить альтернативные входные узлы в сеть Tor</string>
-    <string name="ip_address_and_port_of_bridges">IP-адреса и порты мостов</string>
-    <string name="enter_bridge_addresses">Введите адреса мостов</string>
     <string name="relays">Ретрансляторы</string>
     <string name="relaying">Ретрансляция</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Разрешить вашему устройству быть невыходным ретранслятором</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -55,8 +55,6 @@
   <string name="use_only_these_specified_nodes">ඉහත සදහන් නොඩු *පමණක්* භාවිතා කරන්න </string>
   <string name="bridges">සේතු</string>
   <string name="use_bridges">සේතු භාවිතා කරන්න </string>
-    <string name="ip_address_and_port_of_bridges">IP ලිපිනය හා සේතුවල පෝට</string>
-  <string name="enter_bridge_addresses">සේතු ලිපිනයන් ඇතුළු කරන්න </string>
   <string name="relays">ප්‍රතියෝජකය</string>
   <string name="relaying">ප්‍රතියෝජනය </string>
   <string name="enable_your_device_to_be_a_non_exit_relay">ඔබේ උපාංගය නික්ම-නොයන ප්‍රතියෝජකයක් බවට සබල කරන්න </string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -113,8 +113,7 @@
   <string name="pref_torrc_dialog">Vlasné Torrc</string>
   <string name="bridges_updated">Premostenia aktualizované</string>
   <string name="restart_orbot_to_use_this_bridge_">Prosím reštartujte Orbot, aby sa aktivovali zmeny</string>
-  <string name="menu_qr">QR kódy</string>
-  <string name="get_bridges_email">Email</string>
+    <string name="get_bridges_email">Email</string>
   <string name="send_email">Poslať email</string>
   <string name="save">Uložiť</string>
   <string name="name">Meno</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -66,8 +66,6 @@
   <string name="use_only_these_specified_nodes">Použiť *len* tieto špecifikované uzly</string>
   <string name="bridges">Premostenia</string>
   <string name="use_bridges">Použiť premostenia</string>
-    <string name="ip_address_and_port_of_bridges">IP adresy a porty premostení</string>
-  <string name="enter_bridge_addresses">Vložiť adresy premostení</string>
   <string name="relays">Relé</string>
   <string name="relaying">Postúpenie relé</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Povoliť, aby nebolo vaše zariadenie východiskovým relé / non-exit</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -115,8 +115,7 @@
   <string name="pref_torrc_dialog">Подеси Torrc</string>
   <string name="bridges_updated">Bridges Ажурирање</string>
   <string name="restart_orbot_to_use_this_bridge_">Молимо покрените поново Орбот ради примењивања промена</string>
-  <string name="menu_qr">QR Кодови</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако ваша мобилна мрежа активно блокира Тор, можете премошћивати сервером као алтернативни начин уласка.ОДАБЕРИ једну од опција за конфигурацију и тестирање….</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Ако ваша мобилна мрежа активно блокира Тор, можете премошћивати сервером као алтернативни начин уласка.ОДАБЕРИ једну од опција за конфигурацију и тестирање….</string>
   <string name="get_bridges_email">Е-пошта</string>
   <string name="apps_mode">VPN Мод</string>
     <string name="send_email">Пошаљи Е-пошту</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">Користи САМО ове наведене чворове</string>
   <string name="bridges">Мостови</string>
   <string name="use_bridges">Користи bridge</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Омогућите алтернативне улазе у Тор мрежу</string>
-    <string name="ip_address_and_port_of_bridges">IP адреса и порт bridge-а</string>
-  <string name="enter_bridge_addresses">Унесите bridge адресу </string>
   <string name="relays">Релеји</string>
   <string name="relaying">Релејирање</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">Омогућите вашем уређају да буде релеј без излаза</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Använd *enbart* dessa specificerade noder</string>
     <string name="bridges">Broar</string>
     <string name="use_bridges">Använd Broar</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Aktivera alternativa ingångar i Tor-nätverket</string>
-    <string name="ip_address_and_port_of_bridges">IP adress och port för broar</string>
-    <string name="enter_bridge_addresses">Skriv in Bro Adresser</string>
     <string name="relays">Reläer</string>
     <string name="relaying">Överföring</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Aktivera din enhet till att vara ett icke-utgångsrelä</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Anpassad Torrc</string>
     <string name="bridges_updated">Bryggor uppdaterade</string>
     <string name="restart_orbot_to_use_this_bridge_">Vänligen starta om Orbot för att aktivera ändringarna</string>
-    <string name="menu_qr">QR-koder</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Om ditt mobilnät aktivt blockerar Tor kan du använda en \"Bridge Server\" som ett alternativt sätt. VÄLJ ett av alternativen att konfigurera och testa.,.</string>
     <string name="get_bridges_email">E-post</string>
     <string name="apps_mode">VPN-läge</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">ใช้ *เฉพาะ* โหนดที่ระบุเหล่านี้เท่านั้น</string>
     <string name="bridges">Bridges</string>
     <string name="use_bridges">ใช้งาน Bridges</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">เปิดใช้งานทางเข้าอื่นเข้าสู่เครือข่าย Tor</string>
-    <string name="ip_address_and_port_of_bridges">ที่อยู่ไอพีและพอร์ตของ Bridges</string>
-    <string name="enter_bridge_addresses">ระบุที่อยู่ของ Bridge</string>
     <string name="relays">รีเลย์</string>
     <string name="relaying">การรีเลย์</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">ทำให้อุปกรณ์ของคุณทำงานเป็นรีเลย์แบบไม่ใช่ทางออก</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Torrc ที่กำหนดเอง</string>
     <string name="bridges_updated">Bridges อัพเดตแล้ว</string>
     <string name="restart_orbot_to_use_this_bridge_">กรุณาเริ่ม Orbot ใหม่เพื่อให้การเปลี่ยนแปลงใช้งานได้</string>
-    <string name="menu_qr">รหัสคิวอาร์</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">หากเครือข่ายโทรศัพท์ของคุณปิดกั้น Tor คุณสามารถใช้ \'เซิร์ฟเวอร์ Bridge\' เป็นตัวเลือกในการเข้าถึงได้ เลือกตัวเลือกหนึ่งเพื่อกำหนดค่าและทดสอบ…</string>
     <string name="get_bridges_email">อีเมล</string>
     <string name="apps_mode">โหมด VPN</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -63,8 +63,6 @@
   <string name="use_only_these_specified_nodes">Gumamit ng *only* sa mga ispesipikong nodes </string>
   <string name="bridges">Bridges</string>
   <string name="use_bridges">Gumamit ng Bridges</string>
-    <string name="ip_address_and_port_of_bridges">IP address at port ng bridges</string>
-  <string name="enter_bridge_addresses">Ilagay ang Bridge Addresses</string>
   <string name="relays">Relays</string>
   <string name="relaying">Relaying</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">I-enable ang iyong device na non-exit relay</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">*Yalnız* bu düğümler kullanılsın</string>
     <string name="bridges">Köprüler</string>
     <string name="use_bridges">Köprüleri Kullan</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Alternatif Tor ağı girişleri kullanılabilsin</string>
-    <string name="ip_address_and_port_of_bridges">Köprülerin IP adresleri ve bağlantı noktaları</string>
-    <string name="enter_bridge_addresses">Köprü Adreslerini Girin</string>
     <string name="relays">Aktarıcılar</string>
     <string name="relaying">Aktarım</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Aygıtınız çıkış yapmayan bir aktarıcı olarak kullanılsın</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Özel Torrc Ayarları</string>
     <string name="bridges_updated">Köprüler Güncellendi</string>
     <string name="restart_orbot_to_use_this_bridge_">Değişiklikleri etkinleştirmek için Orbot uygulamasını yeniden başlatın</string>
-    <string name="menu_qr">QR Kodları</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Tor kullanımı mobil ağınızda etkin olarak engelleniyorsa, Tor ağına erişmek için bir \'Köprü Sunucusu\' kullanabilirsiniz. Yapılandırmak ve denemek için aşağıdaki seçeneklerden birini seçin…</string>
     <string name="get_bridges_email">E-posta</string>
     <string name="apps_mode">VPN Kipi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -117,7 +117,6 @@
     <string name="pref_torrc_dialog">Додаткове у Torrc</string>
     <string name="bridges_updated">Мости оновлено</string>
     <string name="restart_orbot_to_use_this_bridge_">Будь ласка, перезапустіть Orbot, щоб зміни ввійшли в силу</string>
-    <string name="menu_qr">QR-коди</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Якщо ваша мобільна мережа активно блокує Tor, ви можете використовувати \'Bridge Server\' як альтернативний спосіб входу. ВИБЕРИ один із параметрів для налаштування та тестування…</string>
     <string name="get_bridges_email">Email</string>
     <string name="apps_mode">VPN Спосіб</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -67,9 +67,6 @@
     <string name="use_only_these_specified_nodes">Використовувати *тільки* ці задані вузли</string>
     <string name="bridges">Мости</string>
     <string name="use_bridges">Використати Мости</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Увімкніть альтернативні входи у мережу Tor</string>
-    <string name="ip_address_and_port_of_bridges">IP адреси і порти мостів</string>
-    <string name="enter_bridge_addresses">Введіть Адреси Мостів</string>
     <string name="relays">Ретранслятори</string>
     <string name="relaying">Ретрансляція</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Дозволити вашому пристрою бути невихідним ретранслятором</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">*Chỉ* dùng những nút được liệt kê</string>
     <string name="bridges">Bridge</string>
     <string name="use_bridges">Dùng bridge</string>
-    <string name="ip_address_and_port_of_bridges">Địa chỉ IP và cổng của bridge</string>
-    <string name="enter_bridge_addresses">Nhập địa chỉ bridge</string>
     <string name="relays">Relay</string>
     <string name="relaying">Chức năng relay</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Cho phép thiết bị bạn trở thành một nút relay (không phải nút cuối)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -113,7 +113,6 @@
     <string name="pref_torrc_dialog">Torrc tùy chỉnh</string>
     <string name="bridges_updated">Bridge được cập nhật</string>
     <string name="restart_orbot_to_use_this_bridge_">Vui lòng khởi động lại Orbot để áp dụng thay đổi</string>
-    <string name="menu_qr">Mã QR</string>
     <string name="get_bridges_email">Email</string>
     <string name="send_email">Gửi email</string>
     <string name="save">Lưu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -66,8 +66,6 @@
     <string name="use_only_these_specified_nodes">仅使用这些指定节点</string>
     <string name="bridges">网桥</string>
     <string name="use_bridges">使用网桥</string>
-    <string name="ip_address_and_port_of_bridges">网桥的 IP 地址和端口</string>
-    <string name="enter_bridge_addresses">输入网桥地址</string>
     <string name="relays">中继</string>
     <string name="relaying">中继转发</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">使您的设备成为非出口中继</string>
@@ -185,7 +183,6 @@
     <string name="title_activity_hidden_services">洋葱服务</string>
     <string name="hidden_services">洋葱服务</string>
     <string name="hidden_service_request">一个应用程序想要打开洋葱服务器%1$s端口到Tor网络。如果你信任这个应用程序，这是安全的。</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">启用进入Tor网络的备用入口</string>
     <string name="pref_connection_padding">连接填充</string>
     <string name="hosted_services">托管的服务</string>
     <string name="onion">.onion 地址</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -113,7 +113,6 @@
     <string name="pref_torrc_dialog">自定义 Torrc</string>
     <string name="bridges_updated">网桥已更新</string>
     <string name="restart_orbot_to_use_this_bridge_">请重启 Orbot 以使变更生效</string>
-    <string name="menu_qr">QR码</string>
     <string name="get_bridges_email">电子邮件</string>
     <string name="apps_mode">VPN 模式</string>
     <string name="send_email">发送电子邮件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -117,8 +117,7 @@
   <string name="pref_torrc_dialog">自訂 Torrc</string>
   <string name="bridges_updated">網橋已更新</string>
   <string name="restart_orbot_to_use_this_bridge_">請重新啟動 Orbot 來讓設定生效。</string>
-  <string name="menu_qr">QR 碼</string>
-  <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">如果行動網路主動地封鎖 Tor 可以使用\"橋接伺服器\"作為替代方式.選擇一個選項作設定和測試</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">如果行動網路主動地封鎖 Tor 可以使用\"橋接伺服器\"作為替代方式.選擇一個選項作設定和測試</string>
   <string name="get_bridges_email">Email</string>
   <string name="apps_mode">VPN 模式</string>
     <string name="send_email">寄送電子信件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -67,9 +67,6 @@
   <string name="use_only_these_specified_nodes">｢只｣使用這些節點</string>
   <string name="bridges">網橋（Bridges）</string>
   <string name="use_bridges">使用網橋</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">啟動替代的入口來進入 Tor 網路</string>
-    <string name="ip_address_and_port_of_bridges">網橋的 IP 位址與連接埠</string>
-  <string name="enter_bridge_addresses">輸入網橋位址</string>
   <string name="relays">中繼（Relays）</string>
   <string name="relaying">中繼設定</string>
   <string name="enable_your_device_to_be_a_non_exit_relay">啟用您的裝置成為 Tor 網路的中繼節點（非出口節點）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,9 +75,6 @@
     <string name="use_only_these_specified_nodes">Use *only* these specified nodes</string>
     <string name="bridges">Bridges</string>
     <string name="use_bridges">Use Bridges</string>
-    <string name="enable_alternate_entrance_nodes_into_the_tor_network">Enable alternate entrances into the Tor Network</string>
-    <string name="ip_address_and_port_of_bridges">IP address and port of bridges</string>
-    <string name="enter_bridge_addresses">Enter Bridge Addresses</string>
     <string name="relays">Relays</string>
     <string name="relaying">Relaying</string>
     <string name="enable_your_device_to_be_a_non_exit_relay">Enable your device to be a non-exit relay</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,8 +151,6 @@
 
     <string name="restart_orbot_to_use_this_bridge_">Please restart Orbot to enable the changes</string>
 
-    <string name="menu_qr">QR Codes</string>
-
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">If your mobile network actively blocks Tor, you can use a \'Bridge Server\' as an alternate way in. SELECT one of the options to configure and test…</string>
 
     <string name="get_bridges_email">Email</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -116,22 +116,6 @@
             android:title="@string/strict_nodes" />
 
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/bridges">
-
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="pref_bridges_enabled"
-            android:summary="@string/enable_alternate_entrance_nodes_into_the_tor_network"
-            android:title="@string/use_bridges" />
-
-        <EditTextPreference
-            android:dialogTitle="@string/enter_bridge_addresses"
-            android:inputType="textMultiLine|textNoSuggestions"
-            android:key="pref_bridges_list"
-            android:summary="@string/ip_address_and_port_of_bridges"
-            android:title="@string/bridges" />
-
-    </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/relays">
         <CheckBoxPreference


### PR DESCRIPTION
It's confusing to have two ways of editing bridges, with the "Custom bridge" wizard in the app it makes more sense to use that (also less resources to localize) 