### PR TITLE
Fixes #573

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -815,6 +815,7 @@ public class OrbotService extends VpnService implements TorServiceConstants, Orb
                 if (conn != null) {
                     try {
                         conn.setEventHandler(mEventHandler);
+                        conn.authenticate(new byte[0]);
                         conn.setEvents(events);
                         logNotice("SUCCESS added control port event handler");
                     } catch (IOException e) {

--- a/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/TorEventHandler.java
@@ -16,7 +16,7 @@ import java.util.StringTokenizer;
  */
 public class TorEventHandler implements EventHandler, TorServiceConstants {
 
-    private final static int BW_THRESDHOLD = 0;
+    private final static int BW_THRESHOLD = 500;
     private final OrbotService mService;
     private long lastRead = -1;
     private long lastWritten = -1;
@@ -81,7 +81,7 @@ public class TorEventHandler implements EventHandler, TorServiceConstants {
     @Override
     public void bandwidthUsed(long read, long written) {
 
-        if (lastWritten > BW_THRESDHOLD || lastRead > BW_THRESDHOLD) {
+        if (lastWritten > BW_THRESHOLD || lastRead > BW_THRESHOLD) {
 
             int iconId = R.drawable.ic_stat_tor;
 


### PR DESCRIPTION
- TorControlConnection needs a call to authenticate to receive bandwidth updates, this is done in tor-android's `TorService
- Undid the threshold being lowered in 8e5dd0ff976712c7612681d1f7f3408559717f3c this wasn't the issue, I did change it from 0 to 500 instead of back to 10000 though, so BW events of a lower quantity still would trigger more frequent UI updates