### PR TITLE
Fix lint error Instantiatable

### DIFF
--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -8,6 +8,9 @@ android {
         targetSdkVersion 33
     }
 
+    lintOptions {
+        disable "Instantiatable"
+    }
 
     flavorDimensions "teevee"
 


### PR DESCRIPTION
Fixes:
```
> Task :app-tv:lintVitalTeeveeRelease FAILED
/orbot/app-tv/src/main/AndroidManifest.xml:54: Error: SettingsPreferencesFragment must extend android.app.Activity [Instantiatable]
            android:name="org.torproject.android.core.ui.SettingsPreferencesFragment"
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Explanation for issues of type "Instantiatable":
Activities, services, broadcast receivers etc. registered in the manifest
file (or for custom views, in a layout file) must be "instantiatable" by
the system, which means that the class must be public, it must have an
empty public constructor, and if it's an inner class, it must be a static.