### PR TITLE
Build pdnsd as shared library

### DIFF
--- a/orbotservice/src/main/jni/Android.mk
+++ b/orbotservice/src/main/jni/Android.mk
@@ -30,7 +30,7 @@ LOCAL_SRC_FILES := $(PDNSD_SOURCES:$(LOCAL_PATH)/%=%)
 LOCAL_CFLAGS    := -Wall -O2 -I$(LOCAL_PATH)/pdnsd -DHAVE_STPCPY
 
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_LIBRARY)
 
 ########################################################
 ## libancillary


### PR DESCRIPTION
The pdnsd executable must be in the form of libpdnsd.so,
otherwise, it is not included in the apk files.