### PR TITLE
Fixes #474 Remove Briar from Orbot VPN Routing + UI

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -34,6 +34,7 @@ import org.torproject.android.R;
 import org.torproject.android.service.OrbotConstants;
 import org.torproject.android.service.util.Prefs;
 import org.torproject.android.service.vpn.TorifiedApp;
+import org.torproject.android.service.vpn.VpnPrefs;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -54,9 +55,13 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
     private ListAdapter adapterApps;
     private ProgressBar progressBar;
 
-    // returns true if the given app is enabled and not orbot
+    /**
+     * @return true if the app is "enabled", not Orbot, and not in
+     * {@link org.torproject.android.service.vpn.VpnPrefs#BYPASS_VPN_PACKAGES}
+     */
     public static boolean includeAppInUi(ApplicationInfo applicationInfo) {
         if (!applicationInfo.enabled) return false;
+        if (Arrays.binarySearch(VpnPrefs.BYPASS_VPN_PACKAGES, applicationInfo.packageName) >= 0) return false;
         return !BuildConfig.APPLICATION_ID.equals(applicationInfo.packageName);
     }
 
@@ -117,7 +122,7 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
 
         final LayoutInflater inflater = getLayoutInflater();
 
-        adapterApps = new ArrayAdapter<TorifiedApp>(this, R.layout.layout_apps_item, R.id.itemtext, mApps) {
+        adapterApps = new ArrayAdapter<>(this, R.layout.layout_apps_item, R.id.itemtext, mApps) {
 
             @Override
             public View getView(int position, View convertView, ViewGroup parent) {

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -344,15 +344,16 @@ public class OrbotVpnManager implements Handler.Callback {
         for (TorifiedApp app : apps) {
             if (app.isTorified() && (!app.getPackageName().equals(mService.getPackageName()))) {
                 if (prefs.getBoolean(app.getPackageName() + OrbotConstants.APP_TOR_KEY, true)) {
-
                     builder.addAllowedApplication(app.getPackageName());
-
                 }
 
                 perAppEnabled = true;
 
             }
         }
+
+        for (String packageName : VpnPrefs.BYPASS_VPN_PACKAGES)
+            builder.addDisallowedApplication(packageName);
 
         if (!perAppEnabled)
             builder.addDisallowedApplication(mService.getPackageName());

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/TorifiedApp.java
@@ -31,6 +31,8 @@ public class TorifiedApp implements Comparable {
     private boolean usesInternet = false;
     private int[] enabledPorts;
 
+
+
     public static ArrayList<TorifiedApp> getApps(Context context, SharedPreferences prefs) {
 
         String tordAppString = prefs.getString(PREFS_KEY_TORIFIED, "");
@@ -56,25 +58,22 @@ public class TorifiedApp implements Comparable {
 
         ApplicationInfo aInfo;
 
-        int appIdx = 0;
         TorifiedApp app;
 
         while (itAppInfo.hasNext()) {
             aInfo = itAppInfo.next();
 
             app = new TorifiedApp();
-
             try {
                 PackageInfo pInfo = pMgr.getPackageInfo(aInfo.packageName, PackageManager.GET_PERMISSIONS);
-
-                if (pInfo != null && pInfo.requestedPermissions != null) {
+                if (Arrays.binarySearch(VpnPrefs.BYPASS_VPN_PACKAGES, aInfo.packageName) >= 0) {
+                    app.setUsesInternet(false);
+                } else if (pInfo != null && pInfo.requestedPermissions != null) {
                     for (String permInfo : pInfo.requestedPermissions) {
                         if (permInfo.equals(Manifest.permission.INTERNET)) {
                             app.setUsesInternet(true);
-
                         }
                     }
-
                 }
 
 
@@ -117,8 +116,6 @@ public class TorifiedApp implements Comparable {
             } else {
                 app.setTorified(false);
             }
-
-            appIdx++;
         }
 
         Collections.sort(apps);

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnPrefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/VpnPrefs.java
@@ -5,4 +5,14 @@ public interface VpnPrefs {
     String PREFS_DNS_PORT = "PREFS_DNS_PORT";
 
     String PREFS_KEY_TORIFIED = "PrefTord";
+
+    /**
+     * Include packages here to make the VPNService ignore these apps (On Lollipop+). This is to
+     * prevent tor over tor scenarios...
+     */
+    String[] BYPASS_VPN_PACKAGES = new String[] {
+            "org.torproject.torbrowser_alpha",
+            "org.torproject.torbrowser",
+            "org.briarproject.briar.android" // https://github.com/guardianproject/orbot/issues/474
+    };
 }


### PR DESCRIPTION
This introduces a compile time list of packages to ignore from VPN routing and the app selection UI

Packages can be added by modifying the list in `OrbotService`s `VpnPrefs`. 

I also removed Tor Browser and Tor Browser Alpha. This goes beyond the Briar in #474, but is likely something we want. I could imagine confused users getting both Orbot and Tor Browser and stumbling into a slow (among other issues...) Tor Over Tor situation. 