### PR TITLE
Create only one pdnsd config file

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -92,7 +92,7 @@ public class OrbotVpnManager implements Handler.Callback {
 
         Log.d(TAG, "pdsnd conf:" + conf);
 
-        File fPid = new File(fileDir, pdnsdPort + "pdnsd.conf");
+        File fPid = new File(fileDir, "pdnsd.conf");
 
         if (fPid.exists()) {
             fPid.delete();


### PR DESCRIPTION
A new pdnsd config file is created each time the vpn is started.  This
creates a lot of unnecessary config files.  Lets just update the latest
config file and overwrite the previous one.