### PR TITLE
Fix teevee build failures

### DIFF
--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -16,7 +16,7 @@ android {
             dimension "teevee"
             minSdkVersion 23 
             applicationId 'org.torproject.android.tv'
-            compileSdkVersion 31
+            compileSdkVersion 33
             versionCode 10020000
             versionName 'orbot-tv-1.0.1-tor-0.4.7.14'
             archivesBaseName = "Orbot-TV-$versionName"

--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -26,6 +26,12 @@ android {
 
 }
 
+configurations {
+    all {
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-ktx'
+    }
+}
+
 dependencies {
     implementation(
             project(':appcore'),

--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -18,7 +18,7 @@ android {
             applicationId 'org.torproject.android.tv'
             compileSdkVersion 31
             versionCode 10020000
-            versionName 'orbot-tv-1.0.1-tor-0.4.7.11'
+            versionName 'orbot-tv-1.0.1-tor-0.4.7.14'
             archivesBaseName = "Orbot-TV-$versionName"
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,10 @@ android {
         }
     }
 
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
     flavorDimensions "free"
 
     productFlavors {


### PR DESCRIPTION
Fix several build failures for Orbot app-tv variant when calling `gradlew assembleRelease`.

1) Set compileSdkVersion to 33  for app-tv since this is now required and causes a build failure.
2) Fix duplicate class androidx.lifecycle.ViewModelLazy found by excluding older kts version
3) Fix another jvm/java version mismatch.  Both java and jvm should be set to 17.