### PR TITLE
refactor: :art: improve Brazilian Portuguese translation

### DIFF
--- a/app-tv/src/main/res/values-pt-rBR/poestrings.xml
+++ b/app-tv/src/main/res/values-pt-rBR/poestrings.xml
@@ -5,7 +5,7 @@
     <string name="action_more">FALE MAIS SOBRE</string>
 
     <string name="vpn_setup">Você pode habilitar qualquer aplicativo para passar pela rede Tor utilizando a nossa VPN integrada.</string>
-    <string name="vpn_setup_sub">Isso não te faz anônimo, mas irá te ajudar a transpassar firewalls.</string>
+    <string name="vpn_setup_sub">Isso não te deixa anônimo, mas irá te ajudar a passar por cima de firewalls.</string>
     <string name="action_vpn_choose">ESCOLHA OS APLICATIVOS</string>
 
     <string name="hello">Olá</string>

--- a/app-tv/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tv/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <string name="app_name">Orbot</string>
-  <string name="app_description">Orbot é um aplicativo de proxy livre que capacita outros aplicativos a usar a internet com mais segurança. Orbot usa o Tor para criptografar seu tráfego na internet e então o esconde \"saltando\" entre uma série de computadores ao redor do mundo. Tor é um software livre e de rede aberta que ajuda você a se defender de certas formas de vigilância que ameaçam privacidade e liberdade pessoais, atividades e relações comerciais confidenciais e segurança estatal conhecida como análise de tráfego.</string>
+  <string name="app_description">Orbot é um aplicativo de proxy livre que permite que outros aplicativos acessem a internet com mais segurança. Orbot usa o Tor para criptografar seu tráfego na internet e então o esconde \"pulando\" entre uma série de computadores ao redor do mundo. Tor é um software livre e de rede aberta que ajuda você a se defender de certas formas de vigilância que ameaçam privacidade e liberdade pessoais, atividades e relações comerciais confidenciais e segurança estatal conhecida como análise de tráfego.</string>
     <string name="status_starting_up">Orbot está iniciando...</string>
   <string name="status_activated">Conectado à rede Tor</string>
   <string name="status_shutting_down">TorService está desligando</string>
@@ -19,7 +19,7 @@
     <string name="btn_okay">Okay</string>
     <!--Welcome Wizard strings (DJH)-->
   <string name="wizard_details">Alguns detalhes do Orbot</string>
-  <string name="wizard_details_msg">Orbot é um software de código aberto que contem Tor, Obfs4Proxy, BadVPN, Tun2Socks e LibEvent. Ele fornece um proxy local HTTP (8118) e um proxy SOCKS (9050) como acesso a rede Tor. Orbot também tem a habilidade, em dispositivos com acesso root, de enviar todo o trafego de Internet via rede Tor.</string>
+  <string name="wizard_details_msg">Orbot é um software de código aberto que contém Tor, Obfs4Proxy, BadVPN, Tun2Socks e LibEvent. Ele fornece um proxy local HTTP (8118) e um proxy SOCKS (9050) como acesso a rede Tor. Orbot também tem a habilidade, em dispositivos com acesso root, de enviar todo o trafego de Internet via rede Tor.</string>
     <!--END Welcome Wizard strings (DJH)-->
     <string name="pref_general_group">Geral</string>
   <string name="pref_start_boot_title">Iniciar Orbot no Boot</string>
@@ -36,7 +36,7 @@
   <string name="pref_entrance_node_summary">Impressões digitais, apelidos, países e endereços para a primeira etapa</string>
   <string name="pref_entrance_node_dialog">Insira os Nós de Entrada</string>
   <string name="pref_allow_background_starts_title">Permitir estrelas em segundo plano</string>
-  <string name="pref_allow_background_starts_summary">Deixar um aplicativo dizer Orbot para iniciar o Tor e seus serviços relacionados</string>
+  <string name="pref_allow_background_starts_summary">Permitir que um aplicativo diga ao Orbot para iniciar o Tor e seus serviços relacionados</string>
     <string name="pref_proxy_title">Proxy de saída da rede (Opcional)</string>
   <string name="pref_proxy_type_title">Tipo de Proxy</string>
   <string name="pref_proxy_type_summary">Protocolo para usar no servidor proxy: HTTP, HTTPS, Socks4, Socks5</string>
@@ -55,10 +55,10 @@
   <string name="pref_proxy_password_dialog">Digite a senha do Proxy</string>
   <string name="error">Erro</string>
   <string name="exit_nodes">Nós de Saída</string>
