### PR TITLE
Disallow clearance of Orbot app data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,11 +35,12 @@
     <application
         android:name=".OrbotApp"
         android:allowBackup="false"
-        android:allowClearUserData="true"
+        android:allowClearUserData="false"
         android:configChanges="locale|orientation|screenSize"
         android:description="@string/app_description"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:manageSpaceActivity=".ui.ManageSpaceActivity"
         android:theme="@style/DefaultTheme"
         tools:replace="android:allowBackup"
         android:hasFragileUserData="false"

--- a/app/src/main/java/org/torproject/android/ui/ManageSpaceActivity.kt
+++ b/app/src/main/java/org/torproject/android/ui/ManageSpaceActivity.kt
@@ -1,0 +1,14 @@
+package org.torproject.android.ui
+
+import android.app.Activity
+import android.os.Bundle
+
+// Creates a dummy activity to manage data clearance
+class ManageSpaceActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Kills the activity on creation
+        finish()
+    }
+}


### PR DESCRIPTION
Partly addresses #870 by solving the second issue (relating to clearing app data) by disallowing this option. The system is directed to a dummy activity which kills itself instantly the user clears the data.

This is done to prevent any sort of tampering with the app and serves as a good security measure which can later be complemented with other features like app locking using biometric or pin code.