### PR TITLE
Replace multiple deprecated methods

### DIFF
--- a/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
+++ b/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
@@ -435,7 +435,7 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
         try {
             String aboutText = readFromAssets(this, "LICENSE");
             aboutText = aboutText.replace("\n", "<br/>");
-            aboutOther.setText(Html.fromHtml(aboutText));
+            aboutOther.setText(Html.fromHtml(aboutText, Html.FROM_HTML_MODE_LEGACY));
         } catch (Exception e) {
         }
 

--- a/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
+++ b/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
@@ -65,7 +65,9 @@ import org.torproject.android.service.vpn.TorifiedApp;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -73,6 +75,7 @@ import java.util.StringTokenizer;
 
 public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLongClickListener {
 
+    private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
     private static final int RESULT_CLOSE_ALL = 0;
     private final static int REQUEST_VPN = 8888;
     private final static int REQUEST_SETTINGS = 0x9874;
@@ -519,7 +522,11 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
                 var loc = new Locale.Builder().setLanguage(Prefs.getDefaultLocale()).build();
                 if (urlString.toLowerCase(loc).startsWith("bridge://")) {
                     String newBridgeValue = urlString.substring(9); //remove the bridge protocol piece
-                    newBridgeValue = URLDecoder.decode(newBridgeValue); //decode the value here
+                    try {
+                        newBridgeValue = URLDecoder.decode(newBridgeValue, DEFAULT_ENCODING); //decode the value here
+                    } catch (UnsupportedEncodingException e) {
+                        throw new RuntimeException(e);
+                    }
 
                     showAlert(getString(R.string.bridges_updated), getString(R.string.restart_orbot_to_use_this_bridge_) + newBridgeValue, false);
 
@@ -636,7 +643,7 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
                     int urlIdx = results.indexOf("://");
 
                     if (urlIdx != -1) {
-                        results = URLDecoder.decode(results, "UTF-8");
+                        results = URLDecoder.decode(results, DEFAULT_ENCODING);
                         results = results.substring(urlIdx + 3);
 
                         showAlert(getString(R.string.bridges_updated), getString(R.string.restart_orbot_to_use_this_bridge_) + results, false);

--- a/app-tv/src/main/java/org/torproject/android/tv/ui/onboarding/OnboardingActivity.java
+++ b/app-tv/src/main/java/org/torproject/android/tv/ui/onboarding/OnboardingActivity.java
@@ -3,6 +3,7 @@ package org.torproject.android.tv.ui.onboarding;
 import android.content.Context;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import com.github.paolorotolo.appintro.AppIntro;
 
@@ -29,8 +30,8 @@ public class OnboardingActivity extends AppIntro {
 
         // OPTIONAL METHODS
         // Override bar/separator color.
-        setBarColor(getResources().getColor(R.color.dark_green));
-        setSeparatorColor(getResources().getColor(R.color.panel_background_main));
+        setBarColor(ContextCompat.getColor(this, R.color.dark_green));
+        setSeparatorColor(ContextCompat.getColor(this, R.color.panel_background_main));
 
         // Hide Skip/Done button.
         showSkipButton(false);

--- a/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
@@ -241,13 +241,7 @@ class ConfigConnectionBottomSheet(private val callbacks: ConnectionHelperCallbac
         if (countryCode != null && countryCode.length == 2)
                   return countryCode.lowercase(Locale.getDefault())
 
-
-        // If network country not available (tablets maybe), get country code from Locale class
-        countryCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            context.resources.configuration.locales[0].country
-        } else {
-            context.resources.configuration.locale.country
-        }
+        countryCode = context.resources.configuration.locales[0].country
 
         return if (countryCode != null && countryCode.length == 2)
             countryCode.lowercase(Locale.getDefault()) else "us"

--- a/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
@@ -13,6 +13,7 @@ import android.widget.Button
 import android.widget.CompoundButton
 import android.widget.RadioButton
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import org.torproject.android.circumvention.Bridges
 import org.torproject.android.circumvention.CircumventionApiManager
 import org.torproject.android.circumvention.SettingsRequest
@@ -172,7 +173,7 @@ class ConfigConnectionBottomSheet(private val callbacks: ConnectionHelperCallbac
 
     private fun askTor () {
 
-        val dLeft = activity?.getDrawable(R.drawable.ic_faq)
+        val dLeft = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_faq)
         btnAskTor.text = getString(R.string.asking)
         btnAskTor.setCompoundDrawablesWithIntrinsicBounds(dLeft, null, null, null)
 
@@ -255,7 +256,7 @@ class ConfigConnectionBottomSheet(private val callbacks: ConnectionHelperCallbac
 
     private fun setPreferenceForSmartConnect() {
 
-        val dLeft = activity?.getDrawable(R.drawable.ic_green_check)
+        val dLeft = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_green_check)
         btnAskTor.setCompoundDrawablesWithIntrinsicBounds(dLeft, null, null, null)
 
         circumventionApiBridges?.let {

--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -273,9 +273,9 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
             text = if (Prefs.isPowerUserMode())
                 getString(R.string.connect)
             else if (connectStr.isEmpty())
-                Html.fromHtml("<big>${getString(R.string.btn_start_vpn)}</big>")
+                Html.fromHtml("<big>${getString(R.string.btn_start_vpn)}</big>", Html.FROM_HTML_MODE_LEGACY)
             else
-                Html.fromHtml("<big>${getString(R.string.btn_start_vpn)}</big><br/><small>${connectStr}</small>")
+                Html.fromHtml("<big>${getString(R.string.btn_start_vpn)}</big><br/><small>${connectStr}</small>", Html.FROM_HTML_MODE_LEGACY)
 
 
             isEnabled = true

--- a/app/src/main/java/org/torproject/android/ui/AboutDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/AboutDialogFragment.java
@@ -65,7 +65,7 @@ public class AboutDialogFragment extends DialogFragment {
             try {
                 String aboutText = DiskUtils.readFileFromAssets("LICENSE", getContext());
                 aboutText = aboutText.replaceAll(ABOUT_LICENSE_EQUALSIGN, "\n").replace("\n\n", "<br/><br/>").replace("\n", "");
-                tvAbout.setText(Html.fromHtml(aboutText));
+                tvAbout.setText(Html.fromHtml(aboutText, Html.FROM_HTML_MODE_LEGACY));
             } catch (IOException e) {
             }
         }

--- a/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerActivity.java
@@ -29,6 +29,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import org.torproject.android.BuildConfig;
 import org.torproject.android.R;
@@ -222,10 +223,10 @@ public class AppManagerActivity extends AppCompatActivity implements OnClickList
 
                 convertView.setOnFocusChangeListener((v, hasFocus) -> {
                     if (hasFocus)
-                        v.setBackgroundColor(getResources().getColor(R.color.dark_purple));
+                        v.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.dark_purple));
                     else
                     {
-                        v.setBackgroundColor(getResources().getColor(android.R.color.transparent));
+                        v.setBackgroundColor(ContextCompat.getColor(getContext(), android.R.color.transparent));
                     }
                 });
 

--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesActivity.java
@@ -35,9 +35,11 @@ import org.torproject.android.service.util.Prefs;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class CustomBridgesActivity extends AppCompatActivity implements TextWatcher {
 
+    private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
     private static final String EMAIL_TOR_BRIDGES = "bridges@torproject.org";
     private static final String URL_TOR_BRIDGES = "https://bridges.torproject.org/bridges";
 
@@ -130,8 +132,7 @@ public class CustomBridgesActivity extends AppCompatActivity implements TextWatc
                     int urlIdx = results.indexOf("://");
 
                     if (urlIdx != -1) {
-                        //noinspection CharsetObjectCanBeUsed   -- requires API 19, we are 18
-                        results = URLDecoder.decode(results, "UTF-8");
+                        results = URLDecoder.decode(results, DEFAULT_ENCODING);
                         results = results.substring(urlIdx + 3);
 
                         setNewBridges(results);

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActionsDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActionsDialogFragment.java
@@ -35,7 +35,7 @@ public class OnionServiceActionsDialogFragment extends DialogFragment {
         AlertDialog ad = new AlertDialog.Builder(getActivity())
                 .setItems(new CharSequence[]{
                         getString(R.string.copy_address_to_clipboard),
-                        Html.fromHtml(getString(R.string.backup_service)),
+                        Html.fromHtml(getString(R.string.backup_service), Html.FROM_HTML_MODE_LEGACY),
                         getString(R.string.delete_service)}, null)
                 .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())
                 .setTitle(R.string.hidden_services)

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActionsDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActionsDialogFragment.java
@@ -25,7 +25,7 @@ public class ClientAuthActionsDialogFragment extends DialogFragment {
         AlertDialog ad = new AlertDialog.Builder(getActivity())
                 .setTitle(R.string.v3_client_auth_activity_title)
                 .setItems(new CharSequence[]{
-                        Html.fromHtml(getString(R.string.v3_backup_key)),
+                        Html.fromHtml(getString(R.string.v3_backup_key), Html.FROM_HTML_MODE_LEGACY),
                         getString(R.string.v3_delete_client_authorization)
                 }, null)
                 .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())

--- a/appcore/src/main/java/org/torproject/android/core/LocaleHelper.kt
+++ b/appcore/src/main/java/org/torproject/android/core/LocaleHelper.kt
@@ -50,15 +50,14 @@ object LocaleHelper {
         return context.createConfigurationContext(configuration)
     }
 
-    @SuppressWarnings("deprecation")
     private fun updateResourcesLegacy(context: Context, language: String): Context {
         val locale = Locale(language)
         Locale.setDefault(locale)
         val resources = context.resources
         val configuration = resources.configuration
-        configuration.locale = locale
+        configuration.setLocale(locale)
         configuration.setLayoutDirection(locale)
-        resources.updateConfiguration(configuration, resources.displayMetrics)
+        context.createConfigurationContext(configuration)
         return context
     }
 }


### PR DESCRIPTION
Needed for and spun off from #956 

Fixed several deprecated methods:
- Html.fromHtml()
- activity?.getDrawable()
- methods related to locale
- URLDecoder.decode()
- getResources().getColor()

(Others still remain for now, until a later PR.)

Please provide feedback if I unintentionally caused any regressions, especially for locale related stuff.