### PR TITLE
Fixes #398 empty notification

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -139,7 +139,6 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
     private static String[] parseBridgesFromSettings(String bridgeList) {
         // this regex replaces lines that only contain whitespace with an empty String
         bridgeList = bridgeList.trim().replaceAll("(?m)^[ \t]*\r?\n", "");
-        Log.d("bim", "bridgeList=" + bridgeList);
         return bridgeList.split("\\n");
     }
 
@@ -244,7 +243,8 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
     }
 
     public int onStartCommand(Intent intent, int flags, int startId) {
-        showToolbarNotification("", NOTIFY_ID, R.drawable.ic_stat_tor);
+        if (!mNotificationShowing)
+            showToolbarNotification(getString(R.string.status_disabled), NOTIFY_ID, R.drawable.ic_stat_tor);
 
         if (intent != null)
             mExecutor.execute(new IncomingIntentRouter(intent));


### PR DESCRIPTION
Orbot notification text is constantly wiped out, this only sets the notification text if:

- a notification isn't showing 
- and if it is, sets it to a "disconnected" message and not an empty string 