### PR TITLE
Reply with dns port alongside http, socks addrs

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -619,6 +619,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
         reply.putExtra(EXTRA_HTTP_PROXY, "http://127.0.0.1:" + mPortHTTP);
         reply.putExtra(EXTRA_HTTP_PROXY_HOST, "127.0.0.1");
         reply.putExtra(EXTRA_HTTP_PROXY_PORT, mPortHTTP);
+        reply.putExtra(EXTRA_DNS_PORT, mPortDns);
 
         if (packageName != null) {
             reply.setPackage(packageName);


### PR DESCRIPTION
Apps like RethinkDNS can forward DNS requests over TCP and UDP to any `port` on `localhost` (doesn't matter if Orbot doesn't support DNS over TCP, though, as all DNS requests and most DNS responses fit in one UDP packet more often than not).

Sending along DNS `port` with HTTP/SOCKS5 proxy info really helps power-user DNS apps that integrate with Orbot (like RethinkDNS) avoid adding special case just for Orbot (https://github.com/celzero/rethink-app/issues/284)