### PR TITLE
Start Orbot via always-on VPN without onboarding

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotMainActivity.java
+++ b/app/src/main/java/org/torproject/android/OrbotMainActivity.java
@@ -267,6 +267,7 @@ public class OrbotMainActivity extends AppCompatActivity implements OrbotConstan
     private void sendIntentToService(final String action) {
         Intent intent = new Intent(OrbotMainActivity.this, OrbotService.class);
         intent.setAction(action);
+        intent.putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true);
         sendIntentToService(intent);
     }
 

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -107,6 +107,14 @@ public interface OrbotConstants {
 
     String EXTRA_DNS_PORT = "org.torproject.android.intent.extra.DNS_PORT";
     String EXTRA_TRANS_PORT = "org.torproject.android.intent.extra.TRANS_PORT";
+    /**
+     * When present, indicates with certainty that the system itself did *not* send the Intent.
+     * Effectively, the lack of this extra indicates that the VPN is being started by the system
+     * as a result of the user's always-on preference for the VPN.
+     * See: <a href="https://developer.android.com/guide/topics/connectivity/vpn#detect_always-on">
+     * Detect always-on | VPN | Android Developers</a>
+     */
+    String EXTRA_NOT_SYSTEM = "org.torproject.android.intent.extra.NOT_SYSTEM";
 
     String LOCAL_ACTION_LOG = "log";
     String LOCAL_ACTION_STATUS = "status";

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -224,10 +224,18 @@ public class OrbotService extends VpnService implements OrbotConstants {
     }
 
     public int onStartCommand(Intent intent, int flags, int startId) {
+        final boolean shouldStartVpn = Prefs.onboardPending() && (intent == null
+                || !intent.getBooleanExtra(OrbotConstants.EXTRA_NOT_SYSTEM, false));
         if (mCurrentStatus.equals(STATUS_OFF))
             showToolbarNotification(getString(R.string.open_orbot_to_connect_to_tor), NOTIFY_ID, R.drawable.ic_stat_tor);
 
-        if (intent != null)
+        if (shouldStartVpn) {
+            Log.d(TAG, "Starting VPN from system intent: " + intent);
+            showToolbarNotification(getString(R.string.status_starting_up), NOTIFY_ID, R.drawable.ic_stat_tor);
+            mExecutor.execute(new IncomingIntentRouter(new Intent(ACTION_START)));
+            mExecutor.execute(new IncomingIntentRouter(new Intent(ACTION_START_VPN)));
+        }
+        else if (intent != null)
             mExecutor.execute(new IncomingIntentRouter(intent));
         else
             Log.d(TAG, "Got null onStartCommand() intent");


### PR DESCRIPTION
When the system tries to start Orbot, if the onboarding process has yet to be completed, automatically connect to Tor without requiring user intervention. This allows Orbot to get started automatically when it is bundled with the OS in always-on mode.

Test: Manual: Install Orbot and connect to Tor. In the system settings, set Orbot as an always-on VPN. Clear storage for Orbot. Reboot the device. Orbot should automatically connect and be available for use.