### PR TITLE
Disable pdnsd debug log

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -363,7 +363,7 @@ public class OrbotVpnManager implements Handler.Callback {
 
         File fileConf = makePdnsdConf(mService, mService.getFilesDir(), torDnsHost, torDnsPort, pdnsdHost, pdnsdPort);
 
-        String[] cmdString = {pdnsPath, "-c", fileConf.toString(), "-g", "-v2"};
+        String[] cmdString = {pdnsPath, "-c", fileConf.toString()};
         ProcessBuilder pb = new ProcessBuilder(cmdString);
         pb.redirectErrorStream(true);
         Process proc = pb.start();

--- a/orbotservice/src/main/res/values/pdnsd.xml
+++ b/orbotservice/src/main/res/values/pdnsd.xml
@@ -12,6 +12,7 @@ global {
 	timeout=10;
 	daemon=on;
 	pid_file="%3$s/pdnsd.pid";
+	debug=off;
 }
 
 server {


### PR DESCRIPTION
This output is never read by Orbot and is only accessible to those who are rooted.

Alternative and preferred option for https://github.com/guardianproject/orbot/pull/491


https://github.com/guardianproject/orbot/commit/7cd5a2884d3d2980c92b323ad3191afe48736c38#diff-72e79c1e7b70841e61823714bd77d0abd6ed1166663fea3f6969b20bad5dc5e1R420