### PR TITLE
New bitrise status chip since app was deleted & replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## Orbot: Android Onion Routing Robot
 
-[![Build Status](https://app.bitrise.io/app/8277d77782019ab0/status.svg?token=FHkjd4_vTHUa6wkPIswcfQ&branch=master)](https://app.bitrise.io/app/8277d77782019ab0)
+[![Build Status](https://app.bitrise.io/app/0e76c31b8e7e1801/status.svg?token=S2weJXueO3AvrDUrrd85SA&branch=master)](https://app.bitrise.io/app/0e76c31b8e7e1801)
 
 Orbot is a freely licensed open-source application developed for the
 Android platform. It acts as a front-end to the Tor binary application,


### PR DESCRIPTION
Apparently, you can't change status between private & public.  If you want build results accessible to folks outside our bitrise org, you need you delete and recreate the app as "public".  Here's a chip for the new ID.