### PR TITLE
Bandwidth Stat Bug Fixes

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -158,16 +158,16 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
                     break;
                 }
                 case TorServiceConstants.LOCAL_ACTION_BANDWIDTH: {
-                    long upload = intent.getLongExtra("up", 0);
-                    long download = intent.getLongExtra("down", 0);
-                    long written = intent.getLongExtra("written", 0);
-                    long read = intent.getLongExtra("read", 0);
+                    long totalWritten = intent.getLongExtra("totalWritten", 0);
+                    long totalRead = intent.getLongExtra("totalRead", 0);
+                    long lastWritten = intent.getLongExtra("lastWritten", 0);
+                    long lastRead = intent.getLongExtra("lastRead", 0);
 
                     Message msg = mStatusUpdateHandler.obtainMessage(MESSAGE_TRAFFIC_COUNT);
-                    msg.getData().putLong("download", download);
-                    msg.getData().putLong("upload", upload);
-                    msg.getData().putLong("readTotal", read);
-                    msg.getData().putLong("writeTotal", written);
+                    msg.getData().putLong("lastRead", lastRead);
+                    msg.getData().putLong("lastWritten", lastWritten);
+                    msg.getData().putLong("totalWritten", totalWritten);
+                    msg.getData().putLong("totalRead", totalRead);
                     msg.getData().putString("status", intent.getStringExtra(TorServiceConstants.EXTRA_STATUS));
 
                     mStatusUpdateHandler.sendMessage(msg);
@@ -1174,12 +1174,12 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
 
             switch (msg.what) {
                 case MESSAGE_TRAFFIC_COUNT:
-                    long upload = data.getLong("upload");
-                    long download = data.getLong("download");
-                    long totalRead = data.getLong("readTotal");
-                    long totalWrite = data.getLong("writeTotal");
-                    oma.downloadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, download), oma.formatTotal(totalRead)));
-                    oma.uploadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, upload), oma.formatTotal(totalWrite)));
+                    long lastWritten = data.getLong("lastWritten");
+                    long lastRead = data.getLong("lastRead");
+                    long totalRead = data.getLong("totalRead");
+                    long totalWrite = data.getLong("totalWritten");
+                    oma.downloadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, lastRead), oma.formatTotal(totalRead)));
+                    oma.uploadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, lastWritten), oma.formatTotal(totalWrite)));
                     break;
 
                 case MESSAGE_PORTS:

--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -339,7 +339,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
     }
 
     private void resetBandwidthStatTextviews() {
-        String zero = String.format("%s / %s", formatCount(0), formatTotal(0));
+        String zero = String.format("%s / %s", OrbotService.formatBandwidthCount(this, 0), formatTotal(0));
         downloadText.setText(zero);
         uploadText.setText(zero);
     }
@@ -1026,20 +1026,6 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mLocalBroadcastReceiver);
     }
 
-    private String formatCount(long count) {
-        NumberFormat numberFormat = NumberFormat.getInstance(Locale.getDefault());
-        // Converts the supplied argument into a string.
-        // Under 2 mebibytes, returns "xxx.xKiB/s"
-        // Over 2 mebibytes, returns "xxx.xxMiB/s"
-        if (count < 1e6)
-            return numberFormat.format(Math.round(((float) ((int) (count * 10 / 1024)) / 10)))
-                    + getString(R.string.kibibyte_per_second);
-        else
-            return numberFormat.format(Math
-                    .round(((float) ((int) (count * 100 / 1024 / 1024)) / 100)))
-                    + getString(R.string.mebibyte_per_second);
-    }
-
     private String formatTotal(long count) {
         NumberFormat numberFormat = NumberFormat.getInstance(Locale.getDefault());
         // Converts the supplied argument into a string.
@@ -1192,8 +1178,8 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
                     long download = data.getLong("download");
                     long totalRead = data.getLong("readTotal");
                     long totalWrite = data.getLong("writeTotal");
-                    oma.downloadText.setText(String.format("%s / %s", oma.formatCount(download), oma.formatTotal(totalRead)));
-                    oma.uploadText.setText(String.format("%s / %s", oma.formatCount(upload), oma.formatTotal(totalWrite)));
+                    oma.downloadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, download), oma.formatTotal(totalRead)));
+                    oma.uploadText.setText(String.format("%s / %s", OrbotService.formatBandwidthCount(oma, upload), oma.formatTotal(totalWrite)));
                     break;
 
                 case MESSAGE_PORTS:

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -191,6 +191,4 @@
     <string name="confirm">Bestätigen</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -208,8 +208,6 @@
     <string name="pref_circuit_padding">Bourrage du circuit</string>
     <string name="mebibyte">Mio</string>
     <string name="kibibyte">Kio</string>
