### PR TITLE
Remove extra kotlin_version definition

### DIFF
--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:installLocation="internalOnly">
 
     <application
-        android:name="org.torproject.android.tv.OrbotTeeVeeApp"
+        android:name=".OrbotTeeVeeApp"
         android:allowBackup="false"
         android:allowClearUserData="true"
         android:configChanges="locale|orientation|screenSize"
@@ -17,7 +17,7 @@
         android:banner="@drawable/banner"
         >
         <activity
-            android:name="org.torproject.android.tv.ui.AppConfigActivity"
+            android:name=".ui.AppConfigActivity"
             android:label="@string/title_activity_app_config"></activity>
         <activity
             android:name=".TeeveeMainActivity"
@@ -54,11 +54,11 @@
             android:name="org.torproject.android.core.ui.SettingsPreferencesActivity"
             android:label="@string/app_name" />
         <activity
-            android:name="org.torproject.android.tv.ui.AppManagerActivity"
+            android:name=".ui.AppManagerActivity"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppCompat.Light" />
 
-        <activity android:name="org.torproject.android.tv.ui.onboarding.OnboardingActivity" />
+        <activity android:name=".ui.onboarding.OnboardingActivity" />
 
 
         <service

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.10'
     apply from: './dependencies.gradle'
     ext {
         kotlin_version = '1.7.10'


### PR DESCRIPTION
kotlin_version is unnecessarily defined twice.  Also, use same package nomenclature for app-tv package and app-mini package.