### PR TITLE
Remove obsolete SDK version checks

### DIFF
--- a/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
+++ b/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
@@ -20,6 +20,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.net.VpnService;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -39,6 +40,7 @@ import android.widget.ImageView;
 import android.widget.Switch;
 import android.widget.TextView;
 
+import androidx.annotation.RequiresApi;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.palette.graphics.Palette;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -438,7 +440,9 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
         try {
             String aboutText = readFromAssets(this, "LICENSE");
             aboutText = aboutText.replace("\n", "<br/>");
-            aboutOther.setText(Html.fromHtml(aboutText, Html.FROM_HTML_MODE_LEGACY));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                aboutOther.setText(Html.fromHtml(aboutText, Html.FROM_HTML_MODE_LEGACY));
+            }
         } catch (Exception e) {
         }
 
@@ -589,6 +593,7 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     @Override
     protected void onActivityResult(int request, int response, Intent data) {
         super.onActivityResult(request, response, data);
@@ -900,6 +905,7 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
 
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     public void showAppConfig(String pkgId) {
         Intent data = new Intent(this, AppConfigActivity.class);
         data.putExtra(Intent.EXTRA_PACKAGE_NAME, pkgId);
@@ -967,7 +973,9 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
 
                     avh.iv.setVisibility(View.VISIBLE);
 
-                    avh.parent.setOnClickListener(v -> showAppConfig(pkgId));
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        avh.parent.setOnClickListener(v -> showAppConfig(pkgId));
+                    }
 
                     avh.parent.setOnFocusChangeListener((v, hasFocus) -> {
                         if (hasFocus)

--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -170,7 +170,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
         val listItems = arrayListOf(OrbotMenuAction(R.string.btn_change_exit, 0) {openExitNodeDialog()},
             OrbotMenuAction(R.string.btn_refresh, R.drawable.ic_refresh) {sendNewnymSignal()},
             OrbotMenuAction(R.string.btn_tor_off, R.drawable.ic_power) {stopTorAndVpn()})
-        if (OrbotActivity.CAN_DO_APP_ROUTING && (!Prefs.isPowerUserMode())) listItems.add(0, OrbotMenuAction(R.string.btn_choose_apps, R.drawable.ic_choose_apps) {
+        if ((!Prefs.isPowerUserMode())) listItems.add(0, OrbotMenuAction(R.string.btn_choose_apps, R.drawable.ic_choose_apps) {
             startActivityForResult(Intent(requireActivity(), AppManagerActivity::class.java), OrbotActivity.REQUEST_VPN_APP_SELECT)
         })
         lvConnectedActions.adapter = OrbotMenuActionAdapter(context, listItems)
@@ -279,14 +279,12 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
 
 
             isEnabled = true
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                backgroundTintList = ColorStateList.valueOf(
-                    ContextCompat.getColor(
-                        requireContext(),
-                        R.color.orbot_btn_enabled_purple
-                    )
+            backgroundTintList = ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.orbot_btn_enabled_purple
                 )
-            }
+            )
             setOnClickListener { startTorAndVpn() }
             //logBottomSheet.resetLog()
         }
@@ -323,14 +321,12 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
         with(btnStartVpn) {
             text = context.getString(android.R.string.cancel)
             isEnabled = true
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                backgroundTintList = ColorStateList.valueOf(
-                    ContextCompat.getColor(
-                        context,
-                        R.color.orbot_btn_enabled_purple
-                    )
+            backgroundTintList = ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    context,
+                    R.color.orbot_btn_enabled_purple
                 )
-            }
+            )
             setOnClickListener {
                 stopTorAndVpn()
             }

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -219,7 +219,6 @@ class OrbotActivity : BaseActivity() {
         const val REQUEST_CODE_VPN = 1234
         const val REQUEST_CODE_SETTINGS = 2345
         const val REQUEST_VPN_APP_SELECT = 2432
-        val CAN_DO_APP_ROUTING = PermissionManager.isLollipopOrHigher()
     }
 
     fun showLog() {

--- a/app/src/main/java/org/torproject/android/ui/OrbotTileService.kt
+++ b/app/src/main/java/org/torproject/android/ui/OrbotTileService.kt
@@ -2,12 +2,10 @@ package org.torproject.android.ui
 
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
-import android.os.Build
 import android.service.quicksettings.TileService
-import androidx.annotation.RequiresApi
+
 import org.torproject.android.OrbotActivity
 
-@RequiresApi(Build.VERSION_CODES.N)
 class OrbotTileService: TileService() {
 
     // Called when the user adds your tile.

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActionsDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActionsDialogFragment.java
@@ -67,12 +67,8 @@ public class OnionServiceActionsDialogFragment extends DialogFragment {
             Toast.makeText(context, R.string.please_restart_Orbot_to_enable_the_changes, Toast.LENGTH_LONG).show();
             return;
         }
-        if (DiskUtils.supportsStorageAccessFramework()) {
-            Intent createFileIntent = DiskUtils.createWriteFileIntent(filename, "application/zip");
-            startActivityForResult(createFileIntent, REQUEST_CODE_WRITE_FILE);
-        } else { // APIs 16, 17, 18
-            attemptToWriteBackup(Uri.fromFile(new File(DiskUtils.getOrCreateLegacyBackupDir(getString(R.string.app_name)), filename)));
-        }
+        Intent createFileIntent = DiskUtils.createWriteFileIntent(filename, "application/zip");
+        startActivityForResult(createFileIntent, REQUEST_CODE_WRITE_FILE);
     }
 
     @Override

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
@@ -113,12 +113,8 @@ public class OnionServiceActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_restore_backup) {
-            if (DiskUtils.supportsStorageAccessFramework()) {
-                Intent readFileIntent = DiskUtils.createReadFileIntent(ZipUtilities.ZIP_MIME_TYPE);
-                startActivityForResult(readFileIntent, REQUEST_CODE_READ_ZIP_BACKUP);
-            } else { // APIs 16, 17, 18
-                doRestoreLegacy();
-            }
+            Intent readFileIntent = DiskUtils.createReadFileIntent(ZipUtilities.ZIP_MIME_TYPE);
+            startActivityForResult(readFileIntent, REQUEST_CODE_READ_ZIP_BACKUP);
         }
         return super.onOptionsItemSelected(item);
     }
