### PR TITLE
Fix Issue #498 Missing VPN App Icons 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -15,6 +15,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
@@ -35,8 +36,10 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -62,6 +65,7 @@ import org.torproject.android.service.OrbotService;
 import org.torproject.android.service.TorServiceConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.util.Utils;
+import org.torproject.android.service.vpn.TorifiedApp;
 import org.torproject.android.service.vpn.VpnPrefs;
 import org.torproject.android.ui.AppManagerActivity;
 import org.torproject.android.ui.dialog.AboutDialogFragment;
@@ -83,8 +87,10 @@ import java.net.URLDecoder;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import pl.bclogic.pulsator4droid.library.PulsatorLayout;
 
@@ -134,9 +140,11 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
     private SwitchCompat mBtnBridges;
     private Spinner spnCountries;
     private DrawerLayout mDrawer;
+    private TextView tvVpnAppStatus;
     /* Some tracking bits */
     private String torStatus = null; //latest status reported from the tor service
     private Intent lastStatusIntent;  // the last ACTION_STATUS Intent received
+
     /**
      * The state and log info from {@link OrbotService} are sent to the UI here in
      * the form of a local broadcast. Regular broadcasts can be sent by any app,
@@ -343,6 +351,8 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         setCountrySpinner();
 
         mPulsator = findViewById(R.id.pulsator);
+        tvVpnAppStatus = findViewById(R.id.tvVpnAppStatus);
+        findViewById(R.id.ivAppVpnSettings).setOnClickListener(v -> startActivityForResult(new Intent(OrbotMainActivity.this, AppManagerActivity.class), REQUEST_VPN_APPS_SELECT));
     }
 
     private void resetBandwidthStatTextviews() {
@@ -1088,79 +1098,61 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
         }
     }
 
-    private void drawAppShortcuts(boolean showSelectedApps) {
+    private void drawAppShortcuts(boolean vpnEnabled) {
+        HorizontalScrollView llBoxShortcuts = findViewById(R.id.llBoxShortcuts);
         if (!PermissionManager.isLollipopOrHigher()) {
-            findViewById(R.id.boxVpnStatus).setVisibility(View.GONE);
+            findViewById(R.id.llVpn).setVisibility(View.GONE);
             return;
         }
+        if (!vpnEnabled) {
+            llBoxShortcuts.setVisibility(View.GONE);
+            tvVpnAppStatus.setText(R.string.vpn_disabled);
+            tvVpnAppStatus.setVisibility(View.VISIBLE);
+            return;
+        }
+        String tordAppString = mPrefs.getString(PREFS_KEY_TORIFIED, "");
+        if (TextUtils.isEmpty(tordAppString)) {
+            drawFullDeviceVpn();
+        } else {
+            PackageManager packageManager = getPackageManager();
+            tvVpnAppStatus.setVisibility(View.GONE);
+            llBoxShortcuts.setVisibility(View.VISIBLE);
+            LinearLayout container = (LinearLayout) llBoxShortcuts.getChildAt(0);
+            container.removeAllViews();
+            List<TorifiedApp> apps = TorifiedApp.getApps(this, mPrefs);
+            TorifiedApp.sortAppsForTorifiedAndAbc(apps);
+            int appsAdded = 0;
 
-        LinearLayout llBoxShortcuts = findViewById(R.id.boxAppShortcuts);
-
-        PackageManager pMgr = getPackageManager();
-
-        llBoxShortcuts.removeAllViews();
-
-        if (showSelectedApps) {
-            ArrayList<String> pkgIds = new ArrayList<>();
-            String tordAppString = mPrefs.getString(PREFS_KEY_TORIFIED, "");
-
-            if (TextUtils.isEmpty(tordAppString)) {
-                addFullDeviceVpnView(llBoxShortcuts);
-            } else {
-                StringTokenizer st = new StringTokenizer(tordAppString, "|");
-                while (st.hasMoreTokens() && pkgIds.size() < 4)
-                    pkgIds.add(st.nextToken());
-                int appsAdded = 0;
-                for (final String pkgId : pkgIds) {
-                    try {
-                        ApplicationInfo aInfo = getPackageManager().getApplicationInfo(pkgId, 0);
-                        // skip disabled packages
-                        if (!aInfo.enabled) continue;
-                        ImageView iv = new ImageView(this);
-                        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-                        params.setMargins(3, 3, 3, 3);
-                        iv.setLayoutParams(params);
-                        iv.setImageDrawable(pMgr.getApplicationIcon(pkgId));
-                        iv.setOnClickListener(v -> openBrowser(URL_TOR_CHECK, false, pkgId));
-                        llBoxShortcuts.addView(iv);
-                        appsAdded++;
-                    } catch (Exception e) {
-                        //package not installed?
-                    }
+            for (TorifiedApp app : apps) {
+                if (!app.isTorified()) break;
+                try {
+                    String pkgId = app.getPackageName();
+                    ImageView iv = new ImageView(this);
+                    LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+                    params.setMargins(3, 3, 3, 3);
+                    iv.setLayoutParams(params);
+                    iv.setImageDrawable(packageManager.getApplicationIcon(pkgId));
+                    iv.setOnClickListener(v -> openBrowser(URL_TOR_CHECK, false, pkgId));
+                    container.addView(iv);
+                    appsAdded++;
+                } catch (PackageManager.NameNotFoundException e) {
+                    e.printStackTrace();
                 }
-                if (appsAdded == 0) {
+            }
+            if (appsAdded == 0) {
                         /* if a user uninstalled or disabled all apps that were set on the device
                            then we want to have the no apps added view appear even though
                            the tordAppString variable is not empty */
