### PR TITLE
Fix #501 - Duplicate Config Info in Build Files

### DIFF
--- a/app-mini/build.gradle
+++ b/app-mini/build.gradle
@@ -44,15 +44,3 @@ dependencies {
     )
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
 }
-
-// For each APK output variant, override version code of outputs based on ABI codes
-// ex) 'mips' -> 3xxx
-// ex) 'x86' -> 4xxx
-android.applicationVariants.all { variant ->
-    variant.outputs.each { output ->
-        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
-        if (baseVersionCode != null) {
-            output.versionCodeOverride = Integer.valueOf(baseVersionCode + variant.versionCode)
-        }
-    }
-}

--- a/app-mini/build.gradle
+++ b/app-mini/build.gradle
@@ -1,59 +1,10 @@
-apply plugin: 'com.android.application'
-
-// Create a variable called keystorePropertiesFile, and initialize it to your
-// keystore.properties file, in the rootProject folder.
-def keystorePropertiesFile = rootProject.file("keystore.properties")
-
-// Initialize a new Properties() object called keystoreProperties.
-def keystoreProperties = new Properties()
-
-// Load your keystore.properties file into the keystoreProperties object.
-if (keystorePropertiesFile.canRead()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-}
+apply from: "../commons-device.gradle"
 
 android {
-    signingConfigs {
-        release {
-            if (keystorePropertiesFile.canRead()) {
-                keyAlias keystoreProperties['keyAlias']
-                keyPassword keystoreProperties['keyPassword']
-                storeFile file(keystoreProperties['storeFile'])
-                storePassword keystoreProperties['storePassword']
-            }
-        }
-    }
-
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
     defaultConfig {
         applicationId "org.torproject.android.mini"
         minSdkVersion 16
         targetSdkVersion 30
-    }
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
-        abortOnError false
-    }
-    buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            signingConfig signingConfigs.release
-        }
-    }
-
-    aaptOptions {
-        cruncherEnabled = false
     }
 
     flavorDimensions "freemini"
@@ -70,72 +21,36 @@ android {
         }
     }
 
-    splits {
-
-        // Configures multiple APKs based on ABI. This helps keep the size down, since PT binaries can be large.
-        abi {
-
-            // Enables building multiple APKs per ABI.
-            enable true
-
-            // By default all ABIs are included, so use reset() and include to specify that we only
-            // want APKs for x86 and x86_64.
-
-            // Resets the list of ABIs that Gradle should create APKs for to none.
-            reset()
-
-            // Specifies a list of ABIs that Gradle should create APKs for.
-            include "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
-
-            // Specifies that we do not want to also generate a universal APK that includes all ABIs.
-            universalApk false
-        }
-
-    }
-
     packagingOptions {
         exclude 'lib/x86/libgojni.so'
         exclude 'lib/x86_64/libgojni.so'
         exclude 'lib/arm64-v8a/libgojni.so'
         exclude 'lib/armeabi-v7a/libgojni.so'
         exclude 'lib/armeabi/libgojni.so'
-        exclude 'META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version'
-    }
-}
-
-repositories {
-    jcenter {
-        content {
-            includeGroup('com.jraska')
-            includeGroup('tools.fastlane')
-        }
     }
 }
 
 dependencies {
-    implementation project(':orbotservice')
-    implementation 'com.github.apl-devs:appintro:v4.2.2'
-    implementation 'androidx.palette:palette:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation project(path: ':appcore')
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation project(path: ':intentintegrator')
+    implementation(
+            project(path: ':appcore'),
+            project(path: ':intentintegrator'),
+            project(':orbotservice'),
+            'androidx.constraintlayout:constraintlayout:2.1.0',
+            'androidx.coordinatorlayout:coordinatorlayout:1.1.0',
+            'androidx.recyclerview:recyclerview:1.2.1',
+            'androidx.palette:palette:1.0.0',
+            'com.github.apl-devs:appintro:v4.2.2',
+            'com.google.android.material:material:1.4.0'
+    )
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
 }
