### PR TITLE
Actually enable AvoidDiskWrites (again)

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -536,7 +536,7 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         extraLines.append("\n");
 
         extraLines.append("RunAsDaemon 0").append('\n');
-        extraLines.append("AvoidDiskWrites 0").append('\n');
+        extraLines.append("AvoidDiskWrites 1").append('\n');
 
         String socksPortPref = prefs.getString(OrbotConstants.PREF_SOCKS, (TorServiceConstants.SOCKS_PROXY_PORT_DEFAULT));
 


### PR DESCRIPTION
Added in 18682e4b974b0dff0120c9ae48cadb597387925f
Enabled in 410ae032564e0a57b3df20391b7023085087d628
Disabled in e78c27bfb0db5cf7e4ea18ff23645e432bd00224
Enabled in 74fce069df64b5cd35003c8bad75cc0f0a2622d2
Disabled in d6ebcd7ef7771fa0ef42e3b7271e131eec246c69

Why has this not just been left on? If it is useful for debugging, put it behind a variable maybe?