-                    addFullDeviceVpnView(llBoxShortcuts);
-                }
+                drawFullDeviceVpn();
             }
-        } else {
-            TextView tv = new TextView(this);
-            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-            params.setMargins(12, 3, 3, 3);
-            tv.setLayoutParams(params);
-            tv.setText(R.string.vpn_disabled);
-            llBoxShortcuts.addView(tv);
         }
 
-        //now add app edit/add shortcut
-        ImageView iv = new ImageView(this);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-        params.setMargins(3, 3, 3, 3);
-        iv.setLayoutParams(params);
-        iv.setImageDrawable(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_settings_white_24dp, null));
-        llBoxShortcuts.addView(iv);
-        iv.setOnClickListener(v -> startActivityForResult(new Intent(OrbotMainActivity.this, AppManagerActivity.class), REQUEST_VPN_APPS_SELECT));
     }
 
-    private void addFullDeviceVpnView(LinearLayout llBoxShortcuts) {
-        TextView tv = new TextView(this);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-        params.setMargins(12, 3, 3, 3);
-        tv.setLayoutParams(params);
-        tv.setText(R.string.full_device_vpn);
-        llBoxShortcuts.addView(tv);
+    private void drawFullDeviceVpn() {
+        findViewById(R.id.llBoxShortcuts).setVisibility(View.GONE);
+        tvVpnAppStatus.setText(R.string.full_device_vpn);
+        tvVpnAppStatus.setVisibility(View.VISIBLE);
     }
 
     @SuppressLint("SetWorldReadable")

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -113,16 +113,7 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
         if (mApps == null)
             mApps = getApps(mPrefs);
 
-        Collections.sort(mApps, (o1, o2) -> {
-            /* Some apps start with lowercase letters and without the sorting being case
-               insensitive they'd appear at the end of the grid of apps, a position where users
-               would likely not expect to find them.
-             */
-            if (o1.isTorified() == o2.isTorified())
-                return o1.getName().compareToIgnoreCase(o2.getName());
-            if (o1.isTorified()) return -1;
-            return 1;
-        });
+        TorifiedApp.sortAppsForTorifiedAndAbc(mApps);
 
         final LayoutInflater inflater = getLayoutInflater();
 
@@ -198,7 +189,6 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
     }
 
     public ArrayList<TorifiedApp> getApps(SharedPreferences prefs) {
-
         String tordAppString = prefs.getString(PREFS_KEY_TORIFIED, "");
 
         String[] tordApps;
@@ -210,22 +200,14 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
             tordApps[tordIdx++] = st.nextToken();
         }
         Arrays.sort(tordApps);
-
         List<ApplicationInfo> lAppInfo = pMgr.getInstalledApplications(0);
-
         Iterator<ApplicationInfo> itAppInfo = lAppInfo.iterator();
-
         ArrayList<TorifiedApp> apps = new ArrayList<>();
 
