### PR TITLE
Expose IsolateDestPort and IsolateClientProtocol

### DIFF
--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -178,6 +178,10 @@
     <string name="consider_enable_battery_optimizations">Consider enable battery optimizations</string>
     <string name="pref_isolate_dest">Isolate destination addresses</string>
     <string name="pref_isolate_dest_summary">Use a different circuit for each destination address</string>
+    <string name="pref_isolate_port">Isolate destination ports</string>
+    <string name="pref_isolate_port_summary">Use a different circuit for each destination port</string>
+    <string name="pref_isolate_protocol">Isolate client protocols</string>
+    <string name="pref_isolate_protocol_summary">Use a different circuit for each connecting protocol</string>
     <string name="pref_connection_padding">Connection padding</string>
     <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
     <string name="pref_reduced_connection_padding">Reduced connection padding</string>

--- a/app-tv/src/main/res/xml/preferences.xml
+++ b/app-tv/src/main/res/xml/preferences.xml
@@ -185,6 +185,18 @@
             android:summary="@string/pref_isolate_dest_summary"
             android:title="@string/pref_isolate_dest" />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_port"
+            android:summary="@string/pref_isolate_port_summary"
+            android:title="@string/pref_isolate_port" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_protocol"
+            android:summary="@string/pref_isolate_protocol_summary"
+            android:title="@string/pref_isolate_protocol" />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="pref_prefer_ipv6"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,10 @@
     <string name="consider_enable_battery_optimizations">No hosted services running, consider enabling battery optimizations</string>
     <string name="pref_isolate_dest">Isolate destination addresses</string>
     <string name="pref_isolate_dest_summary">Use a different circuit for each destination address</string>
+    <string name="pref_isolate_port">Isolate destination ports</string>
+    <string name="pref_isolate_port_summary">Use a different circuit for each destination port</string>
+    <string name="pref_isolate_protocol">Isolate client protocols</string>
+    <string name="pref_isolate_protocol_summary">Use a different circuit for each connecting protocol</string>
     <string name="pref_connection_padding">Connection padding</string>
     <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
     <string name="pref_reduced_connection_padding">Reduced connection padding</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -118,6 +118,18 @@
             android:summary="@string/pref_isolate_dest_summary"
             android:title="@string/pref_isolate_dest" />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_port"
+            android:summary="@string/pref_isolate_port_summary"
+            android:title="@string/pref_isolate_port" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_protocol"
+            android:summary="@string/pref_isolate_protocol_summary"
+            android:title="@string/pref_isolate_protocol" />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="pref_prefer_ipv6"

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -25,6 +25,8 @@ public interface OrbotConstants {
     String PREF_HTTP = "pref_http";
 
     String PREF_ISOLATE_DEST = "pref_isolate_dest";
+    String PREF_ISOLATE_PORT = "pref_isolate_port";
+    String PREF_ISOLATE_PROTOCOL = "pref_isolate_protocol";
 
     String PREF_CONNECTION_PADDING = "pref_connection_padding";
     String PREF_REDUCED_CONNECTION_PADDING = "pref_reduced_connection_padding";

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -601,6 +601,12 @@ public class OrbotService extends VpnService implements OrbotConstants {
         if (prefs.getBoolean(PREF_ISOLATE_DEST, false)) {
             isolate += " IsolateDestAddr ";
         }
+        if (prefs.getBoolean(PREF_ISOLATE_PORT, false)) {
+            isolate += " IsolateDestPort ";
+        }
+        if (prefs.getBoolean(PREF_ISOLATE_PROTOCOL, false)) {
+            isolate += " IsolateClientProtocol ";
+        }
 
         var ipv6Pref = "";
         if (prefs.getBoolean(PREF_PREFER_IPV6, true)) {


### PR DESCRIPTION
Would it be a good idea to enable IsolateDestAddr regardless if VPN mode is in-use?

And should IsolateClientProtocol be default enabled?

Is the wording on pref_isolate_protocol_summary accurate?