### PR TITLE
build-orbotlib: Check for directory before cloning

### DIFF
--- a/OrbotLib/build-orbotlib.sh
+++ b/OrbotLib/build-orbotlib.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 rm *aar *jar
-git clone https://github.com/bitmold/OrbotIPtProxy
+if [ ! -d OrbotIPtProxy ]; then
+   git clone https://github.com/bitmold/OrbotIPtProxy
+fi
 cd OrbotIPtProxy
 git pull
 bash build-orbot.sh


### PR DESCRIPTION
Don't try to clone directory if it already exists to prevent fatal error in log