-        ApplicationInfo aInfo;
-
-        TorifiedApp app;
-
         while (itAppInfo.hasNext()) {
-            aInfo = itAppInfo.next();
+            ApplicationInfo aInfo = itAppInfo.next();
             if (!includeAppInUi(aInfo)) continue;
-            app = new TorifiedApp();
-
+            TorifiedApp app = new TorifiedApp();
 
             try {
                 PackageInfo pInfo = pMgr.getPackageInfo(aInfo.packageName, PackageManager.GET_PERMISSIONS);

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -248,7 +248,7 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
 
 
             // check if this application is allowed
-            if (Arrays.binarySearch(tordApps, app.getUsername()) >= 0) {
+            if (Arrays.binarySearch(tordApps, app.getPackageName()) >= 0) {
                 app.setTorified(true);
             } else {
                 app.setTorified(false);
@@ -268,9 +268,9 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
 
         for (TorifiedApp tApp : mApps) {
             if (tApp.isTorified()) {
-                tordApps.append(tApp.getUsername());
+                tordApps.append(tApp.getPackageName());
                 tordApps.append("|");
-                response.putExtra(tApp.getUsername(), true);
+                response.putExtra(tApp.getPackageName(), true);
             }
         }
 

--- a/app/src/main/res/layout/layout_main.xml
+++ b/app/src/main/res/layout/layout_main.xml
@@ -283,13 +283,43 @@
                         android:text="@string/app_shortcuts" />
 
                     <LinearLayout
-                        android:id="@+id/boxAppShortcuts"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
                         android:orientation="horizontal"
+                        android:id="@+id/llVpn"
+                        android:layout_width="wrap_content"
+                        android:gravity="center"
+                        android:padding="3dp"
                         android:minHeight="200dp"
-                        android:padding="3dp" />
+                        android:weightSum="100"
+                        android:layout_height="wrap_content">
+
+                        <HorizontalScrollView
+                            android:layout_weight="95"
+                            android:layout_margin="3dp"
+                            android:id="@+id/llBoxShortcuts"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content">
+                          <LinearLayout
+                              android:orientation="horizontal"
+                              android:id="@+id/llBoxShortcutsInner"
+                              android:layout_width="match_parent"
+                              android:layout_height="match_parent"/>
+                        </HorizontalScrollView>
+
+                        <TextView
+                            android:layout_weight="95"
+                            android:id="@+id/tvVpnAppStatus"
+                            android:text="@string/full_device_vpn"
+                            android:layout_margin="3dp"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                        <ImageView
+                            android:layout_weight="5"
+                            android:id="@+id/ivAppVpnSettings"
+                            android:src="@drawable/ic_settings_white_24dp"
+                            android:layout_margin="3dp"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
                 </LinearLayout>
 
 

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -27,7 +27,6 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.os.ParcelFileDescriptor;
-import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -112,7 +112,7 @@ public class TorifiedApp implements Comparable {
             //app.setIcon(pMgr.getApplicationIcon(aInfo));
 
             // check if this application is allowed
-            if (Arrays.binarySearch(tordApps, app.getUsername()) >= 0) {
+            if (Arrays.binarySearch(tordApps, app.getPackageName()) >= 0) {
                 app.setTorified(true);
             } else {
                 app.setTorified(false);

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -126,6 +126,19 @@ public class TorifiedApp implements Comparable {
         return apps;
     }
 
+    public static void sortAppsForTorifiedAndAbc(List<TorifiedApp> apps) {
+        Collections.sort(apps, (o1, o2) -> {
+            /* Some apps start with lowercase letters and without the sorting being case
+               insensitive they'd appear at the end of the grid of apps, a position where users
+               would likely not expect to find them.
+             */
+            if (o1.isTorified() == o2.isTorified())
+                return o1.getName().compareToIgnoreCase(o2.getName());
+            if (o1.isTorified()) return -1;
+            return 1;
+        });
+    }
+
     public boolean usesInternet() {
         return usesInternet;
     }


### PR DESCRIPTION
- Some apps will were not showing on the main Orbot Screen 
- This allows a variable number of apps to be shown (previously the UI would break and the apps would spill off of the screen) 
- moved a lot of UI logic from Java to XML too

The first commit of this PR fixes #498 but is not very performant. The bug had to do with occasionally inaccurate information being written to disk when users selected apps for "torification". The first commit completely fixes the bug, however has to perform somewhat expensive logic to get around how the incorrect data was being written to disk. 

The second commit makes the UI logic fast and introduces a change to Orbot where the correct data is written to disk. This will mean that users will have to reopen the app selection screen to see their apps on the main screen. It doesn't actually stop an app, say Firefox, that never appeared on the main screen from going through Tor, so I think it's worth committing. 