### PR TITLE
Simplify repo management in Gradle settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,27 @@
+apply from: './dependencies.gradle'
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    apply from: './dependencies.gradle'
-    ext {
-        kotlin_version = '1.7.10'
-    }
-    repositories {
-        mavenCentral()
-        google()
-        maven { url 'https://jitpack.io' }
-     //   maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
+    ext.kotlin_version = '1.7.10'
 
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    //  maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath "com.android.tools.build:gradle:7.4.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 allprojects {
     repositories {
-
-        mavenCentral()
         google()
-        maven { url 'https://jitpack.io' }
+        mavenCentral()
+        maven { url "https://jitpack.io" }
         maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
-
-        /**
-        flatDir {
-            dirs 'libs'
-        }**/
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,26 +2,21 @@ apply from: './dependencies.gradle'
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext {
+        agp_version = '8.1.2'
+        kotlin_version = '1.7.10'
+    }
 
     repositories {
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
-    //  maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.2"
+        classpath "com.android.tools.build:gradle:$agp_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url "https://jitpack.io" }
-        maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
+		// NOTE: Do not place your application dependencies here; they belong
+		// in the individual module build.gradle files
     }
 }

--- a/commons-device.gradle
+++ b/commons-device.gradle
@@ -50,14 +50,3 @@ android {
     }
 
 }
-
-repositories {
-    //noinspection JcenterRepositoryObsolete
-    jcenter {
-        content {
-            includeGroup('com.jraska')
-            includeGroup('tools.fastlane')
-        }
-    }
-}
-

--- a/commons-limited-device.gradle
+++ b/commons-limited-device.gradle
@@ -1,6 +1,4 @@
-/*
-    Applies across android app module with limited capabilities: {app-tv}
- */
+// Applies across android app module with limited capabilities: app-tv
 apply from: "../commons-device.gradle"
 
 android {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 pluginManagement {
     repositories {
         google()
@@ -7,9 +9,16 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
+        // noinspection JcenterRepositoryObsolete
+        jcenter {
+            content {
+                includeGroup('com.jraska')
+                includeGroup('tools.fastlane')
+            }
+        }
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
@@ -23,6 +32,5 @@ include(
         ':appcore',
         ':intentintegrator',
         ':OrbotLib',
-        ':orbotservice',
-//      ':tor-android'
+        ':orbotservice'
 )

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,28 @@
-include ':intentintegrator'
-include ':appcore'
-include ':orbotservice'
-include ':OrbotLib'
-//include ':tor-android'
-include ':app'
-include ':app-tv'
-
-/**
-enableFeaturePreview("VERSION_CATALOGS")
-dependencyResolutionManagement {
-    versionCatalogs {
-        lib {
-            from(files("./gradle/libs.versions.toml"))
-        }
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
-}**/
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+        maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
+    }
+}
+
+rootProject.name = "Orbot"
+include(
+        ':app',
+        ':app-tv',
+        ':appcore',
+        ':intentintegrator',
+        ':OrbotLib',
+        ':orbotservice',
+//      ':tor-android'
+)


### PR DESCRIPTION
Needed for #915 

- Moved all repo declarations to settings
- Raise exception if any repo is defined outside
- Simplify commons files for later refactoring
- Deleted dead/commented-out code