### PR TITLE
onBootReceiver: Ensure user setup has been completed before starting FGS

### DIFF
--- a/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
@@ -12,7 +12,7 @@ import org.torproject.android.service.util.Prefs
 
 class OnBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (Prefs.startOnBoot() && !sReceivedBoot) {
+        if (!Prefs.onboardPending() && Prefs.startOnBoot() && !sReceivedBoot) {
             if (isNetworkAvailable(context)) {
                 startService(OrbotConstants.ACTION_START, context)
                 sReceivedBoot = true

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -153,4 +153,8 @@ public class Prefs {
     public static void addSnowflakeServed () {
         putInt(PREF_SNOWFLAKES_SERVED_COUNT,getSnowflakesServed()+1);
     }
+
+    public static boolean onboardPending() {
+        return prefs.getBoolean("connect_first_time", true);
+    }
 }


### PR DESCRIPTION
Reupload of #728 to `v16_maintenance` branch. Currently the app constantly spams the logs every second on android 13 if user setup has not been completed: 

`W ActivityManager: Foreground service started from background can not have location/camera/microphone access: service org.torproject.android/.service.OrbotService`

Android also shows the following warning:

![Screenshot_20221213-194347](https://user-images.githubusercontent.com/1216752/207407749-2276347a-7488-4678-a010-108cd1955b63.png)
