### PR TITLE
Fixes #519 Icon Always Leaves on Exit

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -172,7 +172,6 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
             e.printStackTrace(new PrintStream(baos));
 
             sendCallbackLogMessage(msg + '\n' + baos.toString());
-
         } else
             sendCallbackLogMessage(msg);
 
@@ -310,12 +309,12 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
 
             stopTor();
 
-            //stop the foreground priority and make sure to remove the persistant notification
+            //stop the foreground priority and make sure to remove the persistent notification
             stopForeground(true);
 
             sendCallbackLogMessage(getString(R.string.status_disabled));
         } catch (Exception e) {
-            logNotice("An error occured stopping Tor: " + e.getMessage());
+            logNotice("An error occurred stopping Tor: " + e.getMessage());
             sendCallbackLogMessage(getString(R.string.something_bad_happened));
         }
         clearNotifications();
@@ -421,6 +420,8 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
             }
 
             conn = null;
+        } else {
+            stopSelf();
         }
     }
 


### PR DESCRIPTION
This makes sure that when the user Exits Orbot via the "Exit" Item the onion notification icon will also vanish. 

The icon goes away as expected if the user has an active tor connection or is establishing one. This is because `stopTor()` in `OrbotService` will only abort the service (itself) if it's `TorControlConnection` object `conn` is not `null`. 

Since when Orbot first opens it starts an instance of `OrbotService` but does not immediately establish a tor connection, the `stopTor()` method does nothing and `OrbotService` lives after `OrbotMainActivity` finishes; hence the ghost icon. 