-
-// Map for the version code that gives each ABI a value.
-ext.abiCodes = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'mips': '3', 'x86': '4', 'x86_64': '5']
-
-import com.android.build.OutputFile
 
 // For each APK output variant, override version code of outputs based on ABI codes
 // ex) 'mips' -> 3xxx
 // ex) 'x86' -> 4xxx
 android.applicationVariants.all { variant ->
     variant.outputs.each { output ->
-        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
         if (baseVersionCode != null) {
             output.versionCodeOverride = Integer.valueOf(baseVersionCode + variant.versionCode)
         }

--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -1,55 +1,10 @@
-apply plugin: 'com.android.application'
-
-// Create a variable called keystorePropertiesFile, and initialize it to your
-// keystore.properties file, in the rootProject folder.
-def keystorePropertiesFile = rootProject.file("keystore.properties")
-
-// Initialize a new Properties() object called keystoreProperties.
-def keystoreProperties = new Properties()
-
-// Load your keystore.properties file into the keystoreProperties object.
-if (keystorePropertiesFile.canRead()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-}
+apply from: "../commons-limited-device.gradle"
 
 android {
-    signingConfigs {
-        release {
-            if (keystorePropertiesFile.canRead()) {
-                keyAlias keystoreProperties['keyAlias']
-                keyPassword keystoreProperties['keyPassword']
-                storeFile file(keystoreProperties['storeFile'])
-                storePassword keystoreProperties['storePassword']
-            }
-        }
-    }
-
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
     defaultConfig {
         applicationId "org.torproject.android.tv"
         minSdkVersion 23 
         targetSdkVersion 29
-    }
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
-        abortOnError false
-    }
-    buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            signingConfig signingConfigs.release
-        }
     }
 
     aaptOptions {
@@ -70,89 +25,42 @@ android {
         }
     }
 
-    splits {
-
-        // Configures multiple APKs based on ABI. This helps keep the size down, since PT binaries can be large.
-        abi {
-
-            // Enables building multiple APKs per ABI.
-            enable true
-
-            // By default all ABIs are included, so use reset() and include to specify that we only
-            // want APKs for x86 and x86_64.
-
-            // Resets the list of ABIs that Gradle should create APKs for to none.
-            reset()
-
-            // Specifies a list of ABIs that Gradle should create APKs for.
-            include "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
-
-            // Specifies that we do not want to also generate a universal APK that includes all ABIs.
-            universalApk false
-        }
-
-    }
-
     packagingOptions {
         exclude 'lib/x86/obfs4proxy.so'
         exclude 'lib/x86_64/obfs4proxy.so'
         exclude 'lib/arm64-v8a/obfs4proxy.so'
         exclude 'lib/armeabi-v7a/obfs4proxy.so'
         exclude 'lib/armeabi/obfs4proxy.so'
-        exclude 'META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version'
-    }
-}
-
-repositories {
-    jcenter {
-        content {
-            includeGroup('com.jraska')
-            includeGroup('tools.fastlane')
-        }
     }
 }
 
 dependencies {
-    implementation project(':orbotservice')
-    implementation 'com.github.apl-devs:appintro:v4.2.2'
-    implementation 'androidx.palette:palette:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation project(path: ':appcore')
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation project(path: ':intentintegrator')
+    implementation(
+            project(path: ':appcore'),
+            project(path: ':intentintegrator'),
+            project(':orbotservice'),
+            'androidx.constraintlayout:constraintlayout:2.1.0',
+            'androidx.coordinatorlayout:coordinatorlayout:1.1.0',
+            "androidx.leanback:leanback:1.2.0-alpha01",
+            "androidx.leanback:leanback-paging:1.1.0-alpha08",
+            "androidx.leanback:leanback-preference:1.2.0-alpha01",
+            "androidx.leanback:leanback-tab:1.1.0-beta01",
+            'androidx.palette:palette:1.0.0',
+            'androidx.recyclerview:recyclerview:1.2.1',
+            'com.github.apl-devs:appintro:v4.2.2',
+            'com.github.jetradarmobile:android-snowfall:1.2.1',
+            'com.google.android.material:material:1.4.0'
+    )
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
 
-    def leanback_version = "1.1.0-rc01"
-
-    implementation "androidx.leanback:leanback:$leanback_version"
-
-    // leanback-preference is an add-on that provides a settings UI for TV apps.
-    implementation "androidx.leanback:leanback-preference:$leanback_version"
-
-    // leanback-paging is an add-on that simplifies adding paging support to a RecyclerView Adapter.
-    implementation "androidx.leanback:leanback-paging:1.1.0-alpha07"
-
-    // leanback-tab is an add-on that provides customized TabLayout to be used as the top navigation bar.
-    implementation "androidx.leanback:leanback-tab:1.1.0-beta01"
-
-    //add snowflake fun
-    implementation 'com.github.jetradarmobile:android-snowfall:1.2.1'
-
 }
