### PR TITLE
Revert "update submod in script"

### DIFF
--- a/OrbotLib/build-orbotlib.sh
+++ b/OrbotLib/build-orbotlib.sh
@@ -6,7 +6,6 @@ if [ ! -d OrbotIPtProxy ]; then
 fi
 cd OrbotIPtProxy
 git pull
-git submodule update --init
 bash build-orbot.sh
 mv OrbotLib.aar ..
 mv OrbotLib-sources.jar ..


### PR DESCRIPTION
This reverts commit 197af55eae9b6ff04a75605ef208a898b29536c0.

build-orbot.sh already calls "git submodule update --init --recursive", so no need to call it twice.