### PR TITLE
Interface for #540

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -679,7 +679,6 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
      */
     private void startTor() {
         try {
-
             if (torServiceConnection != null && conn != null)
             {
                 showConnectedToTorNetworkNotification();
@@ -701,7 +700,6 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                 }
 
             startTorService();
-
             if (Prefs.hostOnionServicesEnabled()) {
                 try {
                     updateV3OnionNames();
@@ -735,8 +733,8 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                             contentResolver.update(V3_ONION_SERVICES_CONTENT_URI, fields, OnionService._ID + "=" + id, null);
                         }
                     }
-
                 }
+                sendCallbackStatus(STATUS_V3_NAMES_UPDATED);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -1436,7 +1434,10 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                     }
                 } else if (action.equals(ACTION_STOP)) {
                     stopTorAsync();
-                } else if (action.equals(ACTION_START_VPN)) {
+                } else if (action.equals(ACTION_UPDATE_ONION_NAMES)) {
+                    updateV3OnionNames();
+                }
+                else if (action.equals(ACTION_START_VPN)) {
                     if (mVpnManager != null && (!mVpnManager.isStarted())) {
                         //start VPN here
                         Intent vpnIntent = VpnService.prepare(OrbotService.this);

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -734,7 +734,15 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                         }
                     }
                 }
+                /*
+                This old status hack is temporary and fixes the issue reported by syphyr at
+                https://github.com/guardianproject/orbot/pull/556
+                Down the line a better approach needs to happen for sending back the onion names updated
+                status, perhaps just adding it as an extra to the normal Intent callback...
+                 */
+                String oldStatus = mCurrentStatus;
                 sendCallbackStatus(STATUS_V3_NAMES_UPDATED);
+                mCurrentStatus = oldStatus;
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -1400,7 +1408,6 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
 
         public void run() {
             String action = mIntent.getAction();
-
             if (!TextUtils.isEmpty(action)) {
                 if (action.equals(ACTION_START) || action.equals(ACTION_START_ON_BOOT)) {
 

--- a/orbotservice/src/main/java/org/torproject/android/service/TorServiceConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorServiceConstants.java
@@ -34,6 +34,8 @@ public interface TorServiceConstants {
     String ACTION_START_VPN = "org.torproject.android.intent.action.START_VPN";
     String ACTION_STOP_VPN = "org.torproject.android.intent.action.STOP_VPN";
 
+    String ACTION_UPDATE_ONION_NAMES = "org.torproject.android.intent.action.UPDATE_ONION_NAMES";
+
     String ACTION_START_ON_BOOT = "org.torproject.android.intent.action.START_BOOT";
 
     int REQUEST_VPN = 7777;
@@ -78,6 +80,9 @@ public interface TorServiceConstants {
      * All tor-related services and daemons are stopped
      */
     String STATUS_OFF = "OFF";
+
+    String STATUS_V3_NAMES_UPDATED = "V3_NAMES_UPDATED";
+
     /**
      * All tor-related services and daemons have completed starting
      */


### PR DESCRIPTION
- External apps can request orbot to spin up a v3 service
- When cancelled, apps are informed
- When service is created, apps get the .onion url

Also introdued a change where onion service domains are updated when a
fresh connection tor tor is achieved, so users don't have to restart app