@@ -170,7 +166,6 @@ public class OnionServiceActivity extends AppCompatActivity {
     }
 
     void showBatteryOptimizationsMessageIfAppropriate() {
-        if (!PermissionManager.isAndroidM()) return;
         Cursor activeServices = getContentResolver().query(OnionServiceContentProvider.CONTENT_URI, OnionServiceContentProvider.PROJECTION,
                 OnionServiceContentProvider.OnionService.ENABLED + "=1", null, null);
         if (activeServices == null) return;

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/PermissionManager.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/PermissionManager.java
@@ -1,11 +1,9 @@
 package org.torproject.android.ui.v3onionservice;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.PowerManager;
 import android.provider.Settings;
 import android.view.View;
@@ -20,16 +18,7 @@ public class PermissionManager {
 
     private static final int SNACK_BAR_DURATION = 5000;
 
-    public static boolean isLollipopOrHigher() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
-    }
-
-    public static boolean isAndroidM() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
-    }
-
     @SuppressLint("WrongConstant") // docs *say* you can specify custom durations...
-    @TargetApi(Build.VERSION_CODES.M)
     public static void requestBatteryPermissions(FragmentActivity activity, View view) {
         final String packageName = activity.getPackageName();
         PowerManager pm = (PowerManager) activity.getApplicationContext().getSystemService(Context.POWER_SERVICE);
@@ -50,7 +39,6 @@ public class PermissionManager {
     }
 
     @SuppressLint("WrongConstant") // docs *say* you can specify custom durations...
-    @TargetApi(Build.VERSION_CODES.M)
     public static void requestDropBatteryPermissions(FragmentActivity activity, View view) {
         PowerManager pm = (PowerManager) activity.getApplicationContext().getSystemService(Context.POWER_SERVICE);
         if (!pm.isIgnoringBatteryOptimizations(activity.getPackageName())) {

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
@@ -115,13 +115,9 @@ public class ClientAuthActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_import_auth_priv) {
-            if (DiskUtils.supportsStorageAccessFramework()) {
-                // unfortunately no good way to filter .auth_private files
-                Intent readFileIntent = DiskUtils.createReadFileIntent(CLIENT_AUTH_SAF_MIME_TYPE);
-                startActivityForResult(readFileIntent, REQUEST_CODE_READ_ZIP_BACKUP);
-            } else { // APIs 16, 17, 18
-                doRestoreLegacy();
-            }
+            // Unfortunately no good way to filter .auth_private files
+            Intent readFileIntent = DiskUtils.createReadFileIntent(CLIENT_AUTH_SAF_MIME_TYPE);
+            startActivityForResult(readFileIntent, REQUEST_CODE_READ_ZIP_BACKUP);
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthBackupDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthBackupDialogFragment.java
@@ -101,12 +101,8 @@ public class ClientAuthBackupDialogFragment extends DialogFragment {
         String filename = etFilename.getText().toString().trim();
         if (!filename.endsWith(ClientAuthActivity.CLIENT_AUTH_FILE_EXTENSION))
             filename += ClientAuthActivity.CLIENT_AUTH_FILE_EXTENSION;
-        if (DiskUtils.supportsStorageAccessFramework()) {
-            Intent createFileIntent = DiskUtils.createWriteFileIntent(filename, ClientAuthActivity.CLIENT_AUTH_SAF_MIME_TYPE);
-            getActivity().startActivityForResult(createFileIntent, REQUEST_CODE_WRITE_FILE);
-        } else { // APIs 16, 17, 18
-            attemptToWriteBackup(Uri.fromFile(new File(DiskUtils.getOrCreateLegacyBackupDir("Orbot"), filename)));
-        }
+        Intent createFileIntent = DiskUtils.createWriteFileIntent(filename, ClientAuthActivity.CLIENT_AUTH_SAF_MIME_TYPE);
+        getActivity().startActivityForResult(createFileIntent, REQUEST_CODE_WRITE_FILE);
     }
 
     @Override

--- a/appcore/src/main/java/org/torproject/android/core/DiskUtils.kt
+++ b/appcore/src/main/java/org/torproject/android/core/DiskUtils.kt
@@ -1,21 +1,17 @@
 package org.torproject.android.core
 
-import android.annotation.TargetApi
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
+
 import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
 import java.io.InputStreamReader
 
 object DiskUtils {
-
-    @JvmStatic
-    fun supportsStorageAccessFramework() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
 
     @JvmStatic
     @Throws(IOException::class)
@@ -32,7 +28,6 @@ object DiskUtils {
     }
 
     @JvmStatic
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     fun createWriteFileIntent(filename: String, mimeType: String): Intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
         addCategory(Intent.CATEGORY_OPENABLE)
         type = mimeType
@@ -40,7 +35,6 @@ object DiskUtils {
     }
 
     @JvmStatic
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     fun createReadFileIntent(mimeType: String): Intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
         addCategory(Intent.CATEGORY_OPENABLE)
         type = mimeType

--- a/appcore/src/main/java/org/torproject/android/core/ui/NoPersonalizedLearningEditText.kt
+++ b/appcore/src/main/java/org/torproject/android/core/ui/NoPersonalizedLearningEditText.kt
@@ -1,10 +1,13 @@
 package org.torproject.android.core.ui
 
 import android.content.Context
+import android.os.Build
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
+import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatEditText
 
+@RequiresApi(Build.VERSION_CODES.O)
 class NoPersonalizedLearningEditText(context: Context, attrs: AttributeSet?) : AppCompatEditText(context, attrs) {
     init {
         imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -67,7 +67,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import IPtProxy.IPtProxy;
-import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
@@ -100,8 +99,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
     public static File appBinHome;
     public static File appCacheHome;
     private final ExecutorService mExecutor = Executors.newCachedThreadPool();
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP)
-    final boolean mIsLollipop = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    final boolean mIsLollipop = true;
     OrbotRawEventListener mOrbotRawEventListener;
     OrbotVpnManager mVpnManager;
     Handler mHandler;

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -99,7 +99,6 @@ public class OrbotService extends VpnService implements OrbotConstants {
     public static File appBinHome;
     public static File appCacheHome;
     private final ExecutorService mExecutor = Executors.newCachedThreadPool();
-    final boolean mIsLollipop = true;
     OrbotRawEventListener mOrbotRawEventListener;
     OrbotVpnManager mVpnManager;
     Handler mHandler;
@@ -1247,32 +1246,25 @@ public class OrbotService extends VpnService implements OrbotConstants {
     private StringBuffer processSettingsImplDirectPathway(StringBuffer extraLines) {
         var prefs = Prefs.getSharedPrefs(getApplicationContext());
         extraLines.append("UseBridges 0").append('\n');
-        if (Prefs.useVpn()) { //set the proxy here if we aren't using a bridge
-            if (!mIsLollipop) {
-                var proxyType = "socks5";
-                extraLines.append(proxyType + "Proxy" + ' ' + OrbotVpnManager.sSocksProxyLocalhost + ':' + OrbotVpnManager.sSocksProxyServerPort).append('\n');
-            }
-        } else {
-            var proxyType = prefs.getString("pref_proxy_type", null);
-            if (proxyType != null && proxyType.length() > 0) {
-                var proxyHost = prefs.getString("pref_proxy_host", null);
-                var proxyPort = prefs.getString("pref_proxy_port", null);
-                var proxyUser = prefs.getString("pref_proxy_username", null);
-                var proxyPass = prefs.getString("pref_proxy_password", null);
+        var proxyType = prefs.getString("pref_proxy_type", null);
+        if (proxyType != null && proxyType.length() > 0) {
+            var proxyHost = prefs.getString("pref_proxy_host", null);
+            var proxyPort = prefs.getString("pref_proxy_port", null);
+            var proxyUser = prefs.getString("pref_proxy_username", null);
+            var proxyPass = prefs.getString("pref_proxy_password", null);
 
-                if ((proxyHost != null && proxyHost.length() > 0) && (proxyPort != null && proxyPort.length() > 0)) {
-                    extraLines.append(proxyType).append("Proxy").append(' ').append(proxyHost).append(':').append(proxyPort).append('\n');
+            if ((proxyHost != null && proxyHost.length() > 0) && (proxyPort != null && proxyPort.length() > 0)) {
+                extraLines.append(proxyType).append("Proxy").append(' ').append(proxyHost).append(':').append(proxyPort).append('\n');
 
-                    if (proxyUser != null && proxyPass != null) {
-                        if (proxyType.equalsIgnoreCase("socks5")) {
-                            extraLines.append("Socks5ProxyUsername").append(' ').append(proxyUser).append('\n');
-                            extraLines.append("Socks5ProxyPassword").append(' ').append(proxyPass).append('\n');
-                        } else
-                            extraLines.append(proxyType).append("ProxyAuthenticator").append(' ').append(proxyUser).append(':').append(proxyPort).append('\n');
-
-                    } else if (proxyPass != null)
+                if (proxyUser != null && proxyPass != null) {
+                    if (proxyType.equalsIgnoreCase("socks5")) {
+                        extraLines.append("Socks5ProxyUsername").append(' ').append(proxyUser).append('\n');
+                        extraLines.append("Socks5ProxyPassword").append(' ').append(proxyPass).append('\n');
+                    } else
                         extraLines.append(proxyType).append("ProxyAuthenticator").append(' ').append(proxyUser).append(':').append(proxyPort).append('\n');
-                }
+
+                } else if (proxyPass != null)
+                    extraLines.append(proxyType).append("ProxyAuthenticator").append(' ').append(proxyUser).append(':').append(proxyPort).append('\n');
             }
         }
         return extraLines;

--- a/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -16,7 +16,6 @@
 
 package org.torproject.android.service.vpn;
 
-import android.annotation.TargetApi;
 import android.app.Service;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -55,16 +54,11 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-
-import androidx.annotation.ChecksSdkIntAtLeast;
-
 import IPtProxy.IPtProxy;
 import IPtProxy.PacketFlow;
 
 public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
     private static final String TAG = "OrbotVpnService";
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP)
-    private final static boolean mIsLollipop = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     public static int sSocksProxyServerPort = -1;
     public static String sSocksProxyLocalhost = null;
     boolean isStarted = false;
@@ -123,10 +117,6 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
                         mTorSocks = torSocks;
                         mTorDns = torDns;
 
-                        if (!mIsLollipop) {
-                            startSocksBypass();
-                        }
-
                         setupTun2Socks(builder);
                     }
                 }
@@ -137,9 +127,6 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
 
     public void restartVPN (VpnService.Builder builder) {
         stopVPN();
-        if (!mIsLollipop) {
-            startSocksBypass();
-        }
         setupTun2Socks(builder);
     }
 
@@ -183,8 +170,6 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
     }
 
     private void stopVPN() {
-        if (!mIsLollipop)
-            stopSocksBypass();
 
         keepRunningPacket = false;
 
@@ -250,8 +235,7 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
                 builder.setHttpProxy(ProxyInfo.buildDirectProxy("localhost",mTorHttp));
             }**/
 
-            if (mIsLollipop)
-                doLollipopAppRouting(builder);
+            doLollipopAppRouting(builder);
 
             // https://developer.android.com/reference/android/net/VpnService.Builder#setMetered(boolean)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -272,8 +256,7 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
              builder.setSession(mSessionName)
                     .setConfigureIntent(null); // previously this was set to a null member variable
 
-            if (mIsLollipop)
-                builder.setBlocking(true);
+            builder.setBlocking(true);
 
             mInterface = builder.establish();
 
@@ -360,7 +343,6 @@ public class OrbotVpnManager implements Handler.Callback, OrbotConstants {
         return (p.getHeader().getProtocol() == IpNumber.ICMPV4 || p.getHeader().getProtocol() == IpNumber.ICMPV6);
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void doLollipopAppRouting(VpnService.Builder builder) throws NameNotFoundException {
         var apps = TorifiedApp.getApps(mService, prefs);
         var perAppEnabled = false;


### PR DESCRIPTION
Needed for and spun off from #956 

- Removes old checks in app, appcore, and OrbotService
- Removes methods only used for older SDK versions
- Actually adds new checks for app-tv where they seem necessary

Tested on Pixel 7 API 34.