### PR TITLE
Start Orbot via always-on VPN

### DIFF
--- a/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
+++ b/app-tv/src/main/java/org/torproject/android/tv/TeeveeMainActivity.java
@@ -313,6 +313,7 @@ public class TeeveeMainActivity extends Activity implements OrbotConstants, OnLo
 
         Intent intent = new Intent(TeeveeMainActivity.this, OrbotService.class);
         intent.setAction(action);
+        intent.putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true);
         startService(intent);
     }
 

--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -153,7 +153,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
 
 
      fun startTorAndVpn() {
-        val vpnIntent = VpnService.prepare(requireActivity())
+        val vpnIntent = VpnService.prepare(requireActivity())?.putNotSystem()
         if (vpnIntent != null && (!Prefs.isPowerUserMode())) {
             startActivityForResult(vpnIntent, OrbotActivity.REQUEST_CODE_VPN)
         } else {
@@ -377,7 +377,10 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks, ExitNodeDialogFra
             }
     }
 
-    private fun sendIntentToService(intent: Intent) = ContextCompat.startForegroundService(requireActivity(), intent)
+    private fun Intent.putNotSystem(): Intent = this.putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true)
+
+    /** Sends intent to service, first modifying it to indicate it is not from the system */
+    private fun sendIntentToService(intent: Intent) = ContextCompat.startForegroundService(requireActivity(), intent.putNotSystem())
     private fun sendIntentToService(action: String) = sendIntentToService(
         Intent(requireActivity(), OrbotService::class.java).apply {
         this.action = action

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -139,7 +139,10 @@ class OrbotActivity : BaseActivity() {
     }
 
 
-    private fun sendIntentToService(intent: Intent) = ContextCompat.startForegroundService(this, intent)
+    private fun Intent.putNotSystem(): Intent = this.putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true)
+
+    /** Sends intent to service, first modifying it to indicate it is not from the system */
+    private fun sendIntentToService(intent: Intent) = ContextCompat.startForegroundService(this, intent.putNotSystem())
     private fun sendIntentToService(action: String) = sendIntentToService(
         android.content.Intent(this, org.torproject.android.service.OrbotService::class.java)
             .apply {

--- a/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
@@ -32,7 +32,9 @@ class OnBootReceiver : BroadcastReceiver() {
 
         try {
 
-            val intent = Intent(context, OrbotService::class.java).apply { this.action = action }
+            val intent = Intent(context, OrbotService::class.java).apply {
+                this.action = action
+            }.putNotSystem()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
                 context.startForegroundService(intent)
             else {
@@ -43,6 +45,8 @@ class OnBootReceiver : BroadcastReceiver() {
             //catch this to avoid malicious launches as document Cure53 Audit: ORB-01-009 WP1/2: Orbot DoS via exported activity (High)
         }
     }
+
+    private fun Intent.putNotSystem(): Intent = putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true)
 
     companion object {
         private var sReceivedBoot = false

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.java
@@ -108,6 +108,14 @@ public interface OrbotConstants {
 
     String EXTRA_DNS_PORT = "org.torproject.android.intent.extra.DNS_PORT";
     String EXTRA_TRANS_PORT = "org.torproject.android.intent.extra.TRANS_PORT";
+    /**
+     * When present, indicates with certainty that the system itself did *not* send the Intent.
+     * Effectively, the lack of this extra indicates that the VPN is being started by the system
+     * as a result of the user's always-on preference for the VPN.
+     * See: <a href="https://developer.android.com/guide/topics/connectivity/vpn#detect_always-on">
+     * Detect always-on | VPN | Android Developers</a>
+     */
+    String EXTRA_NOT_SYSTEM = "org.torproject.android.intent.extra.NOT_SYSTEM";
 
     String LOCAL_ACTION_LOG = "log";
     String LOCAL_ACTION_STATUS = "status";

--- a/orbotservice/src/main/java/org/torproject/android/service/StartTorReceiver.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/StartTorReceiver.java
@@ -23,7 +23,8 @@ public class StartTorReceiver extends BroadcastReceiver implements OrbotConstant
                 String packageName = intent.getStringExtra(EXTRA_PACKAGE_NAME);
                 if (Prefs.allowBackgroundStarts()) {
                     Intent startTorIntent = new Intent(context, OrbotService.class)
-                            .setAction(action);
+                            .setAction(action)
+                            .putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true);
                     if (packageName != null) {
                         startTorIntent.putExtra(OrbotService.EXTRA_PACKAGE_NAME, packageName);
                     }


### PR DESCRIPTION
This resolves issue https://github.com/guardianproject/orbot/issues/1007 and is an updated version of #828 that was merged into v16_maintenance.

---

When the system tries to start Orbot as a result of the always-on VPN setting, automatically connect to Tor as a VPN without requiring additional user intervention. In this case, the system will also start Orbot on boot regardless of the "Start Orbot on Boot" setting. This support is especially important for scenarios where Orbot is bundled with the OS in always-on mode.

Test: Manual: Install Orbot and start the VPN. In the system settings, set Orbot as an always-on VPN. Clear storage for Orbot, and optionally turn on Notifiations. Reboot the device, or turn the always-on VPN setting off and on again. In either case, Orbot automatically connects and is available for use.