### PR TITLE
IPtProxy 1.3.0

### DIFF
--- a/app-mini/src/main/res/values-ar/strings.xml
+++ b/app-mini/src/main/res/values-ar/strings.xml
@@ -149,10 +149,7 @@
   <string name="consider_disable_battery_optimizations">يرجى تعطيل تحسينات البطارية</string>
   <string name="consider_enable_battery_optimizations">يرجى تشغيل تحسينات طاقة البطارية</string>
   <string name="app_shortcuts">التطبيقات المهيئة للعبور عبر تور</string>
-  <string name="testing_bridges">جارٍ فحص اتصال الجسر بشبكة تور ...</string>
-  <string name="testing_bridges_success">نجحت العملية. إنّ إعدادات الجسر جيدة !</string>
-  <string name="testing_bridges_fail">فشلت العملية. حاول بخيارات أخرى</string>
-  <string name="bridge_direct_connect">الإتصال المباشر بشبكة تور (أفضل)</string>
+    <string name="bridge_direct_connect">الإتصال المباشر بشبكة تور (أفضل)</string>
   <string name="bridge_community">الإتصال عبر خوادم المجتمع</string>
   <string name="bridge_cloud">الإتصال عن طريق الخوادم السحابية</string>
   <string name="trouble_connecting">تواجه مشكلة للإتصال ؟</string>

--- a/app-mini/src/main/res/values-ay/strings.xml
+++ b/app-mini/src/main/res/values-ay/strings.xml
@@ -159,9 +159,6 @@
   <string name="pref_reduced_connection_padding">Juk\'aptayat waythapiñ ch\'amañchiri</string>
   <string name="pref_reduced_connection_padding_summary">Ch\'amachirimp llika katuqatamp  juk\'aqtayañataki, jank\'aki ch\'iqiyir waythapir jist\'antam ukatx juk\'amp juk\'a ch\'amachir wakichäwinak apayam</string>
   <string name="app_shortcuts">Toramp apnaqañataki wakichäwinaka</string>
