### PR TITLE
Only enable pdnsd debug output when debug logging is enabled

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -79,16 +79,18 @@ public class OrbotVpnManager implements Handler.Callback {
     private final File filePdnsd;
     private boolean isRestart = false;
     private final VpnService mService;
+    private final SharedPreferences prefs;
 
     public OrbotVpnManager(VpnService service) {
         mService = service;
+        prefs = Prefs.getSharedPrefs(mService.getApplicationContext());
         filePdnsd = CustomNativeLoader.loadNativeBinary(service.getApplicationContext(), PDNSD_BIN, new File(service.getFilesDir(), PDNSD_BIN));
         Tun2Socks.init();
     }
 
-    public static File makePdnsdConf(Context context, File fileDir, String torDnsHost, int torDnsPort, String pdnsdHost, int pdnsdPort) throws IOException {
+    public static File makePdnsdConf(Context context, File fileDir, String torDnsHost, int torDnsPort, String pdnsdHost, int pdnsdPort, String pdnsdDebug) throws IOException {
         String conf = String.format(context.getString(R.string.pdnsd_conf),
-                torDnsHost, torDnsPort, fileDir.getAbsolutePath(), pdnsdHost, pdnsdPort);
+                torDnsHost, torDnsPort, fileDir.getAbsolutePath(), pdnsdHost, pdnsdPort, pdnsdDebug);
 
         Log.d(TAG, "pdsnd conf:" + conf);
 
@@ -335,7 +337,6 @@ public class OrbotVpnManager implements Handler.Callback {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void doLollipopAppRouting(VpnService.Builder builder) throws NameNotFoundException {
-        SharedPreferences prefs = Prefs.getSharedPrefs(mService.getApplicationContext());
         ArrayList<TorifiedApp> apps = TorifiedApp.getApps(mService, prefs);
 
 
@@ -360,10 +361,16 @@ public class OrbotVpnManager implements Handler.Callback {
     }
 
     private void startDNS(String pdnsPath, String torDnsHost, int torDnsPort, String pdnsdHost, int pdnsdPort) throws IOException, TimeoutException {
+        String debugEnabledCmd = "";
+        String debugEnabledConf = "off";
+        if (prefs.getBoolean(PREF_ENABLE_LOGGING, false)) {
+            debugEnabledCmd = "-g";
+            debugEnabledConf = "on";
+        }
 
-        File fileConf = makePdnsdConf(mService, mService.getFilesDir(), torDnsHost, torDnsPort, pdnsdHost, pdnsdPort);
+        File fileConf = makePdnsdConf(mService, mService.getFilesDir(), torDnsHost, torDnsPort, pdnsdHost, pdnsdPort, debugEnabledConf);
 
-        String[] cmdString = {pdnsPath, "-c", fileConf.toString(), "-g", "-v2"};
+        String[] cmdString = {pdnsPath, "-c", fileConf.toString(), debugEnabledCmd, "-v2"};
         ProcessBuilder pb = new ProcessBuilder(cmdString);
         pb.redirectErrorStream(true);
         Process proc = pb.start();

--- a/orbotservice/src/main/res/values/pdnsd.xml
+++ b/orbotservice/src/main/res/values/pdnsd.xml
@@ -12,6 +12,7 @@ global {
 	timeout=10;
 	daemon=on;
 	pid_file="%3$s/pdnsd.pid";
+	debug=%6$d;
 }
 
 server {


### PR DESCRIPTION
Addresses https://github.com/guardianproject/orbot/issues/471#issuecomment-877599989

Untested

@syphyr 
https://github.com/syphyr/orbot/commit/03b03a86183750f95f9241b07aa8a28870dea326

does `debug=off` override `-g`?