-  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">Impressões digitais, apelidos, países e endereços para a última etapa.</string>
+  <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">Impressões digitais, nicknames, países e endereços para a última etapa.</string>
   <string name="enter_exit_nodes">Insira os Nós de Saída</string>
   <string name="exclude_nodes">Nós Excluídos</string>
-  <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Impressões digitais, apelidos, países e endereços para excluir</string>
+  <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Impressões digitais, nicknames, países e endereços para excluir</string>
   <string name="enter_exclude_nodes">Insira Nós Excluídos</string>
   <string name="strict_nodes">Nós Estritos</string>
   <string name="use_only_these_specified_nodes">Use *somente* estes nós específicos</string>
@@ -73,9 +73,9 @@
   <string name="relay_port">Porta Retransmissora</string>
   <string name="listening_port_for_your_tor_relay">Ouvindo porta do seu retransmissor Tor</string>
   <string name="enter_or_port">Insira porta OR</string>
-  <string name="relay_nickname">Apelido do Retransmissor</string>
-  <string name="the_nickname_for_your_tor_relay">O apelido para seu retransmissor Tor</string>
-  <string name="enter_a_custom_relay_nickname">Insira um apelido de retransmissor customizado</string>
+  <string name="relay_nickname">Nickname do Retransmissor</string>
+  <string name="the_nickname_for_your_tor_relay">O nickname para seu retransmissor Tor</string>
+  <string name="enter_a_custom_relay_nickname">Insira um nickname de retransmissor customizado</string>
   <string name="reachable_addresses">Endereços Atingíveis</string>
   <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Rodar como um cliente atrás de um firewall com políticas restritivas.</string>
   <string name="reachable_ports">Portas Atingíveis</string>
@@ -94,7 +94,7 @@
   <string name="pref_use_expanded_notifications_title">Notificações Expandidas</string>
     <string name="set_locale_title">Idioma</string>
   <string name="pref_disable_network_title">Modo de espera automático</string>
-  <string name="pref_disable_network_summary">Colocar o Tor em modo de espera quando não houver acesso Internet disponível</string>
+  <string name="pref_disable_network_summary">Colocar o Tor em modo de espera quando não houver acesso à Internet disponível</string>
   <string name="newnym">Você trocou para uma nova identidade Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
   <string name="pref_socks_summary">Porta que Tor oferece seu proxy SOCKS (padrão: 9050 ou 0 para desativar)</string>
@@ -111,10 +111,10 @@
   <string name="kb">KB</string>
   <string name="mb">MB</string>
   <string name="bridges_updated">Pontes Atualizadas</string>
-  <string name="restart_orbot_to_use_this_bridge_">Por favor reinicie Orbot para habilitar as mundanças</string>
-    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. SELECIONE umas das opções para configurar e testar..,.</string>
+  <string name="restart_orbot_to_use_this_bridge_">Por favor reinicie o Orbot para habilitar as mundanças</string>
+    <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. SELECIONE umas das opções para configurar e testar...</string>
   <string name="get_bridges_email">Email</string>
-  <string name="activate">Atvar</string>
+  <string name="activate">Ativar</string>
   <string name="apps_mode">Modo VPN</string>
   <string name="send_email">Enviar Email</string>
   <string name="vpn_default_world">Global (Automático)</string>
@@ -125,16 +125,16 @@
   <string name="onion_port">Porta Onion</string>
   <string name="name">Nome</string>
   <string name="done">Feito!</string>
-    <string name="copy_address_to_clipboard">Copiar para a area de transferência </string>
+    <string name="copy_address_to_clipboard">Copiar para a area de transferência</string>
     <string name="backup_service">Serviço de Backup</string>
   <string name="delete_service">Remover Serviço</string>
   <string name="backup_saved_at_external_storage">Backup salvo em mídia externa</string>
   <string name="backup_restored">Backup Restaurado</string>
     <string name="restore_backup">Restaurar Backup</string>
   <string name="confirm_service_deletion">Confirmar a remoção do serviço</string>
-  <string name="click_again_for_backup">Clique novamente para backup</string>
+  <string name="click_again_for_backup">Clique novamente para fazer backup</string>
   <string name="service_type">Tipo do Serviço</string>
-    <string name="please_restart_Orbot_to_enable_the_changes">Por favor reinicie Orbot para habilitar as mundanças</string>
+    <string name="please_restart_Orbot_to_enable_the_changes">Por favor reinicie o Orbot para habilitar as mundanças</string>
   <string name="share_as_qr">Compartilhar como QR</string>
   <string name="disable">Desabilitar</string>
   <string name="enable">Ativar</string>
