### PR TITLE
Use only a single Snowflake at a time

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -369,7 +369,7 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         String stunServer = getCdnFront("snowflake-stun");
 
         IPtProxy.startSnowflake(stunServer, target, front,
-                 null, true, false, true, 3);
+                 null, true, false, true, 1);
 
     }
 


### PR DESCRIPTION
Right now Snowflake can't send client traffic over more than one
Snowlake and maintaining a collection of 3 unecessarily increases
network traffic for the client and places load on the Snowflake network.

This is especially hard on the network since many mobile clients have symmetric NATs and those proxies are in high demand. We'll send out an announcement or notify you if this changes and you can track our progress on the multiple snowflake feature here: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/issues/25723