-
-// Map for the version code that gives each ABI a value.
-ext.abiCodes = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'mips': '3', 'x86': '4', 'x86_64': '5']
-
-import com.android.build.OutputFile
 
 // For each APK output variant, override version code of outputs based on ABI codes
 // ex) 'mips' -> 3xxx
 // ex) 'x86' -> 4xxx
 android.applicationVariants.all { variant ->
     variant.outputs.each { output ->
-        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
         if (baseVersionCode != null) {
             output.versionCodeOverride = Integer.valueOf(baseVersionCode + variant.versionCode)
         }

--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -54,15 +54,3 @@ dependencies {
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
 
 }
-
-// For each APK output variant, override version code of outputs based on ABI codes
-// ex) 'mips' -> 3xxx
-// ex) 'x86' -> 4xxx
-android.applicationVariants.all { variant ->
-    variant.outputs.each { output ->
-        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
-        if (baseVersionCode != null) {
-            output.versionCodeOverride = Integer.valueOf(baseVersionCode + variant.versionCode)
-        }
-    }
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,12 @@ android {
             archivesBaseName = "Orbot-$versionName"
         }
     }
+
+    splits {
+        abi {
+            universalApk true
+        }
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,76 +1,23 @@
-apply plugin: 'com.android.application'
-
-
-// Create a variable called keystorePropertiesFile, and initialize it to your
-// keystore.properties file, in the rootProject folder.
-def keystorePropertiesFile = rootProject.file("keystore.properties")
-
-// Initialize a new Properties() object called keystoreProperties.
-def keystoreProperties = new Properties()
-
-// Load your keystore.properties file into the keystoreProperties object.
-if (keystorePropertiesFile.canRead()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-}
-
-/* gets the version name from the latest Git tag, stripping the leading v off */
-def getVersionName = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags', '--always'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
+apply from: "../commons-device.gradle"
 
 android {
-    signingConfigs {
-        release {
-            if (keystorePropertiesFile.canRead()) {
-                keyAlias keystoreProperties['keyAlias']
-                keyPassword keystoreProperties['keyPassword']
-                storeFile file(keystoreProperties['storeFile'])
-                storePassword keystoreProperties['storePassword']
-            }
-        }
-    }
-
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
     defaultConfig {
         applicationId "org.torproject.android"
         versionName getVersionName()
         minSdkVersion 16
         targetSdkVersion 30
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    aaptOptions {
-        cruncherEnabled = false
-    }
     lintOptions {
-        checkReleaseBuilds false
-        abortOnError false
-
         htmlReport true
         xmlReport false
         textReport false
-
         lintConfig file("../lint.xml")
     }
     buildTypes {
         release {
             minifyEnabled false
             shrinkResources false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            signingConfig signingConfigs.release
         }
-    }
-
-    aaptOptions {
-        cruncherEnabled = false
     }
 
     flavorDimensions "free"
@@ -88,60 +35,23 @@ android {
             archivesBaseName = "Orbot-$versionName"
         }
     }
-
-    splits {
-
-        // Configures multiple APKs based on ABI. This helps keep the size down, since PT binaries can be large.
-        abi {
-
-            // Enables building multiple APKs per ABI.
-            enable true
-
-            // By default all ABIs are included, so use reset() and include to specify that we only
-            // want APKs for x86 and x86_64.
-
-            // Resets the list of ABIs that Gradle should create APKs for to none.
-            reset()
-
-            // Specifies a list of ABIs that Gradle should create APKs for.
-            include "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
-
-            // Specifies that we do not want to also generate a universal APK that includes all ABIs.
-            universalApk true
-        }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version'
-    }
-}
-
-repositories {
-    jcenter {
-        content {
-            includeGroup('com.jraska')
-            includeGroup('tools.fastlane')
-        }
-    }
 }
 
 dependencies {
-    implementation project(':orbotservice')
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'pl.bclogic:pulsator4droid:1.0.3'
-    implementation 'com.github.apl-devs:appintro:v4.2.2'
-    implementation project(path: ':appcore')
-    implementation project(path: ':intentintegrator')
+    implementation(
+            project(path: ':appcore'),
+            project(path: ':intentintegrator'),
+            project(':orbotservice'),
+            'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0',
+            'com.android.volley:volley:1.2.0',
+            'com.github.apl-devs:appintro:v4.2.2',
+            'com.github.jetradarmobile:android-snowfall:1.2.1',
+            'com.github.tladesignz:IPtProxy:1.0.0',
+            'com.google.android.material:material:1.4.0',
+            'pl.bclogic:pulsator4droid:1.0.3'
+    )
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'com.android.volley:volley:1.2.0'
-    implementation 'com.github.tladesignz:IPtProxy:1.0.0'
-
-    implementation 'com.github.jetradarmobile:android-snowfall:1.2.1'
 }
-
-// Map for the version code that gives each ABI a value.
-ext.abiCodes = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'mips': '3', 'x86': '4', 'x86_64': '5']
 
 // For each APK output variant, override version code of outputs based on ABI codes
 // ex) 'mips' -> 3xxx

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,15 +52,3 @@ dependencies {
     )
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
 }
-
-// For each APK output variant, override version code of outputs based on ABI codes
-// ex) 'mips' -> 3xxx
-// ex) 'x86' -> 4xxx
-android.applicationVariants.all { variant ->
-    variant.outputs.each { output ->
-        def baseVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
-        if (baseVersionCode != null) {
-            output.versionCodeOverride = Integer.valueOf(variant.versionCode) + Integer.valueOf(baseVersionCode)
-        }
-    }
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,15 @@
 apply from: "../commons-device.gradle"
 
+/* gets the version name from the latest Git tag, stripping the leading v off */
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     defaultConfig {
         applicationId "org.torproject.android"

--- a/appcore/build.gradle
+++ b/appcore/build.gradle
@@ -1,16 +1,14 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'kotlin-android-extensions'
+}
+apply from: "../commons.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,19 +20,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.5.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation project(path: ':orbotservice')
+    implementation(
+            project(path: ':orbotservice'),
+            "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version",
+            'androidx.core:core-ktx:1.6.0',
+            'androidx.appcompat:appcompat:1.3.1'
+    )
+    androidTestImplementation (
+        'androidx.test.ext:junit:1.1.3',
+        'androidx.test.espresso:espresso-core:3.4.0'
+    )
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.4.32'
+        kotlin_version = '1.5.20'
+        palette_version = "1.0.0"
     }
     repositories {
         mavenCentral()
@@ -9,7 +10,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -45,7 +45,6 @@ android {
             enable true
             reset()
             include "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
-            universalApk false
         }
     }
 

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -1,0 +1,78 @@
+/*
+    Applies across android app modules: {app, app-mini, app-tv}
+ */
+apply plugin: 'com.android.application'
+apply from: "../commons.gradle"
+
+ext.abiCodes = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'mips': '3', 'x86': '4', 'x86_64': '5']
+
+ext.createKeyStoreProperties = { ->
+    def keystorePropertiesFile = rootProject.file("keystore.properties")
+    def properties = new Properties()
+    if (keystorePropertiesFile.canRead()) {
+        properties.load(new FileInputStream(keystorePropertiesFile))
+    }
+    return properties
+}
+
+/* gets the version name from the latest Git tag, stripping the leading v off */
+ext.getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+def keystoreProperties = createKeyStoreProperties()
+
+android {
+
+    signingConfigs {
+        release {
+            if (!keystoreProperties.stringPropertyNames().isEmpty()) {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            signingConfig signingConfigs.release
+        }
+    }
+
+    lintOptions {
+        checkReleaseBuilds false
+        abortOnError false
+    }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
+            universalApk false
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version'
+    }
+}
+
+repositories {
+    jcenter {
+        content {
+            includeGroup('com.jraska')
+            includeGroup('tools.fastlane')
+        }
+    }
+}
+
+

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -4,8 +4,6 @@
 apply plugin: 'com.android.application'
 apply from: "../commons.gradle"
 