@@ -142,6 +142,6 @@
   <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (Melhor forma)</string>
   <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
   <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>
-    <string name="trouble_connecting">Problemas na conexão ? </string>
+    <string name="trouble_connecting">Problemas na conexão?</string>
   <string name="full_device_vpn">VPN PARA TODO O DISPOSITIVO</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Orbot</string>
-    <string name="app_description">O Orbot é um aplicativo de proxy livre que capacita outros aplicativos a usar a internet com mais segurança. O Orbot usa o Tor para criptografar o seu tráfego na internet e então o esconde \"saltando\" entre uma série de computadores ao redor do mundo. O Tor é um software livre e de rede aberta que ajuda você a se defender de certas formas de vigilância que ameacem a privacidade e a sua liberdade pessoal, as atividades e as relações comerciais confidenciais e o estado de segurança conhecida como análise de tráfego.</string>
-    <string name="menu_settings">Definições</string>
+    <string name="app_description">Orbot é um aplicativo de proxy livre que permite que outros aplicativos acessem a internet com mais segurança. Orbot usa o Tor para criptografar seu tráfego na internet e então o esconde \"pulando\" entre uma série de computadores ao redor do mundo. Tor é um software livre e de rede aberta que ajuda você a se defender de certas formas de vigilância que ameaçam privacidade e liberdade pessoais, atividades e relações comerciais confidenciais e segurança estatal conhecida como análise de tráfego.</string>
+    <string name="menu_settings">Configurações</string>
     <string name="menu_log">Registro</string>
     <string name="menu_stop">Parar</string>
     <string name="menu_about">Sobre</string>
@@ -27,10 +27,10 @@
     <string name="pref_node_configuration">Configuração do Nó</string>
     <string name="pref_node_configuration_summary">Aqui estão as configurações avançadas que podem reduzir o seu anonimato</string>
     <string name="pref_entrance_node">Nós de Entrada</string>
-    <string name="pref_entrance_node_summary">Impressões digitais, apelidos, países e endereços para a primeira etapa</string>
+    <string name="pref_entrance_node_summary">Impressões digitais, nicknames, países e endereços para a primeira etapa</string>
     <string name="pref_entrance_node_dialog">Insira os Nós de Entrada</string>
     <string name="pref_allow_background_starts_title">Permitir inicializações em segundo plano</string>
-    <string name="pref_allow_background_starts_summary">Deixar um aplicativo dizer ao Orbot para iniciar o Tor e os seus serviços relacionados</string>
+    <string name="pref_allow_background_starts_summary">Permitir que qualquer aplicativo diga ao Orbot para iniciar o Tor e os seus serviços relacionados</string>
     <string name="pref_proxy_title">Proxy de Saída da Rede (Opcional)</string>
     <string name="pref_proxy_type_title">Tipo de Proxy</string>
     <string name="pref_proxy_type_summary">Protocolo para usar no servidor proxy: HTTP, HTTPS, SOCKS4, SOCKS5</string>
@@ -49,23 +49,23 @@
     <string name="pref_proxy_password_dialog">Digite a Senha do Proxy</string>
     <string name="error">Erro</string>
     <string name="exit_nodes">Nós de Saída</string>
-    <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">Impressões digitais, apelidos, países e endereços para a última etapa</string>
+    <string name="fingerprints_nicks_countries_and_addresses_for_the_last_hop">Impressões digitais, nicknames, países e endereços para a última etapa</string>
     <string name="enter_exit_nodes">Insira os Nós de Saída</string>
     <string name="exclude_nodes">Nós Excluídos</string>
-    <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Impressões digitais, apelidos, países e endereços para excluir</string>
+    <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Impressões digitais, nicknames, países e endereços para excluir</string>
     <string name="enter_exclude_nodes">Insira os Nós Excluídos</string>
     <string name="strict_nodes">Nós Estritos</string>
     <string name="bridges">Pontes</string>
     <string name="use_bridges">Usar Pontes</string>
     <string name="relays">Retransmissores</string>
     <string name="relaying">Retransmitindo</string>
-    <string name="enable_your_device_to_be_a_non_exit_relay">Ativar o seu dispositivo para não ser um retransmissor de saída</string>
+    <string name="enable_your_device_to_be_a_non_exit_relay">Ativar o seu dispositivo para ser retransmissor sem saída</string>
     <string name="relay_port">Porta Retransmissora</string>
     <string name="listening_port_for_your_tor_relay">Ouvindo a porta do seu retransmissor Tor</string>
     <string name="enter_or_port">Insira a porta OR</string>
