### PR TITLE
Fix ReleaseAarMetadata for app-mini and app-tv

### DIFF
--- a/app-mini/build.gradle
+++ b/app-mini/build.gradle
@@ -5,6 +5,7 @@ android {
     defaultConfig {
         applicationId "org.torproject.android.mini"
         minSdkVersion 16
+        compileSdkVersion 31
         targetSdkVersion 31
         multiDexEnabled true
     }

--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -4,7 +4,8 @@ apply from : '../dependencies.gradle'
 android {
     defaultConfig {
         applicationId "org.torproject.android.tv"
-        minSdkVersion 23 
+        minSdkVersion 23
+        compileSdkVersion 31
         targetSdkVersion 31
     }
 


### PR DESCRIPTION
Execution failed for task ':app-mini:checkMiniReleaseAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > One or more issues found when checking AAR metadata values:

     Dependency 'androidx.work:work-runtime-ktx:2.7.1' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':app-mini' is 'android-30'

     Dependency 'androidx.work:work-runtime:2.7.1' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':app-mini' is 'android-30'

Execution failed for task ':app-tv:checkTeeveeReleaseAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > One or more issues found when checking AAR metadata values:

     Dependency 'androidx.work:work-runtime-ktx:2.7.1' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':app-tv' is 'android-30'

     Dependency 'androidx.work:work-runtime:2.7.1' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':app-tv' is 'android-30'