-ext.abiCodes = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'mips': '3', 'x86': '4', 'x86_64': '5']
-
 ext.createKeyStoreProperties = { ->
     def keystorePropertiesFile = rootProject.file("keystore.properties")
     def properties = new Properties()

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -15,16 +15,6 @@ ext.createKeyStoreProperties = { ->
     return properties
 }
 
-/* gets the version name from the latest Git tag, stripping the leading v off */
-ext.getVersionName = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags', '--always'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
-
 def keystoreProperties = createKeyStoreProperties()
 
 android {

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -4,16 +4,21 @@
 apply plugin: 'com.android.application'
 apply from: "../commons.gradle"
 
-ext.createKeyStoreProperties = { ->
-    def keystorePropertiesFile = rootProject.file("keystore.properties")
-    def properties = new Properties()
-    if (keystorePropertiesFile.canRead()) {
-        properties.load(new FileInputStream(keystorePropertiesFile))
-    }
-    return properties
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.canRead()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
-
-def keystoreProperties = createKeyStoreProperties()
+//Increments versionCode by ABI type
+def abiCodeMap = ['armeabi-v7a': '1', 'arm64-v8a': '2', 'x86': '4', 'x86_64': '5']
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def baseVersionCode = abiCodeMap.get(output.getFilter("ABI"))
+        if(baseVersionCode != null) {
+            output.versionCodeOverride = Integer.valueOf(variant.versionCode) + Integer.valueOf(baseVersionCode)
+        }
+    }
+}
 
 android {
 

--- a/commons-limited-device.gradle
+++ b/commons-limited-device.gradle
@@ -1,0 +1,13 @@
+/*
+    Applies across android app module with limited capabilities: {app-mini, app-tv}
+ */
+apply from: "../commons-device.gradle"
+
+android {
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+        }
+    }
+}