-    <string name="relay_nickname">Apelido do Retransmissor</string>
-    <string name="the_nickname_for_your_tor_relay">O apelido para o seu retransmissor Tor</string>
-    <string name="enter_a_custom_relay_nickname">Insira um apelido de retransmissão customizado</string>
+    <string name="relay_nickname">Nickname do Retransmissor</string>
+    <string name="the_nickname_for_your_tor_relay">O nickname para o seu retransmissor Tor</string>
+    <string name="enter_a_custom_relay_nickname">Insira um nickname de retransmissão personalizado</string>
     <string name="reachable_addresses">Endereços Atingíveis</string>
     <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Rodar como um cliente atrás de um firewall com políticas restritivas</string>
     <string name="reachable_ports">Portas Atingíveis</string>
@@ -75,10 +75,10 @@
     <string name="project_home">Site do projeto:</string>
     <string name="third_party_software">Software de Terceiros:</string>
     <string name="hidden_service_request">Um aplicativo quer abrir uma porta no servidor onion %1$s para a rede Tor. É seguro caso você confie neste aplicativo.</string>
-    <string name="pref_use_expanded_notifications">Exibe na notificação o país e o endereço IP do seu nó de saída do tor quando estiver disponível</string>
+    <string name="pref_use_expanded_notifications">Exibe na notificação o país e o endereço IP do seu nó de saída do Tor quando estiver disponível</string>
     <string name="pref_use_expanded_notifications_title">Notificações Expandidas</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Sem Rede, Modo de Espera Automático</string>
+    <string name="pref_disable_network_title">Sem rede. Modo de Espera Automático</string>
     <string name="pref_disable_network_summary">Colocar o Tor em modo de espera quando não houver Internet disponível</string>
     <string name="newnym">Você trocou para uma nova identidade Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
@@ -91,10 +91,10 @@
     <string name="pref_dnsport_summary">Porta que Tor oferece seu DNS no (padrão: 5400 ou 0 para desativar)</string>
     <string name="pref_dnsport_dialog">Config da Porta DNS</string>
     <string name="pref_torrc_title">Config Personalizada do Torrc</string>
-    <string name="pref_torrc_summary">SOMENTE EXPERIENTES: adicione sua própria linha de configuração torrc</string>
+    <string name="pref_torrc_summary">SOMENTE EXPERIENTES: adicione sua própria linha de configuração Torrc</string>
     <string name="pref_torrc_dialog">Torrc Personalizado</string>
     <string name="bridges_updated">Pontes Atualizadas</string>
-    <string name="restart_orbot_to_use_this_bridge_">Por favor reinicie Orbot para habilitar as mundanças</string>
+    <string name="restart_orbot_to_use_this_bridge_">Por favor, reinicie o Orbot para habilitar as mundanças</string>
     <string name="if_your_mobile_network_actively_blocks_tor_you_can_use_a_tor_bridge_to_access_the_network_another_way_to_get_bridges_is_to_send_an_email_to_bridges_torproject_org_please_note_that_you_must_send_the_email_using_an_address_from_one_of_the_following_email_providers_riseup_gmail_or_yahoo_">Se sua rede de dados bloqueia o Tor, você pode utilizar um \'Servidor Bridge\' como alternativa contra o bloqueio. Selecione umas das opções para configurar e testar…</string>
     <string name="get_bridges_email">E-mail</string>
     <string name="apps_mode">Modo VPN</string>
@@ -102,7 +102,7 @@
     <string name="vpn_default_world">Global (Automático)</string>
     <string name="hidden_services">Serviços Ocultos</string>
     <string name="menu_hidden_services">Serviços Ocultos</string>
-    <string name="save">Salve</string>
+    <string name="save">Salvar</string>
     <string name="local_port">Porta Local</string>
     <string name="onion_port">Porta Onion</string>
     <string name="name">Nome</string>
@@ -124,16 +124,16 @@
     <string name="bridge_direct_connect">Conecte-se diretamente ao Tor (Melhor forma)</string>
     <string name="bridge_community">Conecte-se através de servidores da comunidade</string>
     <string name="bridge_cloud">Conecte-se através de servidores em nuvem</string>