-  <string name="testing_bridges">Torar waythapir apayañ thakhix yant\'ataskiwa</string>
-  <string name="testing_bridges_success">Walikipuniwa. ¡jalakipäwix askinjam mayjt\'ayatawa!</string>
-  <string name="testing_bridges_fail">PANTJATAWA. Yaqh yant\'am</string>
   <string name="bridge_direct_connect">Tor ukar chiqak waykattaña (juk\'amp khusa)</string>
   <string name="bridge_community">Yanapirinakan atamirinakapamp waythapiña</string>
   <string name="bridge_cloud">Llikan imirinakamp waythapiña</string>

--- a/app-mini/src/main/res/values-be/strings.xml
+++ b/app-mini/src/main/res/values-be/strings.xml
@@ -159,9 +159,6 @@
   <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
   <string name="pref_reduced_connection_padding_summary">Раней зачыняе рэтрансляваныя злучэнні і адпраўляе менш пакетаў запаўнення для змяншэння аб\'ёму перадатных дадзеных і выкарыстання батарэі</string>
   <string name="app_shortcuts">Дадаткі з падтрымкай Tor</string>
-  <string name="testing_bridges">Тэставанне злучэння з Tor праз мост…</string>
-  <string name="testing_bridges_success">Паспяхова! Мост наладжаны правільна.</string>
-  <string name="testing_bridges_fail">НЯЎДАЛА. Паспрабуйце іншы варыянт.</string>
   <string name="bridge_direct_connect">Падключэнне непасрэдна да Tor (найлепей)</string>
   <string name="bridge_community">Падключэнне праз серверы супольнасці</string>
   <string name="bridge_cloud">Падключэнне праз воблачныя серверы</string>

--- a/app-mini/src/main/res/values-ca/strings.xml
+++ b/app-mini/src/main/res/values-ca/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Farciment de connexió reduit</string>
   <string name="pref_reduced_connection_padding_summary">Tanca les connexions de retransmissió abans i envia menys paquets de farciment per reduir l\'ús de dades i bateria.</string>
     <string name="app_shortcuts">Aplicacions emprant Tor</string>
-    <string name="testing_bridges">Provant connexió pont a Tor...</string>
-  <string name="testing_bridges_success">Èxit. Connexió pont funciona!</string>
-  <string name="testing_bridges_fail">ERROR. Prova una altra opció</string>
   <string name="bridge_direct_connect">Connecta directament a Tor (Lo millor)</string>
   <string name="bridge_community">Connecta mitjançant servidors de comunitat</string>
   <string name="bridge_cloud">Connecta mitjançant servidors núvol</string>

--- a/app-mini/src/main/res/values-de/strings.xml
+++ b/app-mini/src/main/res/values-de/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Reduzierte Verbindungsauffüllung</string>
   <string name="pref_reduced_connection_padding_summary">Schließt Relaisverbindungen früher und sendet weniger Füllpakete, um die Daten und die Batterie zu reduzieren</string>
     <string name="app_shortcuts">Tor-Aktivierte Apps</string>
-    <string name="testing_bridges">Brücken-Verbindung zu Tor wird getestet ....</string>
-  <string name="testing_bridges_success">Erfolgreich. Brücken Konfiguration ist gut!</string>
-  <string name="testing_bridges_fail">GESCHEITERT. Versuchen Sie eine andere Option</string>
   <string name="bridge_direct_connect">Direkt mit Tor verbinden (am Besten)</string>
   <string name="bridge_community">Verbinden Sie sich über Community-Server</string>
   <string name="bridge_cloud">Verbinden Sie sich über Cloud-Server</string>

--- a/app-mini/src/main/res/values-el/strings.xml
+++ b/app-mini/src/main/res/values-el/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Σύνδεση αναπλήρωσης</string>
   <string name="pref_reduced_connection_padding_summary">Κλείνει τον ηλεκτρονόμο συνδέσεων αργά και αποστολή λιγότερο να γεμίσει τα πακέτα για να μειώσει δεδομένων και τη χρήση της μπαταρίας</string>
     <string name="app_shortcuts">Ενεργοποιημένες εφαρμογές με το Τοr</string>
-    <string name="testing_bridges">Δοκιμή σύνδεσης γέφυρας με το Tor....</string>
-  <string name="testing_bridges_success">Επιτυχία. Η διαμόρφωση της γέφυρας πέτυχε!</string>
-  <string name="testing_bridges_fail">ΑΠΟΤΥΧΙΑ. Δοκιμάστε μία άλλη διαμόρφωση</string>
-  <string name="bridge_direct_connect">Απευθείας σύνδεση με το δίκτυο Tor (προεπιλογή)</string>
+    <string name="bridge_direct_connect">Απευθείας σύνδεση με το δίκτυο Tor (προεπιλογή)</string>
   <string name="bridge_community">Σύνδεση μέσω κοινοτικών διακομιστών</string>
   <string name="bridge_cloud">Σύνδεση μέσω cloud server</string>
     <string name="trouble_connecting">Πρόβλημα σύνδεσης;</string>

--- a/app-mini/src/main/res/values-es/strings.xml
+++ b/app-mini/src/main/res/values-es/strings.xml
@@ -161,10 +161,7 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="pref_reduced_connection_padding">Relleno de la conexión reducido</string>
   <string name="pref_reduced_connection_padding_summary">Cierra las conexiones de repetidor más pronto y envía menos paquetes de relleno para reducir el uso de datos y batería</string>
     <string name="app_shortcuts">Aplicaciones habilitadas-para-Tor</string>
-    <string name="testing_bridges">Probando conexión de puente hacia Tor...</string>
-  <string name="testing_bridges_success">Exitosa. ¡La configuración del puente de red es buena!</string>
-  <string name="testing_bridges_fail">FALLIDA. Pruebe otra opción</string>
-  <string name="bridge_direct_connect">Conectar directamente a Tor (lo mejor)</string>
+    <string name="bridge_direct_connect">Conectar directamente a Tor (lo mejor)</string>
   <string name="bridge_community">Conectar a través de servidores de la comunidad</string>
   <string name="bridge_cloud">Conectar a través de servidores de la nube</string>
     <string name="trouble_connecting">¿Problemas al conectar?</string>

--- a/app-mini/src/main/res/values-eu/strings.xml
+++ b/app-mini/src/main/res/values-eu/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Konexioaren betegarria gutxitua</string>
   <string name="pref_reduced_connection_padding_summary">Errelearen konexioa azkarrago ixten du eta pakete betegarri gutxiago bidaltzen ditu datu eta bateria erabilera gutxiagotzeko</string>
     <string name="app_shortcuts">Tor-gaitutako aplikazioak</string>
-    <string name="testing_bridges">Zubiaren Tor konexioa egiaztatzen...</string>
-  <string name="testing_bridges_success">Arrakasta. Zubiaren konfigurazioa egokia da!</string>
-  <string name="testing_bridges_fail">HUTSA. Saiatu beste aukera bat</string>
-  <string name="bridge_direct_connect">Konektatu zuzenean Tor sarera (Onena)</string>
+    <string name="bridge_direct_connect">Konektatu zuzenean Tor sarera (Onena)</string>
   <string name="bridge_community">Konektatu komunitatearen zerbitzarietatik</string>
   <string name="bridge_cloud">Konektatu hodeiko zerbitzarietatik</string>
     <string name="trouble_connecting">Arazoak konektatzeko?</string>

--- a/app-mini/src/main/res/values-fa/strings.xml
+++ b/app-mini/src/main/res/values-fa/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">پنهای ارتباط کاهش پیدا کرد</string>
   <string name="pref_reduced_connection_padding_summary">اتصال بازپخش‌کننده‌های ارتباطی را زودتر قطع می‌کند و بسته‌های لایه‌گذاری کمتری ارسال می‌کند تا استفاده داده و مصرف باتری را کاهش دهد</string>
     <string name="app_shortcuts">اپ‌های فعال شده توسط تور</string>
-    <string name="testing_bridges">تست اتصال پل به تور…</string>
-  <string name="testing_bridges_success">با موفقیت انجام شد. پیکربندی پل خوب است!</string>
-  <string name="testing_bridges_fail">انجام نشد. گزینه‌ی دیگری را انتخاب کنید </string>
-  <string name="bridge_direct_connect">اتصال مستقیم به تور (بهترین عملکرد)</string>
+    <string name="bridge_direct_connect">اتصال مستقیم به تور (بهترین عملکرد)</string>
   <string name="bridge_community">اتصال از طریق سرورهای جامعه</string>
   <string name="bridge_cloud">اتصال از طریق سرورهای ابری</string>
     <string name="trouble_connecting">در اتصال مشکل دارید؟</string>

--- a/app-mini/src/main/res/values-fr/strings.xml
+++ b/app-mini/src/main/res/values-fr/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Bourrage réduit de la connexion</string>
   <string name="pref_reduced_connection_padding_summary">Ferme plus tôt les connexions de relais et envoie moins de paquets de bourrage pour réduire les données et l’utilisation de la pile</string>
     <string name="app_shortcuts">Applis pouvant utiliser Tor</string>
-    <string name="testing_bridges">Test de la connexion-pont vers Tor…</string>
-  <string name="testing_bridges_success">Réussite. La configuration du pont est bonne !</string>
-  <string name="testing_bridges_fail">ÉCHEC. Essayer une autre option</string>
-  <string name="bridge_direct_connect">Se connecter directement à Tor (le mieux)</string>
+    <string name="bridge_direct_connect">Se connecter directement à Tor (le mieux)</string>
   <string name="bridge_community">Se connecter par des serveurs communautaires</string>
   <string name="bridge_cloud">Se connecter par des serveurs nuagiques</string>
     <string name="trouble_connecting">Des problèmes de connexion ?</string>

--- a/app-mini/src/main/res/values-gl/strings.xml
+++ b/app-mini/src/main/res/values-gl/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Espazado limitado da conexión</string>
   <string name="pref_reduced_connection_padding_summary">Pecha as conexións de repetidores máis axiña e envía menos paquetes de espazado para reducir os datos e o uso de batería</string>
     <string name="app_shortcuts">Apps con Tor activado</string>
-    <string name="testing_bridges">Probando a conexión ponte a Tor...</string>
-  <string name="testing_bridges_success">Parabéns. A conexión da Ponte é boa!</string>
-  <string name="testing_bridges_fail">FALLO. Probe outra opción.</string>
-  <string name="bridge_direct_connect">Conectar directamente con Tor (preferido)</string>
+    <string name="bridge_direct_connect">Conectar directamente con Tor (preferido)</string>
   <string name="bridge_community">Conectar a través de servidores da comunidade</string>
   <string name="bridge_cloud">Conectar a través de servidores na nube</string>
     <string name="trouble_connecting">Problemas ao conectar?</string>

--- a/app-mini/src/main/res/values-hi/strings.xml
+++ b/app-mini/src/main/res/values-hi/strings.xml
@@ -161,9 +161,6 @@
   <string name="pref_reduced_connection_padding">कम कनेक्शन पैडिंग</string>
   <string name="pref_reduced_connection_padding_summary">जल्द ही रिले कनेक्शन बंद कर देता है और डेटा और बैटरी उपयोग को कम करने के लिए कम पैडिंग पैकेट भेजता है</string>
     <string name="app_shortcuts">Tor-सक्षम ऐप्स</string>
-    <string name="testing_bridges">Tor से ब्रिज कनेक्शन का परीक्षण ....</string>
-  <string name="testing_bridges_success">सफलता। पुल विन्यास अच्छा है!</string>
-  <string name="testing_bridges_fail">अनुत्तीर्ण होना। दूसरे विकल्प का प्रयास करें</string>
   <string name="bridge_direct_connect">सीधे टॉर से कनेक्ट करें (सर्वश्रेष्ठ)</string>
   <string name="bridge_community">सामुदायिक सर्वर के माध्यम से कनेक्ट करें</string>
   <string name="bridge_cloud">क्लाउड सर्वर से जुड़ें</string>

--- a/app-mini/src/main/res/values-hu/strings.xml
+++ b/app-mini/src/main/res/values-hu/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Csökkentett kapcsolat kitöltés</string>
   <string name="pref_reduced_connection_padding_summary">Hamarabb lezárja a relé kapcsolatokat, és kevesebb kitöltő csomagot küld a csökkentett adat és akkumulátor használat érdekében</string>
     <string name="app_shortcuts">Tor-engedélyezett Alkalmazások</string>
-    <string name="testing_bridges">A híd Tor-hoz csatlakozásának tesztelése....</string>
-  <string name="testing_bridges_success">Sikeres. A híd konfiguráció megfelelő!</string>
-  <string name="testing_bridges_fail">SIKERTELEN: Próbáljon meg másik beállítást</string>
   <string name="bridge_direct_connect">Csatlakozás közvetlenül a Tor-hoz (Legjobb)</string>
   <string name="bridge_community">Csatlakozás közösségi szervereken keresztül</string>
   <string name="bridge_cloud">Csatlakozás felhőszervereken keresztül</string>

--- a/app-mini/src/main/res/values-is/strings.xml
+++ b/app-mini/src/main/res/values-is/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Minnkuð bólstrun tengingar (padding)</string>
   <string name="pref_reduced_connection_padding_summary">Lokar tengingum við endurvarpa fyrr og sendir færri pakka til að bólstra tengingu (padding) svo gagnamagn og rafhlöðunotkun sé sem minnst</string>
     <string name="app_shortcuts">Tor-virkjuð forrit</string>
-    <string name="testing_bridges">Prófa brúartengingu við Tor....</string>
-  <string name="testing_bridges_success">Tókst. Uppsetning brúar virkar!</string>
-  <string name="testing_bridges_fail">MISTÓKST. Reyndu annan valkost</string>
   <string name="bridge_direct_connect">Tengjast beint við Tor (best)</string>
   <string name="bridge_community">Tengjast í gegnum þjóna meðlima</string>
   <string name="bridge_cloud">Tengjast í gegnum þjóna í tölvuskýjum</string>

--- a/app-mini/src/main/res/values-it/strings.xml
+++ b/app-mini/src/main/res/values-it/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Connessione allungata ridotta</string>
   <string name="pref_reduced_connection_padding_summary">Chiudi prima le connessioni dei relay e invia meno pacchetti allungati per ridurre utilizzo di dati e batteria</string>
     <string name="app_shortcuts">App abilitate a Tor</string>
-    <string name="testing_bridges">Test della connessione bridge verso Tor...</string>
-  <string name="testing_bridges_success">Successo. La configurazione bridge è corretta!</string>
-  <string name="testing_bridges_fail">FALLITO. Prova un\'altra opzione</string>
   <string name="bridge_direct_connect">Connettiti direttamente a Tor (Migliore)</string>
   <string name="bridge_community">Connettiti tramite i server comunitari</string>
   <string name="bridge_cloud">Connettiti tramite i server cloud</string>

--- a/app-mini/src/main/res/values-ja/strings.xml
+++ b/app-mini/src/main/res/values-ja/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">減らした通信難読化</string>
   <string name="pref_reduced_connection_padding_summary">データと電力消費を減らすために、リレー接続を早めに閉じ通信難読化を少なめに利用します</string>
     <string name="app_shortcuts">Torが有効化されたアプリ</string>
-    <string name="testing_bridges">Torへのブリッジ接続を検査中...</string>
-  <string name="testing_bridges_success">成功しました。ブリッジ設定は正しい。</string>
-  <string name="testing_bridges_fail">失敗しました。別のオプションを試してください</string>
   <string name="bridge_direct_connect">Tor に直接接続する (ベスト)</string>
   <string name="bridge_community">コミュニティーサーバーを介して接続する</string>
   <string name="bridge_cloud">クラウドサーバーを介して接続する</string>

--- a/app-mini/src/main/res/values-mk/strings.xml
+++ b/app-mini/src/main/res/values-mk/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Редуцирај поврзување со камуфлажа</string>
   <string name="pref_reduced_connection_padding_summary">Исклучете ги врските на релеата поскоро и испраќањето на камуфлирани пакети за да го намалите користењето на податоци и потрошувачката на батеријата</string>
   <string name="app_shortcuts">Tor-овозможени апликации</string>
-  <string name="testing_bridges">Тестирање на мост поврзувањето кон Tor...</string>
-  <string name="testing_bridges_success">Успешно. Мост поставките се добри!</string>
-  <string name="testing_bridges_fail">НЕУСПЕШНО. Пробајте друга опција</string>
   <string name="bridge_direct_connect">Поврзи директно на Tor (Најдобро)</string>
   <string name="bridge_community">Поврзи преку сервери на заедницата</string>
   <string name="bridge_cloud">Поврзи преку облак-сервери</string>

--- a/app-mini/src/main/res/values-nl/strings.xml
+++ b/app-mini/src/main/res/values-nl/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Beperkte verbindingsopvulling</string>
   <string name="pref_reduced_connection_padding_summary">Sluit relayverbindingen sneller en stuurt minder opvullingspakketten om gegevens- en accuverbruik te verminderen</string>
     <string name="app_shortcuts">Tor-gebruikende apps</string>
-    <string name="testing_bridges">Bridgeverbinding met Tor testen....</string>
-  <string name="testing_bridges_success">Voltooid. Bridgeconfiguratie is in orde!</string>
-  <string name="testing_bridges_fail">MISLUKT. Probeer een andere optie</string>
   <string name="bridge_direct_connect">Rechtstreeks verbinden met Tor (best)</string>
   <string name="bridge_community">Verbinden via gemeenschapsservers</string>
   <string name="bridge_cloud">Verbinden via cloudservers</string>

--- a/app-mini/src/main/res/values-pt-rBR/strings.xml
+++ b/app-mini/src/main/res/values-pt-rBR/strings.xml
@@ -150,9 +150,6 @@
   <string name="disable">Desabilitar</string>
   <string name="enable">Ativar</string>
     <string name="app_shortcuts">Aplicações habilitadas para o Tor</string>
-    <string name="testing_bridges">Testando conexão bridge com o Tor</string>
-  <string name="testing_bridges_success">Sucesso. A configuração da Bride é válida.</string>
-  <string name="testing_bridges_fail">Falha. Tente outra opção</string>
   <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (Melhor forma)</string>
   <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
   <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>

--- a/app-mini/src/main/res/values-ru/strings.xml
+++ b/app-mini/src/main/res/values-ru/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
   <string name="pref_reduced_connection_padding_summary">Раньше закрывает ретранслированные соединения и отправляет меньше пакетов заполнения для уменьшения объёма передаваемых данных и использования батареи</string>
     <string name="app_shortcuts">Приложения с поддержкой Tor</string>
-    <string name="testing_bridges">Тестирование соединения с Tor через мост…</string>
-  <string name="testing_bridges_success">Успешно! Мост настроен правильно.</string>
-  <string name="testing_bridges_fail">НЕУДАЧНО. Попробуйте другой вариант.</string>
   <string name="bridge_direct_connect">Подключение непосредственно к Tor (лучше всего)</string>
   <string name="bridge_community">Подключение через серверы сообщества</string>
   <string name="bridge_cloud">Подключение через облачные серверы</string>

--- a/app-mini/src/main/res/values-sv/strings.xml
+++ b/app-mini/src/main/res/values-sv/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Minskad anslutnings-utfyllnad</string>
   <string name="pref_reduced_connection_padding_summary">Stänger relä-anslutningar tidigare, och skickar färre utfyllnadspaket för att minska datatrafik och batteriförbrukning</string>
     <string name="app_shortcuts">Tor-aktiverade appar</string>
-    <string name="testing_bridges">Testa broanslutning till Tor....</string>
-  <string name="testing_bridges_success">Lyckades. Brokonfigurationen är bra!</string>
-  <string name="testing_bridges_fail">MISSLYCKADES. Försök med ett annat alternativ</string>
-  <string name="bridge_direct_connect">Anslut direkt till Tor (Bästa)</string>
+    <string name="bridge_direct_connect">Anslut direkt till Tor (Bästa)</string>
   <string name="bridge_community">Anslut genom gemenskaps servrar</string>
   <string name="bridge_cloud">Anslut via molnservrar</string>
     <string name="trouble_connecting">Problem med att ansluta?</string>

--- a/app-mini/src/main/res/values-th/strings.xml
+++ b/app-mini/src/main/res/values-th/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">ลดช่องว่างภายในเครือข่าย</string>
   <string name="pref_reduced_connection_padding_summary">เลือกการเชื่อมต่อรีเลย์ให้เร็วขึ้นและส่งช่องว่างภายในแพคเก็ตให้น้อยลงเพื่อลดการใช้งานข้อมูลและแบตเตอรี่</string>
     <string name="app_shortcuts">แอปที่ใช้ได้กับ Tor</string>
-    <string name="testing_bridges">ทดสอบการเชื่อมต่อ Bridge กับ Tor</string>
-  <string name="testing_bridges_success">สำเร็จ การกำหนดค่า Bridge เรียบร้อยดีแล้ว</string>
-  <string name="testing_bridges_fail">ล้มเหลว ลองตัวเลือกอื่น</string>
-  <string name="bridge_direct_connect">เชื่อมต่อกับ Tor โดยตรง (ดีที่สุด)</string>
+    <string name="bridge_direct_connect">เชื่อมต่อกับ Tor โดยตรง (ดีที่สุด)</string>
   <string name="bridge_community">เชื่อมต่อผ่านเซิร์ฟเวอร์ของชุมชน</string>
   <string name="bridge_cloud">เชื่อมต่อผ่านเซิร์ฟเวอร์คลาวด์</string>
     <string name="trouble_connecting">มีปัญหากับการเชื่อมต่อหรือไม่</string>

--- a/app-mini/src/main/res/values-tr/strings.xml
+++ b/app-mini/src/main/res/values-tr/strings.xml
@@ -160,10 +160,7 @@
   <string name="pref_reduced_connection_padding">Azaltılmış bağlantı yastıklaması</string>
   <string name="pref_reduced_connection_padding_summary">Aktarıcı bağlantılarını daha kısa sürede kapatır ve veri ve pil kullanımını azaltmak için daha az yastıklama paketi gönderir.</string>
   <string name="app_shortcuts">Tor Kullanan Uygulamalar</string>
-  <string name="testing_bridges">Tor köprü bağlantısı sınanıyor...</string>
-  <string name="testing_bridges_success">Tamamdır, köprü yapılandırması çalışıyor.</string>
-  <string name="testing_bridges_fail">Sorun var. Diğer seçenekleri deneyin</string>
-  <string name="bridge_direct_connect">Doğrudan Tor ağına bağlanılsın (en iyisi)</string>
+    <string name="bridge_direct_connect">Doğrudan Tor ağına bağlanılsın (en iyisi)</string>
   <string name="bridge_community">Topluluk sunucuları üzerinden bağlanılsın</string>
   <string name="bridge_cloud">Bulut sunucular üzerinden bağlanılsın</string>
     <string name="trouble_connecting">Bağlanmakta sorun mu yaşıyorsunuz?</string>

--- a/app-mini/src/main/res/values-uk/strings.xml
+++ b/app-mini/src/main/res/values-uk/strings.xml
@@ -157,10 +157,7 @@
   <string name="pref_isolate_dest_summary">Використати інакшу схему для кожної адреси призначення</string>
   <string name="pref_connection_padding_summary">Завжди забезпечує заповнення підключення для захисту від деяких форм аналізу трафіку. За замовчуванням: автоматично</string>
     <string name="app_shortcuts">Застосунки, що працюють з Tor</string>
-    <string name="testing_bridges">Тестування моста з\'єднання з Tor....</string>
-  <string name="testing_bridges_success">Успішно. Конфігурація мосту хороша!</string>
-  <string name="testing_bridges_fail">НЕ ВДАЛОСЯ. Спробуйте інакший варіант</string>
-  <string name="bridge_direct_connect">Під\'єднання безпосередньо до Tor (Найкраще)</string>
+    <string name="bridge_direct_connect">Під\'єднання безпосередньо до Tor (Найкраще)</string>
   <string name="bridge_community">Під\'єднання через сервери спільноти</string>
   <string name="bridge_cloud">Під\'єднання через хмарні сервери</string>
     <string name="trouble_connecting">Проблеми з під\'єднанням?</string>

--- a/app-mini/src/main/res/values-zh-rTW/strings.xml
+++ b/app-mini/src/main/res/values-zh-rTW/strings.xml
@@ -161,10 +161,7 @@
   <string name="pref_reduced_connection_padding">減少連接保護</string>
   <string name="pref_reduced_connection_padding_summary">關閉中繼連接並傳送少數保護封包來減少資料和電池的用量</string>
     <string name="app_shortcuts">Tor 支持的應用</string>
-    <string name="testing_bridges">測試橋接連線到 Tor</string>
-  <string name="testing_bridges_success">成功,橋接設定良好!</string>
-  <string name="testing_bridges_fail">失敗,嘗試其它選項</string>
-  <string name="bridge_direct_connect">直接連上洋蔥路由網路(最佳)</string>
+    <string name="bridge_direct_connect">直接連上洋蔥路由網路(最佳)</string>
   <string name="bridge_community">透過社區伺服器連接</string>
   <string name="bridge_cloud">透過雲端伺服器連接</string>
     <string name="trouble_connecting">連線遇上問題?</string>

--- a/app-mini/src/main/res/values/strings.xml
+++ b/app-mini/src/main/res/values/strings.xml
@@ -204,9 +204,6 @@
     <string name="pref_disable_ipv4">Disable IPv4 connections</string>
     <string name="pref_disable_ipv4_summary">Tells exits not to connect to IPv4 addresses</string>
     <string name="app_shortcuts">Tor-Enabled Apps</string>
-    <string name="testing_bridges">Testing bridge connection to Tor....</string>
-    <string name="testing_bridges_success">Success. Bridge configuration is good!</string>
-    <string name="testing_bridges_fail">FAILED. Try another option</string>
     <string name="bridge_direct_connect">Connect directly to Tor (Best)</string>
     <string name="bridge_community">Connect through community servers</string>
     <string name="bridge_cloud">Connect through cloud servers</string>

--- a/app-tv/src/main/res/values-ar/strings.xml
+++ b/app-tv/src/main/res/values-ar/strings.xml
@@ -149,9 +149,6 @@
   <string name="consider_disable_battery_optimizations">يرجى تعطيل تحسينات البطارية</string>
   <string name="consider_enable_battery_optimizations">يرجى تشغيل تحسينات طاقة البطارية</string>
   <string name="app_shortcuts">التطبيقات المهيئة للعبور عبر تور</string>
-  <string name="testing_bridges">جارٍ فحص اتصال الجسر بشبكة تور ...</string>
-  <string name="testing_bridges_success">نجحت العملية. إنّ إعدادات الجسر جيدة !</string>
-  <string name="testing_bridges_fail">فشلت العملية. حاول بخيارات أخرى</string>
   <string name="bridge_direct_connect">الإتصال المباشر بشبكة تور (أفضل)</string>
   <string name="bridge_community">الإتصال عبر خوادم المجتمع</string>
   <string name="bridge_cloud">الإتصال عن طريق الخوادم السحابية</string>

--- a/app-tv/src/main/res/values-ay/strings.xml
+++ b/app-tv/src/main/res/values-ay/strings.xml
@@ -159,9 +159,6 @@
   <string name="pref_reduced_connection_padding">Juk\'aptayat waythapiñ ch\'amañchiri</string>
   <string name="pref_reduced_connection_padding_summary">Ch\'amachirimp llika katuqatamp  juk\'aqtayañataki, jank\'aki ch\'iqiyir waythapir jist\'antam ukatx juk\'amp juk\'a ch\'amachir wakichäwinak apayam</string>
   <string name="app_shortcuts">Toramp apnaqañataki wakichäwinaka</string>
-  <string name="testing_bridges">Torar waythapir apayañ thakhix yant\'ataskiwa</string>
-  <string name="testing_bridges_success">Walikipuniwa. ¡jalakipäwix askinjam mayjt\'ayatawa!</string>
-  <string name="testing_bridges_fail">PANTJATAWA. Yaqh yant\'am</string>
   <string name="bridge_direct_connect">Tor ukar chiqak waykattaña (juk\'amp khusa)</string>
   <string name="bridge_community">Yanapirinakan atamirinakapamp waythapiña</string>
   <string name="bridge_cloud">Llikan imirinakamp waythapiña</string>

--- a/app-tv/src/main/res/values-be/strings.xml
+++ b/app-tv/src/main/res/values-be/strings.xml
@@ -159,9 +159,6 @@
   <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
   <string name="pref_reduced_connection_padding_summary">Раней зачыняе рэтрансляваныя злучэнні і адпраўляе менш пакетаў запаўнення для змяншэння аб\'ёму перадатных дадзеных і выкарыстання батарэі</string>
   <string name="app_shortcuts">Дадаткі з падтрымкай Tor</string>
-  <string name="testing_bridges">Тэставанне злучэння з Tor праз мост…</string>
-  <string name="testing_bridges_success">Паспяхова! Мост наладжаны правільна.</string>
-  <string name="testing_bridges_fail">НЯЎДАЛА. Паспрабуйце іншы варыянт.</string>
   <string name="bridge_direct_connect">Падключэнне непасрэдна да Tor (найлепей)</string>
   <string name="bridge_community">Падключэнне праз серверы супольнасці</string>
   <string name="bridge_cloud">Падключэнне праз воблачныя серверы</string>

--- a/app-tv/src/main/res/values-ca/strings.xml
+++ b/app-tv/src/main/res/values-ca/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Farciment de connexió reduit</string>
   <string name="pref_reduced_connection_padding_summary">Tanca les connexions de retransmissió abans i envia menys paquets de farciment per reduir l\'ús de dades i bateria.</string>
     <string name="app_shortcuts">Aplicacions emprant Tor</string>
-    <string name="testing_bridges">Provant connexió pont a Tor...</string>
-  <string name="testing_bridges_success">Èxit. Connexió pont funciona!</string>
-  <string name="testing_bridges_fail">ERROR. Prova una altra opció</string>
   <string name="bridge_direct_connect">Connecta directament a Tor (Lo millor)</string>
   <string name="bridge_community">Connecta mitjançant servidors de comunitat</string>
   <string name="bridge_cloud">Connecta mitjançant servidors núvol</string>

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Reduzierte Verbindungsauffüllung</string>
   <string name="pref_reduced_connection_padding_summary">Schließt Relaisverbindungen früher und sendet weniger Füllpakete, um die Daten und die Batterie zu reduzieren</string>
     <string name="app_shortcuts">Tor-Aktivierte Apps</string>
-    <string name="testing_bridges">Brücken-Verbindung zu Tor wird getestet ....</string>
-  <string name="testing_bridges_success">Erfolgreich. Brücken Konfiguration ist gut!</string>
-  <string name="testing_bridges_fail">GESCHEITERT. Versuchen Sie eine andere Option</string>
   <string name="bridge_direct_connect">Direkt mit Tor verbinden (am Besten)</string>
   <string name="bridge_community">Verbinden Sie sich über Community-Server</string>
   <string name="bridge_cloud">Verbinden Sie sich über Cloud-Server</string>

--- a/app-tv/src/main/res/values-el/strings.xml
+++ b/app-tv/src/main/res/values-el/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Σύνδεση αναπλήρωσης</string>
   <string name="pref_reduced_connection_padding_summary">Κλείνει τον ηλεκτρονόμο συνδέσεων αργά και αποστολή λιγότερο να γεμίσει τα πακέτα για να μειώσει δεδομένων και τη χρήση της μπαταρίας</string>
     <string name="app_shortcuts">Ενεργοποιημένες εφαρμογές με το Τοr</string>
-    <string name="testing_bridges">Δοκιμή σύνδεσης γέφυρας με το Tor....</string>
-  <string name="testing_bridges_success">Επιτυχία. Η διαμόρφωση της γέφυρας πέτυχε!</string>
-  <string name="testing_bridges_fail">ΑΠΟΤΥΧΙΑ. Δοκιμάστε μία άλλη διαμόρφωση</string>
   <string name="bridge_direct_connect">Απευθείας σύνδεση με το δίκτυο Tor (προεπιλογή)</string>
   <string name="bridge_community">Σύνδεση μέσω κοινοτικών διακομιστών</string>
   <string name="bridge_cloud">Σύνδεση μέσω cloud server</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -161,9 +161,6 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="pref_reduced_connection_padding">Relleno de la conexión reducido</string>
   <string name="pref_reduced_connection_padding_summary">Cierra las conexiones de repetidor más pronto y envía menos paquetes de relleno para reducir el uso de datos y batería</string>
     <string name="app_shortcuts">Aplicaciones habilitadas-para-Tor</string>
-    <string name="testing_bridges">Probando conexión de puente hacia Tor...</string>
-  <string name="testing_bridges_success">Exitosa. ¡La configuración del puente de red es buena!</string>
-  <string name="testing_bridges_fail">FALLIDA. Pruebe otra opción</string>
   <string name="bridge_direct_connect">Conectar directamente a Tor (lo mejor)</string>
   <string name="bridge_community">Conectar a través de servidores de la comunidad</string>
   <string name="bridge_cloud">Conectar a través de servidores de la nube</string>

--- a/app-tv/src/main/res/values-eu/strings.xml
+++ b/app-tv/src/main/res/values-eu/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Konexioaren betegarria gutxitua</string>
   <string name="pref_reduced_connection_padding_summary">Errelearen konexioa azkarrago ixten du eta pakete betegarri gutxiago bidaltzen ditu datu eta bateria erabilera gutxiagotzeko</string>
     <string name="app_shortcuts">Tor-gaitutako aplikazioak</string>
-    <string name="testing_bridges">Zubiaren Tor konexioa egiaztatzen...</string>
-  <string name="testing_bridges_success">Arrakasta. Zubiaren konfigurazioa egokia da!</string>
-  <string name="testing_bridges_fail">HUTSA. Saiatu beste aukera bat</string>
   <string name="bridge_direct_connect">Konektatu zuzenean Tor sarera (Onena)</string>
   <string name="bridge_community">Konektatu komunitatearen zerbitzarietatik</string>
   <string name="bridge_cloud">Konektatu hodeiko zerbitzarietatik</string>

--- a/app-tv/src/main/res/values-fa/strings.xml
+++ b/app-tv/src/main/res/values-fa/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">پنهای ارتباط کاهش پیدا کرد</string>
   <string name="pref_reduced_connection_padding_summary">اتصال بازپخش‌کننده‌های ارتباطی را زودتر قطع می‌کند و بسته‌های لایه‌گذاری کمتری ارسال می‌کند تا استفاده داده و مصرف باتری را کاهش دهد</string>
     <string name="app_shortcuts">اپ‌های فعال شده توسط تور</string>
-    <string name="testing_bridges">تست اتصال پل به تور…</string>
-  <string name="testing_bridges_success">با موفقیت انجام شد. پیکربندی پل خوب است!</string>
-  <string name="testing_bridges_fail">انجام نشد. گزینه‌ی دیگری را انتخاب کنید </string>
   <string name="bridge_direct_connect">اتصال مستقیم به تور (بهترین عملکرد)</string>
   <string name="bridge_community">اتصال از طریق سرورهای جامعه</string>
   <string name="bridge_cloud">اتصال از طریق سرورهای ابری</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Bourrage réduit de la connexion</string>
   <string name="pref_reduced_connection_padding_summary">Ferme plus tôt les connexions de relais et envoie moins de paquets de bourrage pour réduire les données et l’utilisation de la pile</string>
     <string name="app_shortcuts">Applis pouvant utiliser Tor</string>
-    <string name="testing_bridges">Test de la connexion-pont vers Tor…</string>
-  <string name="testing_bridges_success">Réussite. La configuration du pont est bonne !</string>
-  <string name="testing_bridges_fail">ÉCHEC. Essayer une autre option</string>
   <string name="bridge_direct_connect">Se connecter directement à Tor (le mieux)</string>
   <string name="bridge_community">Se connecter par des serveurs communautaires</string>
   <string name="bridge_cloud">Se connecter par des serveurs nuagiques</string>

--- a/app-tv/src/main/res/values-gl/strings.xml
+++ b/app-tv/src/main/res/values-gl/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Espazado limitado da conexión</string>
   <string name="pref_reduced_connection_padding_summary">Pecha as conexións de repetidores máis axiña e envía menos paquetes de espazado para reducir os datos e o uso de batería</string>
     <string name="app_shortcuts">Apps con Tor activado</string>
-    <string name="testing_bridges">Probando a conexión ponte a Tor...</string>
-  <string name="testing_bridges_success">Parabéns. A conexión da Ponte é boa!</string>
-  <string name="testing_bridges_fail">FALLO. Probe outra opción.</string>
   <string name="bridge_direct_connect">Conectar directamente con Tor (preferido)</string>
   <string name="bridge_community">Conectar a través de servidores da comunidade</string>
   <string name="bridge_cloud">Conectar a través de servidores na nube</string>

--- a/app-tv/src/main/res/values-hi/strings.xml
+++ b/app-tv/src/main/res/values-hi/strings.xml
@@ -161,9 +161,6 @@
   <string name="pref_reduced_connection_padding">कम कनेक्शन पैडिंग</string>
   <string name="pref_reduced_connection_padding_summary">जल्द ही रिले कनेक्शन बंद कर देता है और डेटा और बैटरी उपयोग को कम करने के लिए कम पैडिंग पैकेट भेजता है</string>
     <string name="app_shortcuts">Tor-सक्षम ऐप्स</string>
-    <string name="testing_bridges">Tor से ब्रिज कनेक्शन का परीक्षण ....</string>
-  <string name="testing_bridges_success">सफलता। पुल विन्यास अच्छा है!</string>
-  <string name="testing_bridges_fail">अनुत्तीर्ण होना। दूसरे विकल्प का प्रयास करें</string>
   <string name="bridge_direct_connect">सीधे टॉर से कनेक्ट करें (सर्वश्रेष्ठ)</string>
   <string name="bridge_community">सामुदायिक सर्वर के माध्यम से कनेक्ट करें</string>
   <string name="bridge_cloud">क्लाउड सर्वर से जुड़ें</string>

--- a/app-tv/src/main/res/values-hu/strings.xml
+++ b/app-tv/src/main/res/values-hu/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Csökkentett kapcsolat kitöltés</string>
   <string name="pref_reduced_connection_padding_summary">Hamarabb lezárja a relé kapcsolatokat, és kevesebb kitöltő csomagot küld a csökkentett adat és akkumulátor használat érdekében</string>
     <string name="app_shortcuts">Tor-engedélyezett Alkalmazások</string>
-    <string name="testing_bridges">A híd Tor-hoz csatlakozásának tesztelése....</string>
-  <string name="testing_bridges_success">Sikeres. A híd konfiguráció megfelelő!</string>
-  <string name="testing_bridges_fail">SIKERTELEN: Próbáljon meg másik beállítást</string>
   <string name="bridge_direct_connect">Csatlakozás közvetlenül a Tor-hoz (Legjobb)</string>
   <string name="bridge_community">Csatlakozás közösségi szervereken keresztül</string>
   <string name="bridge_cloud">Csatlakozás felhőszervereken keresztül</string>

--- a/app-tv/src/main/res/values-is/strings.xml
+++ b/app-tv/src/main/res/values-is/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Minnkuð bólstrun tengingar (padding)</string>
   <string name="pref_reduced_connection_padding_summary">Lokar tengingum við endurvarpa fyrr og sendir færri pakka til að bólstra tengingu (padding) svo gagnamagn og rafhlöðunotkun sé sem minnst</string>
     <string name="app_shortcuts">Tor-virkjuð forrit</string>
-    <string name="testing_bridges">Prófa brúartengingu við Tor....</string>
-  <string name="testing_bridges_success">Tókst. Uppsetning brúar virkar!</string>
-  <string name="testing_bridges_fail">MISTÓKST. Reyndu annan valkost</string>
   <string name="bridge_direct_connect">Tengjast beint við Tor (best)</string>
   <string name="bridge_community">Tengjast í gegnum þjóna meðlima</string>
   <string name="bridge_cloud">Tengjast í gegnum þjóna í tölvuskýjum</string>

--- a/app-tv/src/main/res/values-it/strings.xml
+++ b/app-tv/src/main/res/values-it/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Connessione allungata ridotta</string>
   <string name="pref_reduced_connection_padding_summary">Chiudi prima le connessioni dei relay e invia meno pacchetti allungati per ridurre utilizzo di dati e batteria</string>
     <string name="app_shortcuts">App abilitate a Tor</string>
-    <string name="testing_bridges">Test della connessione bridge verso Tor...</string>
-  <string name="testing_bridges_success">Successo. La configurazione bridge è corretta!</string>
-  <string name="testing_bridges_fail">FALLITO. Prova un\'altra opzione</string>
   <string name="bridge_direct_connect">Connettiti direttamente a Tor (Migliore)</string>
   <string name="bridge_community">Connettiti tramite i server comunitari</string>
   <string name="bridge_cloud">Connettiti tramite i server cloud</string>

--- a/app-tv/src/main/res/values-ja/strings.xml
+++ b/app-tv/src/main/res/values-ja/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">減らした通信難読化</string>
   <string name="pref_reduced_connection_padding_summary">データと電力消費を減らすために、リレー接続を早めに閉じ通信難読化を少なめに利用します</string>
     <string name="app_shortcuts">Torが有効化されたアプリ</string>
-    <string name="testing_bridges">Torへのブリッジ接続を検査中...</string>
-  <string name="testing_bridges_success">成功しました。ブリッジ設定は正しい。</string>
-  <string name="testing_bridges_fail">失敗しました。別のオプションを試してください</string>
   <string name="bridge_direct_connect">Tor に直接接続する (ベスト)</string>
   <string name="bridge_community">コミュニティーサーバーを介して接続する</string>
   <string name="bridge_cloud">クラウドサーバーを介して接続する</string>

--- a/app-tv/src/main/res/values-mk/strings.xml
+++ b/app-tv/src/main/res/values-mk/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Редуцирај поврзување со камуфлажа</string>
   <string name="pref_reduced_connection_padding_summary">Исклучете ги врските на релеата поскоро и испраќањето на камуфлирани пакети за да го намалите користењето на податоци и потрошувачката на батеријата</string>
   <string name="app_shortcuts">Tor-овозможени апликации</string>
-  <string name="testing_bridges">Тестирање на мост поврзувањето кон Tor...</string>
-  <string name="testing_bridges_success">Успешно. Мост поставките се добри!</string>
-  <string name="testing_bridges_fail">НЕУСПЕШНО. Пробајте друга опција</string>
   <string name="bridge_direct_connect">Поврзи директно на Tor (Најдобро)</string>
   <string name="bridge_community">Поврзи преку сервери на заедницата</string>
   <string name="bridge_cloud">Поврзи преку облак-сервери</string>

--- a/app-tv/src/main/res/values-nl/strings.xml
+++ b/app-tv/src/main/res/values-nl/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Beperkte verbindingsopvulling</string>
   <string name="pref_reduced_connection_padding_summary">Sluit relayverbindingen sneller en stuurt minder opvullingspakketten om gegevens- en accuverbruik te verminderen</string>
     <string name="app_shortcuts">Tor-gebruikende apps</string>
-    <string name="testing_bridges">Bridgeverbinding met Tor testen....</string>
-  <string name="testing_bridges_success">Voltooid. Bridgeconfiguratie is in orde!</string>
-  <string name="testing_bridges_fail">MISLUKT. Probeer een andere optie</string>
   <string name="bridge_direct_connect">Rechtstreeks verbinden met Tor (best)</string>
   <string name="bridge_community">Verbinden via gemeenschapsservers</string>
   <string name="bridge_cloud">Verbinden via cloudservers</string>

--- a/app-tv/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tv/src/main/res/values-pt-rBR/strings.xml
@@ -150,9 +150,6 @@
   <string name="disable">Desabilitar</string>
   <string name="enable">Ativar</string>
     <string name="app_shortcuts">Aplicações habilitadas para o Tor</string>
-    <string name="testing_bridges">Testando conexão bridge com o Tor</string>
-  <string name="testing_bridges_success">Sucesso. A configuração da Bride é válida.</string>
-  <string name="testing_bridges_fail">Falha. Tente outra opção</string>
   <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (Melhor forma)</string>
   <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
   <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>

--- a/app-tv/src/main/res/values-ru/strings.xml
+++ b/app-tv/src/main/res/values-ru/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
   <string name="pref_reduced_connection_padding_summary">Раньше закрывает ретранслированные соединения и отправляет меньше пакетов заполнения для уменьшения объёма передаваемых данных и использования батареи</string>
     <string name="app_shortcuts">Приложения с поддержкой Tor</string>
-    <string name="testing_bridges">Тестирование соединения с Tor через мост…</string>
-  <string name="testing_bridges_success">Успешно! Мост настроен правильно.</string>
-  <string name="testing_bridges_fail">НЕУДАЧНО. Попробуйте другой вариант.</string>
   <string name="bridge_direct_connect">Подключение непосредственно к Tor (лучше всего)</string>
   <string name="bridge_community">Подключение через серверы сообщества</string>
   <string name="bridge_cloud">Подключение через облачные серверы</string>

--- a/app-tv/src/main/res/values-sv/strings.xml
+++ b/app-tv/src/main/res/values-sv/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Minskad anslutnings-utfyllnad</string>
   <string name="pref_reduced_connection_padding_summary">Stänger relä-anslutningar tidigare, och skickar färre utfyllnadspaket för att minska datatrafik och batteriförbrukning</string>
     <string name="app_shortcuts">Tor-aktiverade appar</string>
-    <string name="testing_bridges">Testa broanslutning till Tor....</string>
-  <string name="testing_bridges_success">Lyckades. Brokonfigurationen är bra!</string>
-  <string name="testing_bridges_fail">MISSLYCKADES. Försök med ett annat alternativ</string>
   <string name="bridge_direct_connect">Anslut direkt till Tor (Bästa)</string>
   <string name="bridge_community">Anslut genom gemenskaps servrar</string>
   <string name="bridge_cloud">Anslut via molnservrar</string>

--- a/app-tv/src/main/res/values-th/strings.xml
+++ b/app-tv/src/main/res/values-th/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">ลดช่องว่างภายในเครือข่าย</string>
   <string name="pref_reduced_connection_padding_summary">เลือกการเชื่อมต่อรีเลย์ให้เร็วขึ้นและส่งช่องว่างภายในแพคเก็ตให้น้อยลงเพื่อลดการใช้งานข้อมูลและแบตเตอรี่</string>
     <string name="app_shortcuts">แอปที่ใช้ได้กับ Tor</string>
-    <string name="testing_bridges">ทดสอบการเชื่อมต่อ Bridge กับ Tor</string>
-  <string name="testing_bridges_success">สำเร็จ การกำหนดค่า Bridge เรียบร้อยดีแล้ว</string>
-  <string name="testing_bridges_fail">ล้มเหลว ลองตัวเลือกอื่น</string>
   <string name="bridge_direct_connect">เชื่อมต่อกับ Tor โดยตรง (ดีที่สุด)</string>
   <string name="bridge_community">เชื่อมต่อผ่านเซิร์ฟเวอร์ของชุมชน</string>
   <string name="bridge_cloud">เชื่อมต่อผ่านเซิร์ฟเวอร์คลาวด์</string>

--- a/app-tv/src/main/res/values-tr/strings.xml
+++ b/app-tv/src/main/res/values-tr/strings.xml
@@ -160,9 +160,6 @@
   <string name="pref_reduced_connection_padding">Azaltılmış bağlantı yastıklaması</string>
   <string name="pref_reduced_connection_padding_summary">Aktarıcı bağlantılarını daha kısa sürede kapatır ve veri ve pil kullanımını azaltmak için daha az yastıklama paketi gönderir.</string>
   <string name="app_shortcuts">Tor Kullanan Uygulamalar</string>
-  <string name="testing_bridges">Tor köprü bağlantısı sınanıyor...</string>
-  <string name="testing_bridges_success">Tamamdır, köprü yapılandırması çalışıyor.</string>
-  <string name="testing_bridges_fail">Sorun var. Diğer seçenekleri deneyin</string>
   <string name="bridge_direct_connect">Doğrudan Tor ağına bağlanılsın (en iyisi)</string>
   <string name="bridge_community">Topluluk sunucuları üzerinden bağlanılsın</string>
   <string name="bridge_cloud">Bulut sunucular üzerinden bağlanılsın</string>

--- a/app-tv/src/main/res/values-uk/strings.xml
+++ b/app-tv/src/main/res/values-uk/strings.xml
@@ -157,9 +157,6 @@
   <string name="pref_isolate_dest_summary">Використати інакшу схему для кожної адреси призначення</string>
   <string name="pref_connection_padding_summary">Завжди забезпечує заповнення підключення для захисту від деяких форм аналізу трафіку. За замовчуванням: автоматично</string>
     <string name="app_shortcuts">Застосунки, що працюють з Tor</string>
-    <string name="testing_bridges">Тестування моста з\'єднання з Tor....</string>
-  <string name="testing_bridges_success">Успішно. Конфігурація мосту хороша!</string>
-  <string name="testing_bridges_fail">НЕ ВДАЛОСЯ. Спробуйте інакший варіант</string>
   <string name="bridge_direct_connect">Під\'єднання безпосередньо до Tor (Найкраще)</string>
   <string name="bridge_community">Під\'єднання через сервери спільноти</string>
   <string name="bridge_cloud">Під\'єднання через хмарні сервери</string>

--- a/app-tv/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tv/src/main/res/values-zh-rTW/strings.xml
@@ -161,9 +161,6 @@
   <string name="pref_reduced_connection_padding">減少連接保護</string>
   <string name="pref_reduced_connection_padding_summary">關閉中繼連接並傳送少數保護封包來減少資料和電池的用量</string>
     <string name="app_shortcuts">Tor 支持的應用</string>
-    <string name="testing_bridges">測試橋接連線到 Tor</string>
-  <string name="testing_bridges_success">成功,橋接設定良好!</string>
-  <string name="testing_bridges_fail">失敗,嘗試其它選項</string>
   <string name="bridge_direct_connect">直接連上洋蔥路由網路(最佳)</string>
   <string name="bridge_community">透過社區伺服器連接</string>
   <string name="bridge_cloud">透過雲端伺服器連接</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -204,9 +204,6 @@
     <string name="pref_disable_ipv4">Disable IPv4 connections</string>
     <string name="pref_disable_ipv4_summary">Tells exits not to connect to IPv4 addresses</string>
     <string name="app_shortcuts">Tor-Enabled Apps</string>
-    <string name="testing_bridges">Testing bridge connection to Tor....</string>
-    <string name="testing_bridges_success">Success. Bridge configuration is good!</string>
-    <string name="testing_bridges_fail">FAILED. Try another option</string>
     <string name="bridge_direct_connect">Connect directly to Tor (Best)</string>
     <string name="bridge_community">Connect through community servers</string>
     <string name="bridge_cloud">Connect through cloud servers</string>

--- a/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
@@ -2,14 +2,11 @@ package org.torproject.android.ui.onboarding;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.RadioButton;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -20,54 +17,15 @@ import org.torproject.android.R;
 import org.torproject.android.core.LocaleHelper;
 import org.torproject.android.service.util.Prefs;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.lang.ref.WeakReference;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.util.StringTokenizer;
-
 public class BridgeWizardActivity extends AppCompatActivity {
 
     private static final int MOAT_REQUEST_CODE = 666;
     private static final int CUSTOM_BRIDGES_REQUEST_CODE = 1312;
-    private static final String BUNDLE_KEY_TV_STATUS_VISIBILITY = "visibility";
-    private static final String BUNDLE_KEY_TV_STATUS_TEXT = "text";
-    private TextView mTvStatus;
-    private static HostTester runningHostTest;
     private RadioButton mBtDirect;
     private RadioButton mBtObfs4;
     private RadioButton mBtCustom;
     private RadioButton mBtSnowflake;
     private View mBtnConfgiureCustomBridges;
-
-    @SuppressWarnings("SameParameterValue")
-    private static boolean isHostReachable(String serverAddress, int serverTCPport, int timeoutMS) {
-        boolean connected = false;
-
-        try {
-            Socket socket = new Socket();
-            SocketAddress socketAddress = new InetSocketAddress(serverAddress, serverTCPport);
-            socket.connect(socketAddress, timeoutMS);
-            if (socket.isConnected()) {
-                connected = true;
-                socket.close();
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        return connected;
-    }
-
-    private static void cancelHostTestIfRunning() {
-        if (runningHostTest != null) {
-            runningHostTest.cancel(true);
-            runningHostTest = null;
-        }
-    }
 
     private static boolean noBridgesSet() {
         return !Prefs.bridgesEnabled() || Prefs.getBridgesList().trim().equals("");
@@ -85,16 +43,7 @@ public class BridgeWizardActivity extends AppCompatActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        mTvStatus = findViewById(R.id.lbl_bridge_test_status);
-        if (savedInstanceState == null) {
-            mTvStatus.setVisibility(View.GONE);
-        } else {
-            mTvStatus.setVisibility(savedInstanceState.getInt(BUNDLE_KEY_TV_STATUS_VISIBILITY, View.GONE));
-            mTvStatus.setText(savedInstanceState.getString(BUNDLE_KEY_TV_STATUS_TEXT, ""));
-        }
-
         findViewById(R.id.btnMoat).setOnClickListener(v -> {
-            cancelHostTestIfRunning();
             startActivityForResult(new Intent(BridgeWizardActivity.this, MoatActivity.class), MOAT_REQUEST_CODE);
         });
 
@@ -103,8 +52,6 @@ public class BridgeWizardActivity extends AppCompatActivity {
             if (!isChecked) return;
             Prefs.setBridgesList("");
             Prefs.putBridgesEnabled(false);
-            testBridgeConnection();
-
         });
 
         mBtObfs4 = findViewById(R.id.btnBridgesObfs4);
@@ -112,27 +59,18 @@ public class BridgeWizardActivity extends AppCompatActivity {
             if (!isChecked) return;
             Prefs.setBridgesList("obfs4");
             Prefs.putBridgesEnabled(true);
-            testBridgeConnection();
         });
 
         mBtSnowflake = findViewById(R.id.btnBridgesSnowflake);
         mBtSnowflake.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (!isChecked) return;
-            cancelHostTestIfRunning();
             Prefs.setBridgesList("snowflake");
             Prefs.putBridgesEnabled(true);
         });
 
         mBtCustom = findViewById(R.id.btnCustomBridges);
-        mBtCustom.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            if (isChecked) {
-                cancelHostTestIfRunning();
-                mTvStatus.setVisibility(View.GONE);
-                mBtnConfgiureCustomBridges.setVisibility(View.VISIBLE);
-            } else {
-                mBtnConfgiureCustomBridges.setVisibility(View.GONE);
-            }
-        });
+        mBtCustom.setOnCheckedChangeListener((buttonView, isChecked) ->
+                mBtnConfgiureCustomBridges.setVisibility(isChecked ? View.VISIBLE : View.GONE));
 
         mBtnConfgiureCustomBridges = findViewById(R.id.btnConfigureCustomBridges);
         mBtnConfgiureCustomBridges.setOnClickListener(v ->
@@ -179,66 +117,6 @@ public class BridgeWizardActivity extends AppCompatActivity {
         }
     }
 