-    <string name="mebibyte_per_second">Mio/s</string>
-    <string name="kibibyte_per_second">Kio/s</string>
     <string name="get_bridges_email_request">Demander des ponts par courriel</string>
     <string name="be_a_snowflake_desc">Autorisez les autres utilisateurs de Tor de se connecter à Tor par votre appareil</string>
     <string name="be_a_snowflake_title">Exécuter le mandataire Snowflake</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -209,8 +209,6 @@
     <string name="testing_tor_direct">Prófa tengingu við Tor…</string>
     <string name="get_bridges_email_request">Biðja um brýr með tölvupósti</string>
     <string name="mebibyte">MiB</string>
-    <string name="mebibyte_per_second">MiB/sek</string>
-    <string name="kibibyte_per_second">KiB/sek</string>
     <string name="be_a_snowflake_desc">Leyfa öðrum Tor-notendum að tengjast Tor í gegnum tækið þitt</string>
     <string name="be_a_snowflake_title">Keyra Snowflake-milliþjón</string>
     <string name="backup_port_exist">Villa: Önnur onion-þjónusta er þegar að nota gátt %s</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -209,8 +209,6 @@
     <string name="get_bridges_email_request">Forespør broer via e-post</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="confirm">Bekreft</string>
     <string name="deny">Nekt</string>
     <string name="allow">Tillat</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -209,8 +209,6 @@
     <string name="get_bridges_email_request">Solicite Pontes através do E-mail</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="be_a_snowflake_desc">Permita que os outros usuários do Tor se conectem ao Tor através do seu dispositivo</string>
     <string name="be_a_snowflake_title">Execute o proxy Snowflake</string>
     <string name="confirm">Confirme</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -225,8 +225,6 @@
     <string name="get_bridges_email_request">Solicite Pontes através do E-mail</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="deny">Negue</string>
     <string name="allow">Permita</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -225,8 +225,6 @@
     <string name="get_bridges_email_request">Solicite Pontes através do E-mail</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="deny">Negue</string>
     <string name="allow">Permita</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -209,8 +209,6 @@
     <string name="get_bridges_email_request">Köprüleri E-postayla İste</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="be_a_snowflake_desc">Diğer Tor kullanıcılarının aygıtınız üzerinden Tor\'a bağlanmasına izin verin</string>
     <string name="be_a_snowflake_title">Snowflake Vekil Sunucusu Çalıştır</string>
     <string name="confirm">Onayla</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -205,8 +205,6 @@
     <string name="get_bridges_email_request">Запитувати мости електронною поштою</string>
     <string name="mebibyte">МіБ</string>
     <string name="kibibyte">КіБ</string>
-    <string name="mebibyte_per_second">МіБ/с</string>
-    <string name="kibibyte_per_second">КіБ/с</string>
     <string name="pref_reduced_circuit_padding_summary">Використання нижчих накладних алгоритмів заповнення для скорочення використання даних і акумулятора</string>
     <string name="pref_reduced_circuit_padding">Скорочене заповнення ланцюжка</string>
     <string name="pref_circuit_padding_summary">Увімкнути заповнення ланцюжка для захисту від деяких форм аналізу трафіку</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -204,8 +204,6 @@
     <string name="v2_hidden_services">Dịch vụ Onion v2 (Không được hỗ trợ nữa)</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/s</string>
-    <string name="kibibyte_per_second">KiB/s</string>
     <string name="refresh_apps">Làm mới các ứng dụng</string>
     <string name="default_socks_http">SOCKS: - HTTP: -</string>
     <string name="app_services">Dịch vụ ứng dụng</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -209,8 +209,6 @@
     <string name="get_bridges_email_request">通过电子邮件请求网桥</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="mebibyte_per_second">MiB/秒</string>
-    <string name="kibibyte_per_second">KiB/秒</string>
     <string name="be_a_snowflake_desc">允许其他 Tor 用户通过你的设备连接到 Tor</string>
     <string name="be_a_snowflake_title">运行 Snowflake 代理</string>
     <string name="confirm">确认</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,8 +144,6 @@
     <string name="pref_torrc_dialog">Custom Torrc</string>
 
 