-    <string name="trouble_connecting">Problemas na conexão ? </string>
+    <string name="trouble_connecting">Problemas na conexão?</string>
     <string name="full_device_vpn">VPN PARA TODO O DISPOSITIVO</string>
     <string name="refresh_apps">Atualizar os Aplicativos</string>
     <string name="app_services">Serviços dos Aplicativos</string>
     <string name="user_services">Serviços ao Usuário</string>
     <string name="menu_new_identity">Nova Identidade</string>
     <string name="vpn_disabled">VPN Desativada</string>
-    <string name="pref_disable_ipv4_summary">Informa às saídas para não se conectarem aos endereços IPv4</string>
+    <string name="pref_disable_ipv4_summary">Informa às saídas para não se conectarem a endereços IPv4</string>
     <string name="pref_disable_ipv4">Desativar as conexões IPv4</string>
-    <string name="pref_prefer_ipv6_summary">Diz que os endereços IPv6 tem preferência</string>
+    <string name="pref_prefer_ipv6_summary">Diz que os endereços IPv6 têm preferência</string>
     <string name="pref_prefer_ipv6">Prefira conexões IPv6</string>
     <string name="pref_reduced_connection_padding_summary">Fecha as conexões de retransmissão mais cedo e envia menos pacotes de preenchimento para reduzir a utilização de dados e da bateria</string>
     <string name="pref_reduced_connection_padding">Preenchimento de conexão reduzido</string>
@@ -146,14 +146,14 @@
     <string name="onion">.onion</string>
     <string name="start_tor_again_for_finish_the_process">Inicie o Tor novamente para encerrar o processo</string>
     <string name="pref_http_dialog">Configuração da Porta HTTP</string>
-    <string name="pref_http_summary">Porta HTTP onde o proxy do Tor está escutando (a predefinição é: 8118 ou 0 para desativar)</string>
+    <string name="pref_http_summary">Porta HTTP onde o proxy do Tor está escutando (padrão: 8118 ou 0 para desativar)</string>
     <string name="pref_http_title">HTTP do Tor</string>
-    <string name="pref_open_proxy_on_all_interfaces_summary">Permita que os pares Wi-Fi, dispositivos com fio e que qualquer outra pessoa possa se conectar ao seu IP para acessar o Tor</string>
+    <string name="pref_open_proxy_on_all_interfaces_summary">Permita que os pares Wi-Fi, dispositivos com fio e qualquer outra pessoa que consiga se conectar ao seu IP possa acessar o Tor</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Abra o Proxy em Todas as Interfaces</string>
     <string name="bridge_snowflake">Conecte-se através de outros usuários do Tor usando o snowflake (Método 1 - Rápido)</string>
     <string name="use_qr_code">Use um Código QR</string>
     <string name="paste_bridges">Colar as Pontes</string>
-    <string name="in_a_browser">Visite o %s com um navegador e toque no Get Bridges &gt; Just Give Me Bridges!</string>
+    <string name="in_a_browser">Visite o %s com um navegador e toque no Get Bridges &gt; \"Just Give Me Bridges!\"</string>
     <string name="use_custom_bridges">Use Pontes Personalizadas</string>
     <string name="configure_custom_bridges">Configure as Pontes Personalizadas</string>
     <string name="custom_bridges">Pontes Personalizadas</string>
@@ -161,7 +161,7 @@
     <string name="refresh_captcha">Atualize o CAPTCHA</string>
     <string name="testing_tor_direct_success">Sucesso. A conexão com o Tor é boa!</string>
     <string name="testing_tor_direct">Testando a conexão com o Tor…</string>
-    <string name="pref_reduced_circuit_padding_summary">Use menos algoritmos de preenchimento para reduzir o uso dos dados e da bateria</string>
+    <string name="pref_reduced_circuit_padding_summary">Use menos algoritmos de preenchimento para reduzir o uso de dados e de bateria</string>
     <string name="pref_reduced_circuit_padding">Preenchimento reduzido do circuito</string>
     <string name="pref_circuit_padding_summary">Ative o preenchimento do circuito para se defender contra algumas formas de análise de tráfego</string>
     <string name="pref_circuit_padding">Preenchimento do circuito</string>
@@ -172,7 +172,7 @@
     <string name="get_bridges_email_request">Solicite Pontes através do E-mail</string>
     <string name="mebibyte">MiB</string>
     <string name="kibibyte">KiB</string>
-    <string name="confirm">Confirme</string>
+    <string name="confirm">Confirmar</string>
     <string name="v3_import_auth_private">Importe o .auth_private</string>
     <string name="v3_backup_name_hint">Nome do arquivo de backup…</string>
     <string name="v3_delete_client_authorization_confirm">Exclua a autorização do cliente</string>