-    private void testBridgeConnection() {
-        cancelHostTestIfRunning();
-        HostTester hostTester = new HostTester(this);
-        if (TextUtils.isEmpty(Prefs.getBridgesList()) || (!Prefs.bridgesEnabled())) {
-            hostTester.execute("check.torproject.org", "443");
-        } else if (Prefs.getBridgesList().equals("meek")) {
-            hostTester.execute("meek.azureedge.net", "443");
-        } else if (Prefs.getBridgesList().equals("obfs4")) {
-
-            try {
-                BufferedReader in =
-                        new BufferedReader(new InputStreamReader(getResources().openRawResource(org.torproject.android.service.R.raw.bridges), "UTF-8"));
-                String str;
-
-                while ((str = in.readLine()) != null) {
-
-                    StringTokenizer st = new StringTokenizer(str, " ");
-                    String type = st.nextToken();
-
-                    if (type.equals("obfs4")) {
-                        String[] hostport = st.nextToken().split(":");
-                        hostTester.execute(hostport[0], hostport[1]);
-                        break;
-                    }
-
-                }
-
-                in.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-
-
-        } else {
-            hostTester = null;
-            mTvStatus.setText("");
-        }
-        if (hostTester != null) runningHostTest = hostTester;
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
-
-        if (mTvStatus != null) {
-            savedInstanceState.putInt(BUNDLE_KEY_TV_STATUS_VISIBILITY, mTvStatus.getVisibility());
-
-            if (!TextUtils.isEmpty(mTvStatus.getText()))
-                savedInstanceState.putString(BUNDLE_KEY_TV_STATUS_TEXT, mTvStatus.getText().toString());
-        }
-
-        super.onSaveInstanceState(savedInstanceState);
-    }
-
-    @Override
-    public void onDestroy() {
-        cancelHostTestIfRunning();
-        mTvStatus = null;
-        super.onDestroy();
-    }
-
     private void evaluateBridgeListState() {
         Log.d(getClass().getSimpleName(), String.format("bridgesEnabled=%b, bridgesList=%s", Prefs.bridgesEnabled(), Prefs.getBridgesList()));
         if (noBridgesSet()) {
@@ -249,58 +127,6 @@ public class BridgeWizardActivity extends AppCompatActivity {
             mBtSnowflake.setChecked(true);
         } else {
             mBtCustom.setChecked(true);
-        }
-    }
-
-    private static class HostTester extends AsyncTask<String, Void, Boolean> {
-
-        private WeakReference<BridgeWizardActivity> ref;
-
-        HostTester(BridgeWizardActivity activity) {
-            ref = new WeakReference<>(activity);
-        }
-
-        private boolean shouldStop() {
-            return ref.get() == null || ref.get().isFinishing();
-        }
-
-        @Override
-        protected void onPreExecute() {
-            if (shouldStop()) return;
-            BridgeWizardActivity bwa = ref.get();
-            if (bwa.mTvStatus != null) {
-                bwa.mTvStatus.setVisibility(View.VISIBLE);
-                bwa.mTvStatus.setText(bwa.mBtDirect.isChecked() ? R.string.testing_tor_direct : R.string.testing_bridges);
-            }
-        }
-
-        @Override
-        protected Boolean doInBackground(String... host) {
-            for (int i = 0; i < host.length; i++) {
-                if (shouldStop() || isCancelled()) return null;
-                String testHost = host[i];
-                i++; //move to the port
-                int testPort = Integer.parseInt(host[i]);
-                if (isHostReachable(testHost, testPort, 5000)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        protected void onPostExecute(Boolean result) {
-            if (shouldStop()) return;
-            BridgeWizardActivity bwa = ref.get();
-            if (bwa.mTvStatus != null) {
-                runningHostTest = null;
-                if (result) {
-                    int stringRes = bwa.mBtDirect.isChecked() ? R.string.testing_tor_direct_success : R.string.testing_bridges_success;
-                    bwa.mTvStatus.setText(stringRes);
-                } else {
-                    bwa.mTvStatus.setText(R.string.testing_bridges_fail);
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/BridgeWizardActivity.java
@@ -25,6 +25,7 @@ public class BridgeWizardActivity extends AppCompatActivity {
     private RadioButton mBtObfs4;
     private RadioButton mBtCustom;
     private RadioButton mBtSnowflake;
+    private RadioButton mBtnSnowflakeAmp;
     private View mBtnConfgiureCustomBridges;
 
     private static boolean noBridgesSet() {
@@ -65,6 +66,13 @@ public class BridgeWizardActivity extends AppCompatActivity {
         mBtSnowflake.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (!isChecked) return;
             Prefs.setBridgesList("snowflake");
+            Prefs.putBridgesEnabled(true);
+        });
+
+        mBtnSnowflakeAmp = findViewById(R.id.btnSnowflakeAmp);
+        mBtnSnowflakeAmp.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (!isChecked) return;
+            Prefs.setBridgesList("snowflake-amp");
             Prefs.putBridgesEnabled(true);
         });
 
@@ -125,6 +133,8 @@ public class BridgeWizardActivity extends AppCompatActivity {
             mBtObfs4.setChecked(true);
         } else if (Prefs.getBridgesList().equals("snowflake")) {
             mBtSnowflake.setChecked(true);
+        } else if (Prefs.getBridgesList().equals("snowflake-amp")) {
+            mBtnSnowflakeAmp.setChecked(true);
         } else {
             mBtCustom.setChecked(true);
         }

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesActivity.java
@@ -204,6 +204,6 @@ public class CustomBridgesActivity extends AppCompatActivity implements TextWatc
 
     private static boolean userHasSetPreconfiguredBridge(String bridges) {
         if (bridges == null) return false;
-        return bridges.equals("obfs4") || bridges.equals("meek") || bridges.equals("snowflake");
+        return bridges.equals("obfs4") || bridges.equals("meek") || bridges.equals("snowflake") || bridges.equals("snowflake-amp");
     }
 }

--- a/app/src/main/res/layout/content_bridge_wizard.xml
+++ b/app/src/main/res/layout/content_bridge_wizard.xml
@@ -67,12 +67,21 @@
                 android:layout_margin="12dp"
                 android:text="@string/bridge_snowflake" />
 
+
+            <RadioButton
+                android:id="@+id/btnSnowflakeAmp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:text="@string/bridge_snowflake_amp"/>
+
             <RadioButton
                 android:id="@+id/btnCustomBridges"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="12dp"
                 android:text="@string/custom_bridges" />
+
 
         </RadioGroup>
 
@@ -84,14 +93,5 @@
             android:text="@string/configure_custom_bridges"
             android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/lbl_bridge_test_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="12dp"
-            android:gravity="center"
-            android:textColor="@color/bright_green"
-            android:textSize="16sp"
-            android:textStyle="bold" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -143,9 +143,6 @@
     <string name="consider_disable_battery_optimizations">يرجى تعطيل تحسينات البطارية</string>
     <string name="consider_enable_battery_optimizations">يرجى تشغيل تحسينات طاقة البطارية</string>
     <string name="app_shortcuts">التطبيقات المهيئة للعبور عبر تور</string>
-    <string name="testing_bridges">جارٍ فحص اتصال الجسر بشبكة تور …</string>
-    <string name="testing_bridges_success">نجحت العملية. إنّ إعدادات الجسر جيدة !</string>
-    <string name="testing_bridges_fail">فشلت العملية. حاول بخيارات أخرى</string>
     <string name="bridge_direct_connect">الإتصال المباشر بشبكة تور (أفضل)</string>
     <string name="bridge_community">الإتصال عبر خوادم المجتمع</string>
     <string name="bridge_cloud">الإتصال عن طريق الخوادم السحابية</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -152,9 +152,6 @@
   <string name="pref_reduced_connection_padding">Juk\'aptayat waythapiñ ch\'amañchiri</string>
   <string name="pref_reduced_connection_padding_summary">Ch\'amachirimp llika katuqatamp  juk\'aqtayañataki, jank\'aki ch\'iqiyir waythapir jist\'antam ukatx juk\'amp juk\'a ch\'amachir wakichäwinak apayam</string>
   <string name="app_shortcuts">Toramp apnaqañataki wakichäwinaka</string>
-  <string name="testing_bridges">Torar waythapir apayañ thakhix yant\'ataskiwa</string>
-  <string name="testing_bridges_success">Walikipuniwa. ¡jalakipäwix askinjam mayjt\'ayatawa!</string>
-  <string name="testing_bridges_fail">PANTJATAWA. Yaqh yant\'am</string>
   <string name="bridge_direct_connect">Tor ukar chiqak waykattaña (juk\'amp khusa)</string>
   <string name="bridge_community">Yanapirinakan atamirinakapamp waythapiña</string>
   <string name="bridge_cloud">Llikan imirinakamp waythapiña</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -152,9 +152,6 @@
   <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
   <string name="pref_reduced_connection_padding_summary">Раней зачыняе рэтрансляваныя злучэнні і адпраўляе менш пакетаў запаўнення для змяншэння аб\'ёму перадатных дадзеных і выкарыстання батарэі</string>
   <string name="app_shortcuts">Дадаткі з падтрымкай Tor</string>
-  <string name="testing_bridges">Тэставанне злучэння з Tor праз мост…</string>
-  <string name="testing_bridges_success">Паспяхова! Мост наладжаны правільна.</string>
-  <string name="testing_bridges_fail">НЯЎДАЛА. Паспрабуйце іншы варыянт.</string>
   <string name="bridge_direct_connect">Падключэнне непасрэдна да Tor (найлепей)</string>
   <string name="bridge_community">Падключэнне праз серверы супольнасці</string>
   <string name="bridge_cloud">Падключэнне праз воблачныя серверы</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Farciment de connexió reduit</string>
     <string name="pref_reduced_connection_padding_summary">Tanca les connexions de retransmissió abans i envia menys paquets de farciment per reduir l\'ús de dades i bateria</string>
     <string name="app_shortcuts">Aplicacions emprant Tor</string>
-    <string name="testing_bridges">Provant connexió pont a Tor…</string>
-    <string name="testing_bridges_success">Èxit. Connexió pont funciona!</string>
-    <string name="testing_bridges_fail">ERROR. Prova una altra opció</string>
     <string name="bridge_direct_connect">Connecta directament a Tor (Lo millor)</string>
     <string name="bridge_community">Connecta mitjançant servidors de comunitat</string>
     <string name="bridge_cloud">Connecta mitjançant servidors núvol</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Reduzierte Verbindungsauffüllung</string>
     <string name="pref_reduced_connection_padding_summary">Schließt Relaisverbindungen früher und sendet weniger Füllpakete, um Datenmenge und Akkulast zu reduzieren</string>
     <string name="app_shortcuts">Tor-Aktivierte Apps</string>
-    <string name="testing_bridges">Brücken-Verbindung zu Tor wird getestet….</string>
-    <string name="testing_bridges_success">Erfolgreich. Brücken-Konfiguration ist gut!</string>
-    <string name="testing_bridges_fail">GESCHEITERT. Versuchen Sie eine andere Option</string>
     <string name="bridge_direct_connect">Direkt mit Tor verbinden (am besten)</string>
     <string name="bridge_community">Über Community-Server verbinden</string>
     <string name="bridge_cloud">Über Cloud-Server verbinden</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Σύνδεση αναπλήρωσης</string>
     <string name="pref_reduced_connection_padding_summary">Κλείνει τον ηλεκτρονόμο συνδέσεων αργά και αποστολή λιγότερο να γεμίσει τα πακέτα για να μειώσει δεδομένων και τη χρήση της μπαταρίας</string>
     <string name="app_shortcuts">Ενεργοποιημένες εφαρμογές με το Τοr</string>
-    <string name="testing_bridges">Δοκιμή σύνδεσης γέφυρας με το Tor…</string>
-    <string name="testing_bridges_success">Επιτυχία. Η διαμόρφωση της γέφυρας πέτυχε!</string>
-    <string name="testing_bridges_fail">ΑΠΟΤΥΧΙΑ. Δοκιμάστε μία άλλη διαμόρφωση</string>
     <string name="bridge_direct_connect">Απευθείας σύνδεση με το δίκτυο Tor (προεπιλογή)</string>
     <string name="bridge_community">Σύνδεση μέσω κοινοτικών διακομιστών</string>
     <string name="bridge_cloud">Σύνδεση μέσω cloud server</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Relleno de la conexión reducido</string>
     <string name="pref_reduced_connection_padding_summary">Cierra las conexiones de repetidor más pronto y envía menos paquetes de relleno para reducir el uso de datos y batería</string>
     <string name="app_shortcuts">Aplicaciones habilitadas-para-Tor</string>
-    <string name="testing_bridges">Probando conexión de puente hacia Tor…</string>
-    <string name="testing_bridges_success">Exitosa. ¡La configuración del puente de red es buena!</string>
-    <string name="testing_bridges_fail">FALLIDA. Pruebe otra opción</string>
     <string name="bridge_direct_connect">Conectar directamente a Tor (lo mejor)</string>
     <string name="bridge_community">Conectar a través de servidores de la comunidad</string>
     <string name="bridge_cloud">Conectar a través de servidores de la nube</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Konexioaren betegarria gutxitua</string>
     <string name="pref_reduced_connection_padding_summary">Errelearen konexioa azkarrago ixten du eta pakete betegarri gutxiago bidaltzen ditu datu eta bateria erabilera gutxiagotzeko</string>
     <string name="app_shortcuts">Tor-gaitutako aplikazioak</string>
-    <string name="testing_bridges">Zubiaren Tor konexioa egiaztatzen…</string>
-    <string name="testing_bridges_success">Arrakasta. Zubiaren konfigurazioa egokia da!</string>
-    <string name="testing_bridges_fail">HUTSA. Saiatu beste aukera bat</string>
     <string name="bridge_direct_connect">Konektatu zuzenean Tor sarera (Onena)</string>
     <string name="bridge_community">Konektatu komunitatearen zerbitzarietatik</string>
     <string name="bridge_cloud">Konektatu hodeiko zerbitzarietatik</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">پنهای ارتباط کاهش پیدا کرد</string>
     <string name="pref_reduced_connection_padding_summary">اتصال بازپخش‌کننده‌های ارتباطی را زودتر قطع می‌کند و بسته‌های لایه‌گذاری کمتری ارسال می‌کند تا استفاده داده و مصرف باتری را کاهش دهد</string>
     <string name="app_shortcuts">اپ‌های ال شده توسط تور</string>
-    <string name="testing_bridges">تست اتصال پل به تور…</string>
-    <string name="testing_bridges_success">با موفقیت انجام شد. پیکربندی پل خوب است!</string>
-    <string name="testing_bridges_fail">انجام نشد. گزینه‌ی دیگری را انتخاب کنید </string>
     <string name="bridge_direct_connect">اتصال مستقیم به تور (بهترین عملکرد)</string>
     <string name="bridge_community">اتصال از طریق سرورهای جامعه</string>
     <string name="bridge_cloud">اتصال از طریق سرورهای ابری</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -188,11 +188,8 @@
     <string name="bridge_cloud">Yhdistä pilvipalvelimien läpi</string>
     <string name="bridge_community">Yhdistä yhteisöpalvelimien läpi</string>
     <string name="bridge_direct_connect">Yhdistä suoraan Toriin (Paras)</string>
-    <string name="testing_bridges_fail">EPÄONNISTUI. Kokeile toista vaihtoehtoa</string>
     <string name="testing_tor_direct_success">Onnistui. Tor-yhteys on kunnossa!</string>
-    <string name="testing_bridges_success">Onnistui. Siltamääritykset ovat kunnossa!</string>
     <string name="testing_tor_direct">Kokeillaan yhteyttä Toriin…</string>
-    <string name="testing_bridges">Kokeillaan siltayhteyttä Toriin….</string>
     <string name="app_shortcuts">Torilla toimivat sovellukset</string>
     <string name="pref_disable_ipv4_summary">Kertoo exit-solmulle, ettei yhdistetä IPv4-osoitteisiin</string>
     <string name="pref_disable_ipv4">Poista käytöstä IPv4-yhteydet</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -161,9 +161,6 @@
     <string name="pref_disable_ipv4">Désactiver les connexions IPv4</string>
     <string name="pref_disable_ipv4_summary">Indique aux sorties de ne pas se connecter aux adresses IPv4</string>
     <string name="app_shortcuts">Applis pour lesquelles Tor est activé</string>
-    <string name="testing_bridges">Essai de connexion par pont vers Tor…</string>
-    <string name="testing_bridges_success">C’est réussi. La configuration du pont est valide.</string>
-    <string name="testing_bridges_fail">ÉCHEC. Essayez une autre option</string>
     <string name="bridge_direct_connect">Se connecter directement à Tor (le meilleur choix)</string>
     <string name="bridge_community">Se connecter par des serveurs communautaires</string>
     <string name="bridge_cloud">Se connecter par des serveurs nuagiques</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -152,9 +152,6 @@
   <string name="pref_reduced_connection_padding">Bourrage réduit de la connexion</string>
   <string name="pref_reduced_connection_padding_summary">Ferme plus tôt les connexions de relais et envoie moins de paquets de bourrage pour réduire les données et l’utilisation de la pile</string>
     <string name="app_shortcuts">Applis pouvant utiliser Tor</string>
-    <string name="testing_bridges">Test de la connexion-pont vers Tor…</string>
-  <string name="testing_bridges_success">Réussite. La configuration du pont est bonne !</string>
-  <string name="testing_bridges_fail">ÉCHEC. Essayer une autre option</string>
   <string name="bridge_direct_connect">Se connecter directement à Tor (le mieux)</string>
   <string name="bridge_community">Se connecter par des serveurs communautaires</string>
   <string name="bridge_cloud">Se connecter par des serveurs nuagiques</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Espazado limitado da conexión</string>
     <string name="pref_reduced_connection_padding_summary">Pecha as conexións de repetidores máis axiña e envía menos paquetes de espazado para reducir os datos e o uso de batería</string>
     <string name="app_shortcuts">Apps con Tor activado</string>
-    <string name="testing_bridges">Probando a conexión ponte a Tor…</string>
-    <string name="testing_bridges_success">Parabéns. A conexión da Ponte é boa!</string>
-    <string name="testing_bridges_fail">FALLO. Probe outra opción.</string>
     <string name="bridge_direct_connect">Conectar directamente con Tor (preferido)</string>
     <string name="bridge_community">Conectar a través de servidores da comunidade</string>
     <string name="bridge_cloud">Conectar a través de servidores na nube</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -153,9 +153,6 @@
     <string name="pref_reduced_connection_padding">कम कनेक्शन पैडिंग</string>
     <string name="pref_reduced_connection_padding_summary">जल्द ही रिले कनेक्शन बंद कर देता है और डेटा और बैटरी उपयोग को कम करने के लिए कम पैडिंग पैकेट भेजता है</string>
     <string name="app_shortcuts">Tor-सक्षम ऐप्स</string>
-    <string name="testing_bridges">Tor से ब्रिज कनेक्शन का परीक्षण …</string>
-    <string name="testing_bridges_success">सफलता। पुल विन्यास अच्छा है!</string>
-    <string name="testing_bridges_fail">अनुत्तीर्ण होना। दूसरे विकल्प का प्रयास करें</string>
     <string name="bridge_direct_connect">सीधे टॉर से कनेक्ट करें (सर्वश्रेष्ठ)</string>
     <string name="bridge_community">सामुदायिक सर्वर के माध्यम से कनेक्ट करें</string>
     <string name="bridge_cloud">क्लाउड सर्वर से जुड़ें</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Csökkentett kapcsolat kitöltés</string>
     <string name="pref_reduced_connection_padding_summary">Hamarabb lezárja a relé kapcsolatokat, és kevesebb kitöltő csomagot küld a csökkentett adat és akkumulátor használat érdekében</string>
     <string name="app_shortcuts">Tor-engedélyezett Alkalmazások</string>
-    <string name="testing_bridges">A híd Tor-hoz csatlakozásának tesztelése…</string>
-    <string name="testing_bridges_success">Sikeres. A híd konfiguráció megfelelő!</string>
-    <string name="testing_bridges_fail">SIKERTELEN: Próbáljon meg másik beállítást</string>
     <string name="bridge_direct_connect">Csatlakozás közvetlenül a Tor-hoz (Legjobb)</string>
     <string name="bridge_community">Csatlakozás közösségi szervereken keresztül</string>
     <string name="bridge_cloud">Csatlakozás felhőszervereken keresztül</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Minnkuð bólstrun tengingar (padding)</string>
     <string name="pref_reduced_connection_padding_summary">Lokar tengingum við endurvarpa fyrr og sendir færri pakka til að bólstra tengingu (padding) svo gagnamagn og rafhlöðunotkun sé sem minnst</string>
     <string name="app_shortcuts">Tor-virkjuð forrit</string>
-    <string name="testing_bridges">Prófa brúartengingu við Tor….</string>
-    <string name="testing_bridges_success">Tókst. Uppsetning brúar virkar!</string>
-    <string name="testing_bridges_fail">MISTÓKST. Reyndu annan valkost</string>
     <string name="bridge_direct_connect">Tengjast beint við Tor (best)</string>
     <string name="bridge_community">Tengjast í gegnum þjóna meðlima</string>
     <string name="bridge_cloud">Tengjast í gegnum þjóna í tölvuskýjum</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Connessione allungata ridotta</string>
     <string name="pref_reduced_connection_padding_summary">Chiudi prima le connessioni dei relay e invia meno pacchetti allungati per ridurre utilizzo di dati e batteria</string>
     <string name="app_shortcuts">App abilitate a Tor</string>
-    <string name="testing_bridges">Test della connessione bridge verso Tor…</string>
-    <string name="testing_bridges_success">Successo. La configurazione bridge è corretta!</string>
-    <string name="testing_bridges_fail">FALLITO. Prova un\'altra opzione</string>
     <string name="bridge_direct_connect">Connettiti direttamente a Tor (Migliore)</string>
     <string name="bridge_community">Connettiti tramite i server comunitari</string>
     <string name="bridge_cloud">Connettiti tramite i server cloud</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">減らした通信難読化</string>
     <string name="pref_reduced_connection_padding_summary">データと電力消費を減らすために、リレー接続を早めに閉じ通信難読化を少なめに利用します</string>
     <string name="app_shortcuts">Torが有効化されたアプリ</string>
-    <string name="testing_bridges">Torへのブリッジ接続を検査中…</string>
-    <string name="testing_bridges_success">成功しました。ブリッジ設定は正しい。</string>
-    <string name="testing_bridges_fail">失敗しました。別のオプションを試してください</string>
     <string name="bridge_direct_connect">Tor に直接接続する (ベスト)</string>
     <string name="bridge_community">コミュニティーサーバーを介して接続する</string>
     <string name="bridge_cloud">クラウドサーバーを介して接続する</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -42,8 +42,6 @@
     <string name="v3_client_auth">v3 „Onion Service“ kliento autorizavimas</string>
     <string name="testing_tor_direct_success">Sėkmė. „Tor“ jungtis yra gera!</string>
     <string name="bridge_direct_connect">Prisijungti tiesiogiai prie „Tor“ (geriausia)</string>
-    <string name="testing_bridges_success">Sėkmė. Tilto konfigūracija gera!</string>
-    <string name="testing_bridges">Tikrinamas tilto prijungimas prie „Tor“….</string>
     <string name="backup_saved_at_external_storage">Atsarginė kopija išsaugota išorinėje saugykloje</string>
     <string name="updating_settings_in_tor_service">atnaujinami „Tor“ paslaugos nustatymai</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Atidaryti įgaliotąjį serverį visose sąsajose</string>
@@ -58,7 +56,6 @@
     <string name="default_socks_http">Kojinės: - HTTP: -</string>
     <string name="bridge_cloud">Prisijungti per debesų serverius</string>
     <string name="bridge_community">Prisijungti per bendruomenės serverius</string>
-    <string name="testing_bridges_fail">NEPAVYKO. Išbandykite kitą parinktį</string>
     <string name="consider_enable_battery_optimizations">Apsvarstykite galimybę įjungti baterijos optimizavimą</string>
     <string name="consider_disable_battery_optimizations">Apsvarstykite galimybę išjungti baterijos optimizavimą</string>
     <string name="create_a_backup_first">Pirmiausia sukurkite atsarginę kopiją</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Редуцирај поврзување со камуфлажа</string>
     <string name="pref_reduced_connection_padding_summary">Исклучете ги врските на релеата поскоро и испраќањето на камуфлирани пакети за да го намалите користењето на податоци и потрошувачката на батеријата</string>
     <string name="app_shortcuts">Tor-овозможени апликации</string>
-    <string name="testing_bridges">Тестирање на мост поврзувањето кон Tor…</string>
-    <string name="testing_bridges_success">Успешно. Мост поставките се добри!</string>
-    <string name="testing_bridges_fail">НЕУСПЕШНО. Пробајте друга опција</string>
     <string name="bridge_direct_connect">Поврзи директно на Tor (Најдобро)</string>
     <string name="bridge_community">Поврзи преку сервери на заедницата</string>
     <string name="bridge_cloud">Поврзи преку облак-сервери</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -161,7 +161,6 @@
     <string name="bridge_cloud">Koble til gjennom skytjenere</string>
     <string name="refresh_apps">Gjenoppfrisk programmer</string>
     <string name="pref_prefer_ipv6">Foretrekk IPv6-tilknytninger</string>
-    <string name="testing_bridges">Tester bro-tilknytning til Tor…</string>
     <string name="pref_prefer_ipv6_summary">Forteller utgangsnoder at IPv6-adresser foretrekkes</string>
     <string name="pref_reduced_connection_padding_summary">Lukker stafettrutingsoppsettstilknytninger tidligere, og sender flere utfyllingspakker for å redusere data- og batteribruk.</string>
     <string name="pref_reduced_connection_padding">Redusert tilknytningsutfylling</string>
@@ -169,8 +168,6 @@
     <string name="pref_connection_padding">Tilkoblingsutfylling</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Tillat Wi-Fi-likemenn, tjudrede enheter, og alle som kan koble til din IP; tilgang til Tor</string>
     <string name="app_shortcuts">Programmer som kan bruke Tor</string>
-    <string name="testing_bridges_success">Brooppsettet fungerer.</string>
-    <string name="testing_bridges_fail">Mislyktes. Prøv et annet alternativ.</string>
     <string name="backup_saved_at_external_storage">Sikkerhetskopi lagret på eksternt lagringsområde</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Hvis ditt mobilnettverk aktivt blokkerer Tor, kan du bruke en «Brotjener» som alternativ vei inn. VELG én av alternativene å sette opp og teste…</string>
     <string name="pref_http_summary">Porten Tor tilbyr sin HTTP-mellomtjener på (forvalg: 8118 eller 0 for å skru av)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Beperkte verbindingsopvulling</string>
     <string name="pref_reduced_connection_padding_summary">Sluit relayverbindingen sneller en stuurt minder opvullingspakketten om gegevens- en accuverbruik te verminderen</string>
     <string name="app_shortcuts">Tor-gebruikende apps</string>
-    <string name="testing_bridges">Bridgeverbinding met Tor testen…</string>
-    <string name="testing_bridges_success">Voltooid. Bridgeconfiguratie is in orde!</string>
-    <string name="testing_bridges_fail">MISLUKT. Probeer een andere optie</string>
     <string name="bridge_direct_connect">Rechtstreeks verbinden met Tor (best)</string>
     <string name="bridge_community">Verbinden via gemeenschapsservers</string>
     <string name="bridge_cloud">Verbinden via cloudservers</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -158,9 +158,6 @@
     <string name="bridge_cloud">Połącz się przez serwery w chmurze</string>
     <string name="bridge_community">Połącz się przez serwery społeczności</string>
     <string name="bridge_direct_connect">Połącz się bezpośrednio z Tor (najlepiej)</string>
-    <string name="testing_bridges_fail">Nie powiodło się. Wypróbuj inną opcję</string>
-    <string name="testing_bridges_success">Sukces. Konfiguracja mostu jest dobra!</string>
-    <string name="testing_bridges">Testuję połączenie mostu z Tor…</string>
     <string name="app_shortcuts">Aplikacje obsługujące Tor</string>
     <string name="pref_disable_ipv4_summary">Informuje wyjścia, aby nie łączyły się z adresami IPv4</string>
     <string name="pref_disable_ipv4">Wyłącz połączenia IPv4</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -142,9 +142,6 @@
     <string name="disable">Desabilitar</string>
     <string name="enable">Ativar</string>
     <string name="app_shortcuts">Aplicações habilitadas para o Tor</string>
-    <string name="testing_bridges">Testando a ponte de conexão com o Tor….</string>
-    <string name="testing_bridges_success">Sucesso. A configuração da Ponte está boa!</string>
-    <string name="testing_bridges_fail">Falha. Tente outra opção</string>
     <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (Melhor forma)</string>
     <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
     <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -115,9 +115,6 @@
     <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>
     <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
     <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (O melhor)</string>
-    <string name="testing_bridges_fail">FALHOU. Tente outra opção</string>
-    <string name="testing_bridges_success">Sucesso. A configuração da Ponte está boa!</string>
-    <string name="testing_bridges">Testando a ponte de conexão com o Tor….</string>
     <string name="app_shortcuts">Aplicações ativadas para o Tor</string>
     <string name="share_as_qr">Compartilhar como QR</string>
     <string name="please_restart_Orbot_to_enable_the_changes">Por favor reinicie Orbot para ativar as mundanças</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -105,9 +105,6 @@
     <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>
     <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
     <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (O melhor)</string>
-    <string name="testing_bridges_fail">FALHOU. Tente outra opção</string>
-    <string name="testing_bridges_success">Sucesso. A configuração da Ponte está boa!</string>
-    <string name="testing_bridges">Testando a ponte de conexão com o Tor….</string>
     <string name="app_shortcuts">Aplicações ativadas para o Tor</string>
     <string name="share_as_qr">Compartilhar como QR</string>
     <string name="please_restart_Orbot_to_enable_the_changes">Por favor reinicie Orbot para ativar as mundanças</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -69,11 +69,8 @@
     <string name="bridge_cloud">Conectare prin intermediul serverelor cloud</string>
     <string name="bridge_community">Conectați-vă prin intermediul serverelor comunității</string>
     <string name="bridge_direct_connect">Conectați-vă direct la Tor (Cel mai bun)</string>
-    <string name="testing_bridges_fail">A EȘUAT. Încercați o altă opțiune</string>
     <string name="testing_tor_direct_success">Succes. Configurația punții este bună!</string>
-    <string name="testing_bridges_success">Succes. Configurația punții este bună!</string>
     <string name="testing_tor_direct">Testarea conexiunii la Tor…</string>
-    <string name="testing_bridges">Testarea conexiunii punții la Tor....</string>
     <string name="app_shortcuts">Aplicații compatibile cu Tor</string>
     <string name="pref_disable_ipv4_summary">Spune ieșirilor să nu se conecteze la adrese IPv4</string>
     <string name="pref_disable_ipv4">Dezactivați conexiunile IPv4</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Сокращённая прокладка соединения</string>
     <string name="pref_reduced_connection_padding_summary">Раньше закрывает ретранслированные соединения и отправляет меньше пакетов заполнения для уменьшения объёма передаваемых данных и использования батареи</string>
     <string name="app_shortcuts">Приложения с поддержкой Tor</string>
-    <string name="testing_bridges">Тестирование мостового соединения с Tor....</string>
-    <string name="testing_bridges_success">Успех. Конфигурация моста в порядке!</string>
-    <string name="testing_bridges_fail">НЕ УДАЛОСЬ. Попробуйте другой вариант</string>
     <string name="bridge_direct_connect">Подключение непосредственно к Tor (лучше всего)</string>
     <string name="bridge_community">Подключение через серверы сообщества</string>
     <string name="bridge_cloud">Подключение через облачные серверы</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Minskad anslutnings-utfyllnad</string>
     <string name="pref_reduced_connection_padding_summary">Stänger relä-anslutningar tidigare, och skickar färre utfyllnadspaket för att minska datatrafik och batteriförbrukning</string>
     <string name="app_shortcuts">Tor-aktiverade appar</string>
-    <string name="testing_bridges">Testa broanslutning till Tor…</string>
-    <string name="testing_bridges_success">Lyckades. Brokonfigurationen är bra!</string>
-    <string name="testing_bridges_fail">MISSLYCKADES. Försök med ett annat alternativ</string>
     <string name="bridge_direct_connect">Anslut direkt till Tor (Bästa)</string>
     <string name="bridge_community">Anslut genom gemenskaps servrar</string>
     <string name="bridge_cloud">Anslut via molnservrar</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">ลดช่องว่างภายในเครือข่าย</string>
     <string name="pref_reduced_connection_padding_summary">เลือกการเชื่อมต่อรีเลย์ให้เร็วขึ้นและส่งช่องว่างภายในแพคเก็ตให้น้อยลงเพื่อลดการใช้งานข้อมูลและแบตเตอรี่</string>
     <string name="app_shortcuts">แอปที่ใช้ได้กับ Tor</string>
-    <string name="testing_bridges">ทดสอบการเชื่อมต่อ Bridge กับ Tor…</string>
-    <string name="testing_bridges_success">สำเร็จ การกำหนดค่า Bridge เรียบร้อยดีแล้ว!</string>
-    <string name="testing_bridges_fail">ล้มเหลว ลองตัวเลือกอื่น</string>
     <string name="bridge_direct_connect">เชื่อมต่อกับ Tor โดยตรง (ดีที่สุด)</string>
     <string name="bridge_community">เชื่อมต่อผ่านเซิร์ฟเวอร์ของชุมชน</string>
     <string name="bridge_cloud">เชื่อมต่อผ่านเซิร์ฟเวอร์คลาวด์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -152,9 +152,6 @@
     <string name="pref_reduced_connection_padding">Azaltılmış bağlantı yastıklaması</string>
     <string name="pref_reduced_connection_padding_summary">Aktarıcı bağlantılarını daha kısa sürede kapatır ve veri ve pil kullanımını azaltmak için daha az yastıklama paketi gönderir</string>
     <string name="app_shortcuts">Tor Kullanan Uygulamalar</string>
-    <string name="testing_bridges">Tor ile köprü bağlantısı test ediliyor…</string>
-    <string name="testing_bridges_success">Tamamdır. Köprü yapılandırması çalışıyor!</string>
-    <string name="testing_bridges_fail">Sorun var. Diğer seçenekleri deneyin</string>
     <string name="bridge_direct_connect">Doğrudan Tor ağına bağlanılsın (en iyisi)</string>
     <string name="bridge_community">Topluluk sunucuları üzerinden bağlanılsın</string>
     <string name="bridge_cloud">Bulut sunucular üzerinden bağlanılsın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -149,9 +149,6 @@
     <string name="pref_isolate_dest_summary">Використати інакшу схему для кожної адреси призначення</string>
     <string name="pref_connection_padding_summary">Завжди забезпечує заповнення підключення для захисту від деяких форм аналізу трафіку. За замовчуванням: автоматично</string>
     <string name="app_shortcuts">Застосунки, що працюють з Tor</string>
-    <string name="testing_bridges">Тестування моста з\'єднання з Tor….</string>
-    <string name="testing_bridges_success">Успішно. Конфігурація мосту хороша!</string>
-    <string name="testing_bridges_fail">НЕ ВДАЛОСЯ. Спробуйте інакший варіант</string>
     <string name="bridge_direct_connect">Під\'єднання безпосередньо до Tor (Найкраще)</string>
     <string name="bridge_community">Під\'єднання через сервери спільноти</string>
     <string name="bridge_cloud">Під\'єднання через хмарні сервери</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -144,7 +144,6 @@
     <string name="pref_reduced_connection_padding">Giảm khoảng cách kết nối</string>
     <string name="pref_connection_padding_summary">Luôn bật đặt khoảng cách cho kết nối để phòng vệ chống lại một số dạng phân tích lưu lượng. Mặc định: tự động</string>
     <string name="pref_connection_padding">Đặt khoảng cách cho kết nối</string>
-    <string name="testing_bridges">Đang thử nghiệm kết nối cầu nối đến Tor….</string>
     <string name="app_shortcuts">Ứng dụng được bật Tor</string>
     <string name="pref_disable_ipv4_summary">Bảo các lối ra không được kết nối đến các địa chỉ IPv4</string>
     <string name="pref_disable_ipv4">Tắt các kết nối IPv4</string>
@@ -202,9 +201,7 @@
     <string name="bridge_cloud">Kết nối thông qua các máy chủ đám mây</string>
     <string name="bridge_community">Kết nối thông qua các máy chủ cộng đồng</string>
     <string name="bridge_direct_connect">Kết nối trực tiếp đến Tor (Tốt nhất)</string>
-    <string name="testing_bridges_fail">THẤT BẠI. Hãy thử một tuỳ chọn khác</string>
     <string name="testing_tor_direct_success">Thành công. Kết nối đến Tor tốt rồi!</string>
-    <string name="testing_bridges_success">Thành công. Thiết lập cầu nối tốt rồi!</string>
     <string name="testing_tor_direct">Đang thử nghiệm kết nối đến Tor…</string>
     <string name="request_bridges">Yêu cầu cầu nối</string>
     <string name="solve_captcha_instruction">Giải CAPTCHA để yêu cầu cầu nối.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -145,9 +145,6 @@
     <string name="consider_enable_battery_optimizations">考虑启用电池优化</string>
     <string name="pref_disable_ipv4">禁用 IPv4 连接</string>
     <string name="app_shortcuts">启用 Tor 的应用</string>
-    <string name="testing_bridges">正在测试通过网桥连接到Tor ….</string>
-    <string name="testing_bridges_success">成功。网桥配置良好！</string>
-    <string name="testing_bridges_fail">失败。尝试其他选项</string>
     <string name="bridge_direct_connect">直接连接到 Tor（最佳）</string>
     <string name="bridge_community">通过社区服务器进行连接</string>
     <string name="bridge_cloud">通过云服务器进行连接</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -153,9 +153,6 @@
   <string name="pref_reduced_connection_padding">減少連接保護</string>
   <string name="pref_reduced_connection_padding_summary">關閉中繼連接並傳送少數保護封包來減少資料和電池的用量</string>
     <string name="app_shortcuts">Tor 支持的應用</string>
-    <string name="testing_bridges">測試橋接連線到 Tor</string>
-  <string name="testing_bridges_success">成功,橋接設定良好!</string>
-  <string name="testing_bridges_fail">失敗,嘗試其它選項</string>
   <string name="bridge_direct_connect">直接連上洋蔥路由網路(最佳)</string>
   <string name="bridge_community">透過社區伺服器連接</string>
   <string name="bridge_cloud">透過雲端伺服器連接</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,7 +258,7 @@
 
     <string name="be_a_snowflake_title_limit">Snowflake Proxy Limits</string>
     <string name="be_a_snowflake_desc_limit">Only when device is plugged in and on wifi</string>
-    <string name="snowflake_proxy_enabled">SNOWFLAKE PROXY MODE ENABLED</string>
+    <string formatted="true" name="snowflake_proxy_enabled">Snowflake proxy mode enabled</string>
     <string name="snowflake_proxy_msg_title">Show Connection Notification</string>
     <string name="snowflake_proxy_msg_description">Show a message when your snowflake helps someone circumvent censorship</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,9 @@
     <string name="be_a_snowflake_title_limit">Snowflake Proxy Limits</string>
     <string name="be_a_snowflake_desc_limit">Only when device is plugged in and on wifi</string>
     <string name="snowflake_proxy_enabled">SNOWFLAKE PROXY MODE ENABLED</string>
+    <string name="snowflake_proxy_msg_title">Show Connection Notification</string>
+    <string name="snowflake_proxy_msg_description">Show a message when your snowflake helps someone circumvent censorship</string>
+
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,11 +214,8 @@
     <string name="pref_disable_ipv4">Disable IPv4 connections</string>
     <string name="pref_disable_ipv4_summary">Tells exits not to connect to IPv4 addresses</string>
     <string name="app_shortcuts">Tor-Enabled Apps</string>
-    <string name="testing_bridges">Testing bridge connection to Tor….</string>
     <string name="testing_tor_direct">Testing connection to Tor…</string>
-    <string name="testing_bridges_success">Success. Bridge configuration is good!</string>
     <string name="testing_tor_direct_success">Success. Tor connection is good!</string>
-    <string name="testing_bridges_fail">FAILED. Try another option</string>
     <string name="bridge_direct_connect">Connect directly to Tor (Best)</string>
     <string name="bridge_community">Connect through community servers</string>
     <string name="bridge_cloud">Connect through cloud servers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,7 +249,8 @@
     <string name="paste_bridges">Paste Bridges</string>
     <string name="use_qr_code">Use QR Code</string>
     <string name="snowflake_proxy_pref_category">Snowflake Proxy (Experimental)</string>
-    <string name="bridge_snowflake">Connect through other Tor peers (experimental)</string>
+    <string name="bridge_snowflake">Connect through peers via the snowflake proxy (using domain fronting)</string>
+    <string name="bridge_snowflake_amp">Connect through peers via the snowflake proxy (using AMP cache rendezvous)</string>
     <string name="be_a_snowflake_title">Run Snowflake Proxy</string>
     <string name="be_a_snowflake_desc">Allow other Tor users to connect to Tor through your device. (This can\'t be used if you connect alongside bridges)</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -297,6 +297,13 @@
             android:key="pref_be_a_snowflake"
             android:title="@string/be_a_snowflake_title"
             android:summary="@string/be_a_snowflake_desc" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_show_snowflake_proxy_msg"
+            android:title="@string/snowflake_proxy_msg_title"
+            android:summary="@string/snowflake_proxy_msg_description"/>
+
 <!--        <CheckBoxPreference-->
 <!--            android:defaultValue="false"-->
 <!--            android:key="pref_be_a_snowflake_limit"-->

--- a/appcore/src/main/java/org/torproject/android/core/ui/SettingsPreferencesActivity.kt
+++ b/appcore/src/main/java/org/torproject/android/core/ui/SettingsPreferencesActivity.kt
@@ -35,6 +35,7 @@ class SettingsPreferencesActivity : PreferenceActivity() {
         val bridgesEnabled = getSharedPreferences("org.torproject.android_preferences", MODE_MULTI_PROCESS).getBoolean("pref_bridges_enabled", false)
         findPreference("pref_be_a_snowflake")?.isEnabled = !bridgesEnabled
         findPreference("pref_be_a_snowflake_limit")?.isEnabled = !bridgesEnabled
+        findPreference("pref_show_snowflake_proxy_msg")?.isEnabled = !bridgesEnabled
     }
 
     override fun attachBaseContext(newBase: Context) = super.attachBaseContext(LocaleHelper.onAttach(newBase))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
             guardian_geoip               : "20191217",
             guardian_jsocks              : "1.0.4",
             guardian_jtorctl             : "0.4.5.7",
-            ipt_proxy                    : "1.2.0",
+            ipt_proxy                    : "1.3.0",
             portmapper                   : "2.0.5",
             tor_android                  : "0.4.6.7"
     ]

--- a/orbotservice/src/main/assets/fronts
+++ b/orbotservice/src/main/assets/fronts
@@ -1,7 +1,6 @@
 snowflake-target https://snowflake-broker.torproject.net.global.prod.fastly.net/
 snowflake-front cdn.sstatic.net
 snowflake-stun stun:stun.stunprotocol.org:3478
-snowflake-ampcache https://cdn.ampproject.org/
 moat-cdn https://d50gd378qj74g.cloudfront.net/
 moat-url https://moat.torproject.org.global.prod.fastly.net/
 moat-front cdn.sstatic.net

--- a/orbotservice/src/main/assets/fronts
+++ b/orbotservice/src/main/assets/fronts
@@ -1,6 +1,7 @@
 snowflake-target https://snowflake-broker.torproject.net.global.prod.fastly.net/
 snowflake-front cdn.sstatic.net
 snowflake-stun stun:stun.stunprotocol.org:3478
+snowflake-ampcache https://cdn.ampproject.org/
 moat-cdn https://d50gd378qj74g.cloudfront.net/
 moat-url https://moat.torproject.org.global.prod.fastly.net/
 moat-front cdn.sstatic.net

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -36,6 +36,7 @@ import android.os.IBinder;
 import android.provider.BaseColumns;
 import android.text.TextUtils;
 import android.util.Log;
+import android.widget.Toast;
 
 import net.freehaven.tor.control.TorControlCommands;
 import net.freehaven.tor.control.TorControlConnection;
@@ -74,7 +75,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import IPtProxy.IPtProxy;
-
+import IPtProxy.SnowflakeClientConnected;
 import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
@@ -372,8 +373,14 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         String logFile = null;
         boolean keepLocalAddresses = true;
         boolean unsafeLogging = false;
-        IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, natProbe, logFile, keepLocalAddresses, unsafeLogging, null);
-
+        SnowflakeClientConnected callback = null;
+        if (Prefs.showSnowflakeProxyMessage()) {
+            callback = (SnowflakeClientConnected) () -> {
+                String message = String.format(getString(R.string.snowflake_proxy_client_connected_msg), "❄️", "❄️");
+                Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+            };
+        }
+        IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, natProbe, logFile, keepLocalAddresses, unsafeLogging, callback);
         logNotice("Snowflake Proxy mode ENABLED");
     }
 

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -355,10 +355,10 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         String target = getCdnFront("snowflake-target");
         String front = getCdnFront("snowflake-front");
         String stunServer = getCdnFront("snowflake-stun");
-        String ampCache = "https://cdn.ampproject.org/";
+        String ampCache = null; //  getCdnFront("snowflake-ampcache");
 
         IPtProxy.startSnowflake(stunServer, target, front, ampCache,
-                 null, true, false, true, 1);
+                 null, true, false, false, 1);
     }
 
     /*
@@ -366,9 +366,9 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
      */
     private void enableSnowflakeProxy () {
         int capacity = 1;
-        String broker = "https://snowflake-broker.bamsoftware.com/";
-        String relay = "wss://snowflake.bamsoftware.com/";
-        String stun = "stun:stun.stunprotocol.org:3478";
+        String broker = null; // "https://snowflake-broker.bamsoftware.com/";
+        String relay =  null; // "wss://snowflake.bamsoftware.com/";
+        String stun = null; // "stun:stun.stunprotocol.org:3478";
         String natProbe = null;
         String logFile = null;
         boolean keepLocalAddresses = true;
@@ -377,7 +377,7 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         if (Prefs.showSnowflakeProxyMessage()) {
             callback = (SnowflakeClientConnected) () -> {
                 String message = String.format(getString(R.string.snowflake_proxy_client_connected_msg), "❄️", "❄️");
-                Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+                new Handler(getMainLooper()).post(() -> Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show());
             };
         }
         IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, natProbe, logFile, keepLocalAddresses, unsafeLogging, callback);

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -354,10 +354,10 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         String target = getCdnFront("snowflake-target");
         String front = getCdnFront("snowflake-front");
         String stunServer = getCdnFront("snowflake-stun");
+        String ampCache = "https://cdn.ampproject.org/";
 
-        IPtProxy.startSnowflake(stunServer, target, front,
+        IPtProxy.startSnowflake(stunServer, target, front, ampCache,
                  null, true, false, true, 1);
-
     }
 
     /*
@@ -368,10 +368,11 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
         String broker = "https://snowflake-broker.bamsoftware.com/";
         String relay = "wss://snowflake.bamsoftware.com/";
         String stun = "stun:stun.stunprotocol.org:3478";
+        String natProbe = null;
         String logFile = null;
         boolean keepLocalAddresses = true;
         boolean unsafeLogging = false;
-        IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, logFile, keepLocalAddresses, unsafeLogging);
+        IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, natProbe, logFile, keepLocalAddresses, unsafeLogging, null);
 
         logNotice("Snowflake Proxy mode ENABLED");
     }

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -76,6 +76,7 @@ public class Prefs {
     }
 
     public static boolean beSnowflakeProxy () {
+        if (Prefs.bridgesEnabled()) return false;
         return prefs.getBoolean(PREF_BE_A_SNOWFLAKE,false);
     }
 

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -21,6 +21,7 @@ public class Prefs {
     private final static String PREF_USE_VPN = "pref_vpn";
     private final static String PREF_EXIT_NODES = "pref_exit_nodes";
     private final static String PREF_BE_A_SNOWFLAKE = "pref_be_a_snowflake";
+    private final static String PREF_SHOW_SNOWFLAKE_MSG = "pref_show_snowflake_proxy_msg";
     private final static String PREF_BE_A_SNOWFLAKE_LIMIT = "pref_be_a_snowflake_limit";
 
     private final static String PREF_HOST_ONION_SERVICES = "pref_host_onionservices";
@@ -76,6 +77,10 @@ public class Prefs {
 
     public static boolean beSnowflakeProxy () {
         return prefs.getBoolean(PREF_BE_A_SNOWFLAKE,false);
+    }
+
+    public static boolean showSnowflakeProxyMessage() {
+        return prefs.getBoolean(PREF_SHOW_SNOWFLAKE_MSG, false);
     }
 
     public static void setBeSnowflakeProxy (boolean beSnowflakeProxy) {

--- a/orbotservice/src/main/res/values/strings.xml
+++ b/orbotservice/src/main/res/values/strings.xml
@@ -25,5 +25,8 @@
     <string name="kibibyte_per_second">KiB/s</string>
     <string name="mebibyte_per_second">MiB/s</string>
 
+    <string name="snowflake_proxy_client_connected_msg">%s Your snowflake proxy helped someone circumvent censorship %s</string>
+
+
 </resources>
 


### PR DESCRIPTION
- Bumps IPtProxy to 1.3.0
- Optional preference to display snowflake toast when a client connects to proxy 
- Uses `"https://cdn.ampproject.org/"` as hardcoded amp cache 

This still needs to be tested...  