### PR TITLE
Geoip performance optimization

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotApp.kt
+++ b/app/src/main/java/org/torproject/android/OrbotApp.kt
@@ -9,7 +9,6 @@ import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.util.Prefs
 import java.util.Locale
 
-
 class OrbotApp : Application(), OrbotConstants {
 
 
@@ -35,6 +34,15 @@ class OrbotApp : Application(), OrbotConstants {
 
         // If it exists, remove v2 onion service data
         deleteDatabase("hidden_services")
+
+        // this code only runs on first install and app updates
+        if (Prefs.getCurrentVersionForUpdate() < BuildConfig.VERSION_CODE) {
+            Prefs.setCurrentVersionForUpdate(BuildConfig.VERSION_CODE);
+            // don't do anything resource intensive here, instead set a flag to do the task later
+
+            // tell OrbotService it needs to reinstall geoip
+            Prefs.setIsGeoIpReinstallNeeded(true)
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/org/torproject/android/OrbotApp.kt
+++ b/app/src/main/java/org/torproject/android/OrbotApp.kt
@@ -32,9 +32,6 @@ class OrbotApp : Application(), OrbotConstants {
             Languages.setLanguage(this, Prefs.getDefaultLocale(), true)
         }
 
-        // If it exists, remove v2 onion service data
-        deleteDatabase("hidden_services")
-
         // this code only runs on first install and app updates
         if (Prefs.getCurrentVersionForUpdate() < BuildConfig.VERSION_CODE) {
             Prefs.setCurrentVersionForUpdate(BuildConfig.VERSION_CODE);

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -466,6 +466,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
                 // only write out geoip files if there's an app update or they don't exist
                 if (!hasGeoip || !hasGeoip6 || Prefs.isGeoIpReinstallNeeded()) {
                     try {
+                        Log.d(TAG, "Installing geoip files...");
                         new CustomTorResourceInstaller(this, appBinHome).installGeoIP();
                         Prefs.setIsGeoIpReinstallNeeded(false);
                     } catch (IOException io) { // user has < 10MB free space on disk...

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -460,13 +460,20 @@ public class OrbotService extends VpnService implements OrbotConstants {
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) createNotificationChannel();
 
-                try {
-                    CustomTorResourceInstaller installer = new CustomTorResourceInstaller(this, appBinHome);
-                    installer.installGeoIP();
-                } catch (IOException io) {
-                    Log.e(TAG, "Error installing geoip files", io);
-                    logNotice(getString(R.string.log_notice_geoip_error));
-                }
+                var hasGeoip = new File(appBinHome, GEOIP_ASSET_KEY).exists();
+                var hasGeoip6 = new File(appBinHome, GEOIP6_ASSET_KEY).exists();
+
+                // only write out geoip files if there's an app update or they don't exist
+                if (!hasGeoip || !hasGeoip6 || Prefs.isGeoIpReinstallNeeded()) {
+                    try {
+                        new CustomTorResourceInstaller(this, appBinHome).installGeoIP();
+                        Prefs.setIsGeoIpReinstallNeeded(false);
+                    } catch (IOException io) {
+                        Log.e(TAG, "Error installing geoip files", io);
+                        logNotice(getString(R.string.log_notice_geoip_error));
+                    }
+                } else Log.d(TAG, "no need to write geoip");
+
 
                 pluggableTransportInstall();
 
@@ -1096,11 +1103,10 @@ public class OrbotService extends VpnService implements OrbotConstants {
                 extraLines = processSettingsImplObfs4(extraLines);
             }
         }
-        //only apply GeoIP if you need it
         var fileGeoIP = new File(appBinHome, GEOIP_ASSET_KEY);
         var fileGeoIP6 = new File(appBinHome, GEOIP6_ASSET_KEY);
 
-        if (fileGeoIP.exists()) {
+        if (fileGeoIP.exists()) { // only apply geoip if it exists
             extraLines.append("GeoIPFile" + ' ').append(fileGeoIP.getCanonicalPath()).append('\n');
             extraLines.append("GeoIPv6File" + ' ').append(fileGeoIP6.getCanonicalPath()).append('\n');
         }

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -468,11 +468,10 @@ public class OrbotService extends VpnService implements OrbotConstants {
                     try {
                         new CustomTorResourceInstaller(this, appBinHome).installGeoIP();
                         Prefs.setIsGeoIpReinstallNeeded(false);
-                    } catch (IOException io) {
+                    } catch (IOException io) { // user has < 10MB free space on disk...
                         Log.e(TAG, "Error installing geoip files", io);
-                        logNotice(getString(R.string.log_notice_geoip_error));
                     }
-                } else Log.d(TAG, "no need to write geoip");
+                }
 
 
                 pluggableTransportInstall();

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -39,6 +39,8 @@ public class Prefs {
     private final static String PREF_SNOWFLAKES_SERVED_COUNT = "pref_snowflakes_served";
     private final static String PREF_SNOWFLAKES_SERVED_COUNT_WEEKLY = "pref_snowflakes_served_weekly";
 
+    private static final String PREF_CURRENT_VERSION = "pref_current_version";
+
     private static final String PREF_CONNECTION_PATHWAY = "pref_connection_pathway";
     public static final String PATHWAY_SMART = "smart", PATHWAY_DIRECT = "direct",
         PATHWAY_SNOWFLAKE = "snowflake", PATHWAY_SNOWFLAKE_AMP = "snowflake_amp", PATHWAY_CUSTOM = "custom";
@@ -46,6 +48,22 @@ public class Prefs {
     public static final String PREF_SECURE_WINDOW_FLAG = "pref_flag_secure";
 
     private static SharedPreferences prefs;
+
+    public static int getCurrentVersionForUpdate() {
+        return prefs.getInt(PREF_CURRENT_VERSION, 0);
+    }
+
+    public static void setCurrentVersionForUpdate(int version) {
+        putInt(PREF_CURRENT_VERSION, version);
+    }
+
+    private static final String PREF_REINSTALL_GEOIP = "pref_geoip";
+    public static boolean isGeoIpReinstallNeeded() {
+        return prefs.getBoolean(PREF_REINSTALL_GEOIP, true);
+    }
+    public static void setIsGeoIpReinstallNeeded(boolean reinstallNeeded) {
+        putBoolean(PREF_REINSTALL_GEOIP, reinstallNeeded);
+    }
 
     public static void setContext(Context context) {
         if (prefs == null) {

--- a/orbotservice/src/main/res/values/strings.xml
+++ b/orbotservice/src/main/res/values/strings.xml
@@ -38,7 +38,6 @@
     <string name="log_notice_added_event_handler">Added control port event handler</string>
     <string name="log_notice_connected_to_tor_control_port">Connected to tor control port</string>
     <string name="log_notice_ignoring_start_request">Ignoring start request, already started.</string>
-    <string name="log_notice_geoip_error">There was an error installing geoip files</string>
 
 </resources>
 


### PR DESCRIPTION
Rather than taking geoip and geoip6 which are zipped into the APK and inflating them, then copying all 10MB of them each time `OrbotService` starts, we now only extract these files and write them to internal storage if they don't exist or the first time the user opens the app after an update. This way every single time `OrbotService` is subsequently created it doesn't need to do this disk IO. 

My concern was that blocking disk IO could somehow be deprioritized when Orbot starts in the background on device boot or power saving mode is turned onto the device. For users who start with always on VPN maybe this will make them enter the tor network faster. 

This geoip business hooks into a lightweight preference based system into `OrbotApp` that could allow for future on "orbot was just updated to a new version" events. 