### PR TITLE
onBootReceiver: Ensure user setup has been completed before starting FGS

### DIFF
--- a/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
@@ -12,7 +12,7 @@ import org.torproject.android.service.util.Prefs
 
 class OnBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (Prefs.startOnBoot() && !sReceivedBoot) {
+        if (!Prefs.onboardPending() && Prefs.startOnBoot() && !sReceivedBoot) {
             if (isNetworkAvailable(context)) {
                 startService(OrbotConstants.ACTION_START, context)
                 sReceivedBoot = true

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -146,4 +146,8 @@ public class Prefs {
     public static void addSnowflakeServed () {
         putInt(PREF_SNOWFLAKES_SERVED_COUNT,getSnowflakesServed()+1);
     }
+
+    public static boolean onboardPending() {
+        return prefs.getBoolean("connect_first_time", true);
+    }
 }


### PR DESCRIPTION
## Summary

This PR introduces an additional check for the `onBootReceiver` class before starting the `OrbotService` to ensure that the user's onboarding has been completed. This is required as if the user's onboarding hasn't been complete (which means the user never opened the app), the service will still be triggered.

## Test

Install artifact generated with this patch, reboot the device, and ensure FGS no longer gets triggered until onboarding is complete.