### PR TITLE
Remove unused STUN server

### DIFF
--- a/orbotservice/src/main/assets/fronts
+++ b/orbotservice/src/main/assets/fronts
@@ -1,6 +1,6 @@
 snowflake-target https://snowflake-broker.torproject.net.global.prod.fastly.net/
 snowflake-front github.githubassets.com
-snowflake-stun stun:stun.l.google.com:19302,stun:stun.altar.com.pl:3478,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.sonetel.net:3478,stun:stun.stunprotocol.org:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
+snowflake-stun stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.sonetel.net:3478,stun:stun.stunprotocol.org:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
 snowflake-target-direct https://snowflake-broker.torproject.net/
 snowflake-amp-front www.google.com
 snowflake-amp-cache https://cdn.ampproject.org/


### PR DESCRIPTION
stun.altar.com.pl is no longer used by torproject