-    <string name="kibibyte_per_second">KiB/s</string>
-    <string name="mebibyte_per_second">MiB/s</string>
     <string name="kibibyte">KiB</string>
     <string name="mebibyte">MiB</string>
 

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -60,10 +60,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -1186,6 +1188,16 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         }
 
         return extraLines;
+    }
+
+    public static String formatBandwidthCount(Context context, long bitsPerSecond) {
+        NumberFormat nf = NumberFormat.getInstance(Locale.getDefault());
+        if (bitsPerSecond < 1e6)
+            return nf.format(Math.round(((float) ((int) (bitsPerSecond * 10 / 1024)) / 10)))
+                    + context.getString(R.string.kibibyte_per_second);
+        else
+            return nf.format(Math.round(((float) ((int) (bitsPerSecond * 100 / 1024 / 1024)) / 100)))
+                    + context.getString(R.string.mebibyte_per_second);
     }
 
     private void addV3OnionServicesToTorrc(StringBuffer torrc, ContentResolver contentResolver) {

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -986,13 +986,13 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         }
     }
 
-    protected void sendCallbackBandwidth(long upload, long download, long written, long read) {
+    protected void sendCallbackBandwidth(long lastWritten, long lastRead, long totalWritten, long totalRead) {
         Intent intent = new Intent(LOCAL_ACTION_BANDWIDTH);
 
-        intent.putExtra("up", upload);
-        intent.putExtra("down", download);
-        intent.putExtra("written", written);
-        intent.putExtra("read", read);
+        intent.putExtra("totalWritten", totalWritten);
+        intent.putExtra("totalRead", totalRead);
+        intent.putExtra("lastWritten", lastWritten);
+        intent.putExtra("lastRead", lastRead);
         intent.putExtra(EXTRA_STATUS, mCurrentStatus);
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);

--- a/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
@@ -1,7 +1,6 @@
 package org.torproject.android.service;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import net.freehaven.tor.control.EventHandler;
 
@@ -35,7 +34,6 @@ public class TorEventHandler implements EventHandler, TorServiceConstants {
 
     @Override
     public void message(String severity, String msg) {
-        Log.d("bim", "message: " + msg);
         if (severity.equalsIgnoreCase("debug"))
             mService.debug(severity + ": " + msg);
         else
@@ -90,18 +88,14 @@ public class TorEventHandler implements EventHandler, TorServiceConstants {
             if (read > 0 || written > 0)
                 iconId = R.drawable.ic_stat_tor_xfer;
 
-            String sb = OrbotService.formatBandwidthCount(mService, read) +
-                    " \u2193" +
-                    " / " +
-                    OrbotService.formatBandwidthCount(mService, written) +
-                    " \u2191";
-            Log.d("bim", "bandWidthUsed " + read + ", " + written);
+            String sb = OrbotService.formatBandwidthCount(mService, read) + " \u2193" + " / " +
+                    OrbotService.formatBandwidthCount(mService, written) + " \u2191";
             mService.showToolbarNotification(sb, OrbotService.NOTIFY_ID, iconId);
 
             mTotalTrafficWritten += written;
             mTotalTrafficRead += read;
 
-            mService.sendCallbackBandwidth(lastWritten, lastRead, mTotalTrafficWritten, mTotalTrafficRead);
+            mService.sendCallbackBandwidth(written, read, mTotalTrafficWritten, mTotalTrafficRead);
 
             lastWritten = 0;
             lastRead = 0;

--- a/orbotservice/src/main/res/values-de/strings.xml
+++ b/orbotservice/src/main/res/values-de/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">Tor kann nicht gestartet werden:</string>
     <string name="newnym">Sie haben zu einer neuen Tor-Identität gewechselt!</string>
     <string name="updating_settings_in_tor_service">Einstellungen im Tor-Dienst werden aktualisiert</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-fr-rFR/strings.xml
+++ b/orbotservice/src/main/res/values-fr-rFR/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">Impossible de démarrer Tor :</string>
     <string name="newnym">Vous avez basculé vers une nouvelle identité Tor !</string>
     <string name="updating_settings_in_tor_service">mise à jour des paramètres dans le service Tor</string>
+  <string name="mebibyte_per_second">Mio/s</string>
+  <string name="kibibyte_per_second">Kio/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-is/strings.xml
+++ b/orbotservice/src/main/res/values-is/strings.xml
@@ -22,4 +22,7 @@
   <string name="unable_to_start_tor">Get ekki kveikt á Tor:</string>
     <string name="newnym">Þú ert komin með nýtt Tor auðkenni!</string>
     <string name="updating_settings_in_tor_service">uppfæri stillingar í Tor þjónustu</string>
+
+  <string name="mebibyte_per_second">MiB/sek</string>
+  <string name="kibibyte_per_second">KiB/sek</string>
 </resources>

--- a/orbotservice/src/main/res/values-nb/strings.xml
+++ b/orbotservice/src/main/res/values-nb/strings.xml
@@ -22,4 +22,6 @@
   <string name="unable_to_start_tor">Klarte ikke å starte Tor:</string>
     <string name="newnym">Du har byttet til en ny Tor-identitet!</string>
     <string name="updating_settings_in_tor_service">Oppdaterer innstillinger i Tor service</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-pt-rBR/strings.xml
+++ b/orbotservice/src/main/res/values-pt-rBR/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">Habilitar iniciar o Tor:</string>
     <string name="newnym">Você trocou para uma nova identidade Tor!</string>
     <string name="updating_settings_in_tor_service">atualizando configurações no serviço Tor</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-pt-rPT/strings.xml
+++ b/orbotservice/src/main/res/values-pt-rPT/strings.xml
@@ -9,4 +9,7 @@
   <!--Permissions screen-->
   <!--TipsAndTricks screen-->
   <!--Transparent Proxy screen-->
+
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-pt/strings.xml
+++ b/orbotservice/src/main/res/values-pt/strings.xml
@@ -19,4 +19,6 @@
   <string name="unable_to_start_tor">Não é possível iniciar o Tor:</string>
     <string name="newnym">Mudou para uma nova identidade do Tor!</string>
     <string name="updating_settings_in_tor_service">a atualizar as definições no serviço Tor</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-tr/strings.xml
+++ b/orbotservice/src/main/res/values-tr/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">Tor başlatılamadı:</string>
     <string name="newnym">Yeni bir Tor kimliğine geçiş yaptınız!</string>
     <string name="updating_settings_in_tor_service">Tor hizmet ayarları güncellemesi</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-uk/strings.xml
+++ b/orbotservice/src/main/res/values-uk/strings.xml
@@ -22,4 +22,6 @@
   <string name="unable_to_start_tor">Неможливо запустити Tor:</string>
     <string name="newnym">Ви перемкнулись на новий ідентифікатор Tor!</string>
     <string name="updating_settings_in_tor_service">оновлення налаштувань у сервісі Tor</string>
+  <string name="mebibyte_per_second">МіБ/с</string>
+  <string name="kibibyte_per_second">КіБ/с</string>
 </resources>

--- a/orbotservice/src/main/res/values-vi/strings.xml
+++ b/orbotservice/src/main/res/values-vi/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">Không thể khởi động Tor được: </string>
     <string name="newnym">Bạn đã chuyển sang một mạch Tor mới!</string>
     <string name="updating_settings_in_tor_service">đang cập nhật cài đặt dịch vụ Tor</string>
+  <string name="mebibyte_per_second">MiB/s</string>
+  <string name="kibibyte_per_second">KiB/s</string>
 </resources>

--- a/orbotservice/src/main/res/values-zh-rCN/strings.xml
+++ b/orbotservice/src/main/res/values-zh-rCN/strings.xml
@@ -23,4 +23,6 @@
   <string name="unable_to_start_tor">无法启动 Tor：</string>
     <string name="newnym">已切换为新的 Tor 标识！</string>
     <string name="updating_settings_in_tor_service">正在更新 Tor 服务中的设置</string>
+  <string name="mebibyte_per_second">MiB/秒</string>
+  <string name="kibibyte_per_second">KiB/秒</string>
 </resources>

--- a/orbotservice/src/main/res/values/strings.xml
+++ b/orbotservice/src/main/res/values/strings.xml
@@ -22,4 +22,9 @@
     <string name="menu_new_identity">New Identity</string>
     <string name="waiting_for_control_port">Waiting for control port...</string>
     <string name="connecting_to_control_port">Connecting to control port:</string>
+
+    <string name="kibibyte_per_second">KiB/s</string>
+    <string name="mebibyte_per_second">MiB/s</string>
+
 </resources>
+


### PR DESCRIPTION
- all data per second string formatting is centralized (and open to more localization) in the service
- bandwidth data was **not** propagated to the app UI correctly. was only ever accurate in the service 
- the bandwidth text in the notification was formatted correctly (but accurate) 