@@ -183,8 +183,8 @@
     <string name="v3_key_hash">Chave privada x25519 na Base 32</string>
     <string name="v3_client_auth_activity_title">Autorização do cliente</string>
     <string name="v3_hosted_services">Serviços Onion hospedados</string>
-    <string name="deny">Negue</string>
-    <string name="allow">Permita</string>
+    <string name="deny">Negar</string>
+    <string name="allow">Permitir</string>
     <string name="backup_port_exist">Erro: Um serviço Onion já está usando a porta %s</string>
     <string name="version">Versão:</string>
     <string name="license">Licença:</string>
@@ -203,7 +203,7 @@
     <string name="secure_your_connection_subtitle">Oculte o aplicativos do monitoramento da rede e obtenha acesso quando eles estiverem bloqueados.</string>
     <string name="btn_configure">Escolha como se conectar</string>
     <string name="btn_start_vpn">Iniciar a VPN</string>
-    <string name="volunteer_mode">Modo bondade</string>
+    <string name="volunteer_mode">Modo Bondade</string>
     <string name="trying_to_connect_title">Conectando…</string>
     <string name="btn_change_exit">Altere a saída</string>
     <string name="menu_help_others">Ajude os outros</string>
@@ -212,14 +212,14 @@
     <string name="btn_tor_off">Desligar o Tor</string>
     <string name="no_thx">Não, obrigado</string>
     <string name="menu_header_features">Características</string>
-    <string name="captcha_title">Diga-nos que é humano</string>
+    <string name="captcha_title">Prove que é humano</string>
     <string name="menu_tor_connection">Conexão Tor</string>
     <string name="btn_use_custom_bridge">Use uma ponte personalizada</string>
     <string name="configure_header">Configure a sua conexão Tor</string>
-    <string name="volunteer_mode_subtitle_desc">O modo bondade permite que o seu dispositivo seja uma ponte para os outros. Ajuda as pessoas a usar o Tor em lugares onde ele esteja bloqueado.
+    <string name="volunteer_mode_subtitle_desc">O modo Bondade permite que o seu dispositivo seja uma ponte para os outros. Ajuda as pessoas a usar o Tor em lugares onde ele esteja bloqueado.
 \n
-\n• Não drenará a sua bateria
-\n• Não desacelerará a sua internet
+\n• Não drena a sua bateria
+\n• Não desacelera a sua internet
 \n• Só funciona via wi-fi
 \n• Pode ser desligado a qualquer momento</string>
     <string name="drawer_open">Abrir</string>
@@ -233,7 +233,7 @@
     <string name="proxy_ports">Portas do proxy</string>
     <string name="volunteer_mode_title">Ajude outros
 \na se conectar ao Tor</string>
-    <string name="volunteer_mode_label">Modo bondade</string>
+    <string name="volunteer_mode_label">Modo Bondade</string>
     <string name="volunteer_mode_weekly_label">Total semanal</string>
     <string name="volunteer_mode_alltime_label">Total de todos os períodos</string>
     <string name="ports_not_set">Portas não definidas</string>
@@ -251,8 +251,8 @@
     <string name="having_trouble">Tendo problemas</string>
     <string name="power_user_description">Para usuários familiarizados com Tor. Permite que você inicie o Orbot sem a configuração VPN e mostra as portas SOCKS e HTTP que estejam abertas</string>
     <string name="action_activate">Ativar</string>
-    <string name="volunteer_status_title">Hoje está melhor
-\npor sua causa.</string>
+    <string name="volunteer_status_title">Hoje o dia está melhor
+\ngraças a você.</string>
     <string name="title_choose_apps">Escolha os aplicativos</string>
     <string name="app_suggested_subtitle">O Orbot funciona melhor com aplicativos de mensagens e mídias sociais.</string>
     <string name="apps_suggested_title">Sugestões de aplicativos</string>
@@ -261,8 +261,8 @@
     <string name="hide_apps">Oculte os aplicativos de monitoramento da rede e obtenha acesso quando eles estiverem bloqueados.</string>
     <string name="log_copied">Registro log copiado</string>
     <string name="snowflake_amp">Snowflake (AMP)</string>
-    <string name="not_sure">Não tem certeza\?</string>
-    <string name="kindess_config_detail">Configure como e quando o seu dispositivo poder atuar como um proxy Snowflake para outros usuários do Tor.</string>
+    <string name="not_sure">Não tem certeza?</string>
+    <string name="kindess_config_detail">Configure como e quando o seu dispositivo pode atuar como um proxy Snowflake para outros usuários do Tor.</string>
     <string name="many_ways">Existem muitas maneiras de chegar ao Tor. Alguns podem funcionar melhor do que outros para você.</string>
     <string name="ask_tor">Pergunte ao Tor</string>
     <string name="action_use">Usar</string>