--- a/commons.gradle
+++ b/commons.gradle
@@ -1,0 +1,11 @@
+/*
+    Applies across all modules
+ */
+android {
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/intentintegrator/build.gradle
+++ b/intentintegrator/build.gradle
@@ -1,14 +1,10 @@
 apply plugin: 'com.android.library'
+apply from: "../commons.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
         consumerProguardFiles "consumer-rules.pro"
     }
 
@@ -18,13 +14,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 }

--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.library'
+apply from: "../commons.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
     ndkVersion '21.3.6528147'
 
     sourceSets {
@@ -15,10 +14,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -26,18 +22,14 @@ android {
         }
     }
 
-    aaptOptions {
-        cruncherEnabled = false
-    }
 
+    //Note: abortOnError turned off to lint error - needs fix
     lintOptions {
         checkReleaseBuilds false
-        abortOnError true
-
+        abortOnError false
         htmlReport true
         xmlReport false
         textReport false
-
         lintConfig file("../lint.xml")
     }
 
@@ -47,21 +39,17 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'com.gitlab.guardianproject:jsocksandroid:1.0.4'
-
-    implementation 'com.jaredrummler:android-shell:1.0.0'
-
-    implementation 'androidx.core:core:1.6.0'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    testImplementation 'junit:junit:4.13.2'
-
-    implementation 'com.offbynull.portmapper:portmapper:2.0.5'
-
-    implementation 'info.guardianproject:geoip:20191217'
-
     api 'info.guardianproject:jtorctl:0.4.5.7'
-    implementation 'info.guardianproject:tor-android:0.4.5.9'
+    implementation(
+            'androidx.core:core:1.6.0',
+            'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0',
+            'com.github.tladesignz:IPtProxy:1.0.0',
+            'com.gitlab.guardianproject:jsocksandroid:1.0.4',
+            'com.jaredrummler:android-shell:1.0.0',
+            'com.offbynull.portmapper:portmapper:2.0.5',
+            'info.guardianproject:geoip:20191217',
+            'info.guardianproject:tor-android:0.4.5.9',
 
-    implementation 'com.github.tladesignz:IPtProxy:1.0.0'
+    )
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -23,10 +23,9 @@ android {
     }
 
 
-    //Note: abortOnError turned off to lint error - needs fix
     lintOptions {
         checkReleaseBuilds false
-        abortOnError false
+        abortOnError true
         htmlReport true
         xmlReport false
         textReport false


### PR DESCRIPTION
Changes
* Upgraded gradle from 6.7.1 -> 7.0.2
* Cleaned up and reordered dependencies in lexical order
* Added the following gradle build files to remove duplication

1. commons.gradle - all projects
2. commons-device.gradle - Applies across android app modules: {app, app-mini, app-tv}
3. commons-limited-device.gradle - Applies across android app module with limited capabilities: {app-mini, app-tv}

Upgrade dependency versions

- 'androidx.core:core-ktx:1.5.0' -> 1.6.0
-  'androidx.appcompat:appcompat:1.3.0' -> 1.3.1'
- 'androidx.test.ext:junit:1.1.2' -> 1.1.3
- 'androidx.test.espresso:espresso-core:3.3.0' -> 3.4.0
- 'androidx.constraintlayout:constraintlayout:2.0.4' -> 2.1.0
- "androidx.leanback:leanback-paging:1.1.0-alpha07" -> 1.1.0-alpha08
- 'androidx.recyclerview:recyclerview:1.1.0' -> 1.2.
- 'com.google.android.material:material:1.2.1' -> 1.4.0
- kotlin: 1.4.32 -> 1.5.20
- leanback: 1.1.0-rc01 -> 1.2.0-alpha01

Build Issues
I found that the command line build on master fails on a lint error for orbotservice: I turned off abortOnError for orbotserivice n the 501 branch for now to get the build working. This will be another issue.

Verified build works in Android Studio 2020.3.1 and on command line on Mac. Ran the main app in emulator successfully. Did not test app functionality for mini or TV.
