### PR TITLE
Bump fastlane to 2.0.0 (which needed Android 18 min sdk)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
             androidx_recyclerview        : "1.2.1",
             apl_appintro                 : "v4.2.3",
             bclogic_pulsator             : "1.0.3",
-            fastlane_screengrab          : "1.2.0",
+            fastlane_screengrab          : "2.0.0",
             guardian_jsocks              : "1.0.4",
             guardian_jtorctl             : "0.4.5.7",
             ipt_proxy                    : "1.7.1",


### PR DESCRIPTION
This means fastlane uses Android X, after this is merged only two deps will be on the old android support libraries

getting rid of every appcompat lib means we can turn off the jetifier thing and orbot will build way faster on my slow computer.

i'm doing this as a pull request because i've never used fastlane before and don't know how to test it - the thing seems to build fine though ...