### PR TITLE
Set ConnectionPathway when Custom Bridges are used

### DIFF
--- a/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
@@ -127,7 +127,12 @@ class ConfigConnectionBottomSheet(private val callbacks: ConnectionHelperCallbac
                 Prefs.putConnectionPathway(Prefs.PATHWAY_SNOWFLAKE_AMP)
                 closeAndConnect()
             } **/else if (rbCustom.isChecked) {
-                CustomBridgeBottomSheet(callbacks).show(requireActivity().supportFragmentManager, CustomBridgeBottomSheet.TAG)
+                CustomBridgeBottomSheet(object : ConnectionHelperCallbacks {
+                    override fun tryConnecting() {
+                        Prefs.putConnectionPathway(Prefs.PATHWAY_CUSTOM)
+                        callbacks.tryConnecting()
+                    }
+                }).show(requireActivity().supportFragmentManager, CustomBridgeBottomSheet.TAG)
             }
         }
 


### PR DESCRIPTION
Addresses #924.

Previously, ConnectionPathway was not set when "Custom Bridge" is selected. Now it is set when user clicks on "Connect".