@@ -278,7 +278,7 @@
     <string name="setting_debug">Depurar</string>
     <string name="option_only_on_wifi">Apenas no WiFi</string>
     <string name="option_only_when_charging">Apenas ao carregar</string>
-    <string name="menu_kindness">Delicadeza</string>
+    <string name="menu_kindness">Bondade</string>
     <string name="setting_padding">Preenchimento</string>
     <string name="menu_more">Mais</string>
 </resources>

--- a/description/pt-rBR.xlf
+++ b/description/pt-rBR.xlf
@@ -45,7 +45,7 @@ IT’S OFFICIAL: This is the official version of the Tor onion routing service f
       </trans-unit>
       <trans-unit id="universalmode">
         <source>UNIVERSAL MODE: Orbot can be configured to transparently proxy all of your Internet traffic through Tor. You can also choose which specific apps you want to use through Tor.</source>
-        <target>MODO UNIVERSAL: Orbot pode ser configurado de forma transparente para transportar todo o seu tráfego de Internet através da rede Tor. Você também pode escolher quais aplicativos específicos deseja utilizar através da rede Tor.</target>
+        <target>MODO UNIVERSAL: Orbot pode ser configurado de forma transparente para transportar todo o seu tráfego de Internet através da rede Tor. Você também pode escolher quais aplicativos em específico deseja utilizar através da rede Tor.</target>
       </trans-unit>
       <trans-unit id="wespeakyourlanguage">
         <source>★ WE SPEAK YOUR LANGUAGE: Orbot is available for friends who speak:</source>
@@ -58,7 +58,7 @@ IT’S OFFICIAL: This is the official version of the Tor onion routing service f
       </trans-unit>
       <trans-unit id="helptranslate">
         <source>Don’t see your language? Join us and help translate the app:</source>
-        <target>Não vê seu idioma? Junte-se a nós e ajude a traduzir o aplicativo:</target>
+        <target>Não encontrou o seu idioma? Junte-se a nós e ajude a traduzir o aplicativo:</target>
       </trans-unit>
       <trans-unit id="helptranslateurl" translate="no">
         <source>https://www.transifex.com/projects/p/orbot</source>

--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -1,23 +1,23 @@
 Orbot
 Proxy com Tor
-Orbot é um aplicativo de proxy livre que permite que outras aplicações usem a internet de forma mais segura. O Orbot usa o Tor para criptografar o tráfego da Internet e usando uma série de caminhos alternativos através de uma série de computadores ao redor do mundo escondendo o seu computador. Tor é um software livre de rede aberta que ajuda você a se defender contra algumas formas de vigilâncias que ameaçam a liberdade, privacidade, atividades comerciais, confidenciais e relacionamentos. Assim como segurança imposta pelo Estado de análise de tráfego.
+Orbot é um aplicativo de proxy livre que permite que outras aplicações usem a internet de forma mais segura. O Orbot usa o Tor para criptografar o tráfego da Internet, usando uma série de caminhos alternativos através de uma série de computadores ao redor do mundo escondendo o seu computador. Tor é um software livre de rede aberta que ajuda você a se defender contra algumas formas de vigilâncias que ameaçam a liberdade, privacidade, atividades comerciais, confidenciais e relacionamentos. Assim como segurança imposta pelo Estado de análise de tráfego.
 
 Orbot é o único aplicativo que cria uma conexão verdadeiramente privada com a internet. Como o New York Times descreveu, “quando uma comunicação chega a partir da rede Tor, você não saberá de onde vem ou de onde partiu.”
 
 Tor ganhou em 2012 o prêmio Electronic Frontier Foundation (EFF) Pioneer Award.
 
