### PR TITLE
Underline a text for better clarity 

### DIFF
--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.graphics.Paint
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.VpnService
@@ -254,6 +255,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
         tvSubtitle.text = getString(R.string.secure_your_connection_subtitle)
         tvConfigure.visibility = View.VISIBLE
         tvConfigure.text = getString(R.string.btn_configure)
+        tvConfigure.paintFlags = Paint.UNDERLINE_TEXT_FLAG
         tvConfigure.setOnClickListener {openConfigureTorConnection()}
         with(btnStartVpn) {
             visibility = View.VISIBLE


### PR DESCRIPTION
A minor UX improvement that makes it more clear to the user that the "Choose How To Connect" is a clickable button by underlining it. This change only affects the ConnectFragment and not the ConfigConnectionBottomSheet where an underline is not needed.

| How it looks now: |
| --- |
| <img src="https://github.com/guardianproject/orbot/assets/114044633/9f119003-6a1a-4ec4-aaaa-56a5c1ffb6e4" width="200"> |