### PR TITLE
Configure md templates for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG]'
+labels: bug
+assignees: ''
+
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**What Custom Configuration Do You Use?**
+If applicable, how did you set up Orbot? Did you configure some settings?
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Smartphone (please complete the following information):**
+- Device: [e.g. Pixel 8]
+- OS: [e.g. Android 14]
+- Version: [e.g. v17.1 RC 2]
+
+**Crash Logs (Advanced)**
+If applicable, add crash logs collected using ADB Logcat.
+
+**Additional Context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[Feature Request]'
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the Solution You'd Like**
+A clear and concise description of what you want to happen.
+
+**Describe the Alternatives You've Considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: A general question about the app or its implementation
+title: '[Question]'
+labels: question
+assignees: ''
+
+---
+
+**Describe Your Question**
+A clear and concise description of what you want to happen.
+
+**Is Your Question Related?**
+Is your question related to an existing/previous issue? Describe.
+
+**Additional Context**
+Add any other context or screenshots about the question here.


### PR DESCRIPTION
- The PR introduces three markdown templates for different types of GitHub issues: questions, bug reports, and feature requests.
- These templates automatically add titles and labels to the issues, helping to categorize and organize them more effectively.
- The templates also suggest relevant fields to be filled out when creating an issue, ensuring that all necessary information is provided for better issue resolution.