-★ NÃO ACEITE NENHUM SUBSTITUTO: O Orbot sem dúvida é a forma mais segura de usar a Internet em dispositivos com o sistema operacional Android (Tvs, tablets, celulares e etc ). O Orbot transfere o seu tráfego criptografado várias vezes entre computadores espalhados geograficamente em todo o mundo, em vez de conectá-lo diretamente ao seu destino, assim como fazem as VPNs e proxies. Esse processo demora um pouco mais se comparado a uma conexão normal, porém é o preço que se paga para ter mais privacidade e proteção de identidade, vale a pena esperar.
+★ NÃO ACEITE NENHUM SUBSTITUTO: O Orbot sem dúvida é a forma mais segura de usar a Internet em dispositivos com o sistema operacional Android (Tvs, tablets, celulares, etc). O Orbot transfere o seu tráfego criptografado várias vezes entre computadores espalhados geograficamente em todo o mundo, em vez de conectá-lo diretamente ao seu destino, assim como fazem as VPNs e proxies. Esse processo demora um pouco mais se comparado a uma conexão normal, porém é o preço que se paga para ter mais privacidade e proteção de identidade. Vale a pena esperar um pouco.
 ★ PRIVACIDADE PARA OS APLICATIVOS: Qualquer aplicativo pode ser roteado via Tor através do recurso Orbot VPN
-★ PRIVACIDADE PARA TODOS: O Orbot impede que alguém que esteja observando a sua conexão saiba quais os aplicativos você está usando ou quais os sites você acessa. Tudo o que a pessoa que esteja monitorando o seu tráfego de rede poderá ver, é que você está usando o Tor.
-★ UMA FORMA FÁCIL DE TER PRIVACIDADE: Confira a nossa diversão, passo a passo de modo interativo: https://guardianproject.info/howto/browsefreely
-★ É OFICIAL: Esta é uma versão oficial do serviço de roteamento cebola Tor para o Android.
+★ PRIVACIDADE PARA TODOS: O Orbot impede que alguém que esteja observando a sua conexão saiba quais os aplicativos você está usando ou quais os sites você acessa. Tudo o que está visível para a pessoa que está lhe monitorando é que você está usando a rede Tor.
+★ UMA FORMA FÁCIL DE TER PRIVACIDADE: Confira como instalar a nossa "brincadeirinha" com esse passo a passo interativo: https://guardianproject.info/howto/browsefreely
+★ É OFICIAL: Esta é uma versão oficial do serviço de roteamento da rede Tor para o Android.
 
 *** Nós amamos comentários ***
 ★ SAIBA MAIS: Saiba mais sobre o Orbot e participe em https://orbot.app
 ★ QUEM SOMOS: O Guardian Project é um grupo de desenvolvedores que fazem aplicações móveis seguras e de código aberto para um amanhã melhor.
-★ CÓDIGO ABERTO: O Orbot é um software livre. Dê uma olhada em nosso código fonte, ou juntar-se a nossa comunidade para torná-lo ainda melhor: https://github.com/guardianproject/orbot
+★ CÓDIGO ABERTO: O Orbot é um software livre. Dê uma olhada em nosso código fonte, ou junte-se a nossa comunidade para torná-lo ainda melhor: https://github.com/guardianproject/orbot
 SOBRE O PROJETO Tor: https://TorProject.org
-★ MANDE-NOS UMA MENSAGEM: Será que estamos desprezando o seu recurso favorito? Encontrou algum bug chato? Gostaríamos muito de ouvir de você! Envie-nos um e-mail: root@guardianproject.info
+★ MANDE-NOS UMA MENSAGEM: Estamos deixando de lado seu recurso favorito? Encontrou algum bug chato? Gostaríamos muito de ouvir de você! Envie-nos um e-mail: root@guardianproject.info
 
 ***Isenção de Responsabilidade***
-O Guardian Project faz aplicativos que foram projetados para proteger a sua segurança e o anonimato. Os protocolos que usamos são amplamente considerados como o estado da arte em tecnologia de segurança. Enquanto estamos constantemente atualizando o nosso software para combater as ameaças mais recentes e eliminar bugs, nenhuma tecnologia é 100% infalível. Para a máxima segurança e anonimato, os usuários devem utilizar as melhores práticas para se manterem seguros. Você pode encontrar um bom guia introdutório para esses tópicos em https://securityinabox.org
+|O Guardian Project faz aplicativos que foram projetados para proteger a sua segurança e o anonimato. Os protocolos que usamos são amplamente considerados como a arte em tecnologia de segurança. Enquanto estamos constantemente atualizando o nosso software para combater as ameaças mais recentes e eliminar bugs, nenhuma tecnologia é 100% infalível. Para a máxima segurança e anonimato, os usuários devem utilizar as melhores práticas para se manterem seguros. Você pode encontrar um bom guia introdutório para esses tópicos em https://securityinabox.org


### PR DESCRIPTION
Plenty of the Brazilian Portuguese entries were actually written in Portuguese from Portugal, which is really different from Brazilian Portuguese. This can cause Brazilian users to, sometimes, not understand what is going on. Also, some translations were just plain wrong or just misspelled. I believe I've solved such problems.