### PR TITLE
Update AGP, Gradle, Kotlin, and dependencies

### DIFF
--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "org.torproject.android.tv"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 
     buildTypes {
@@ -22,7 +22,7 @@ android {
             dimension "teevee"
             minSdkVersion 23 
             applicationId 'org.torproject.android.tv'
-            compileSdkVersion 33
+            compileSdkVersion 34
             versionCode 10020000
             versionName 'orbot-tv-1.0.1-tor-0.4.7.14'
             archivesBaseName = "Orbot-TV-$versionName"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "org.torproject.android"
         versionName getVersionName()
         minSdkVersion 23
-        compileSdk 33
-        targetSdkVersion 33
+        compileSdk 34
+        targetSdkVersion 34
         multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         archivesBaseName = "Orbot"
@@ -103,14 +103,14 @@ android {
     namespace 'org.torproject.android'
 }
 dependencies {
-    implementation "androidx.core:core-ktx:1.8.0"
+    implementation "androidx.core:core-ktx:1.13.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     // Kotlin
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.7.7"
+    implementation "androidx.navigation:navigation-ui-ktx:2.7.7"
 
     //root detection
     implementation 'com.scottyab:rootbeer-lib:0.1.0'

--- a/appcore/build.gradle
+++ b/appcore/build.gradle
@@ -1,15 +1,14 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
 }
 apply from: "../commons.gradle"
-apply from : '../dependencies.gradle'
+apply from: '../dependencies.gradle'
 
 android {
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -34,8 +33,8 @@ dependencies {
             project(':orbotservice'),
             "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version",
             libs.androidx_appcompat,
-            "androidx.preference:preference:1.1.0"
+            "androidx.preference:preference:1.2.1"
     )
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }

--- a/appcore/src/main/java/org/torproject/android/core/ui/SettingsPreferencesFragment.kt
+++ b/appcore/src/main/java/org/torproject/android/core/ui/SettingsPreferencesFragment.kt
@@ -21,8 +21,8 @@ class SettingsPreferencesFragment : PreferenceFragmentCompat() {
 
         prefLocale = findPreference("pref_default_locale")
         val languages = Languages[requireActivity()]
-        prefLocale?.entries = languages!!.allNames
-        prefLocale?.entryValues = languages.supportedLocales
+        prefLocale?.entries = languages?.allNames
+        prefLocale?.entryValues = languages?.supportedLocales
         prefLocale?.value = Prefs.getDefaultLocale()
         prefLocale?.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any? ->

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply from: './dependencies.gradle'
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        agp_version = '8.1.2'
-        kotlin_version = '1.7.10'
+        agp_version = '8.5.0'
+        kotlin_version = '2.0.0'
     }
 
     repositories {

--- a/commons.gradle
+++ b/commons.gradle
@@ -1,9 +1,6 @@
-
-/*
-    Applies across all modules
- */
+// Applies across all modules
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion '33.0.0'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,17 @@
 ext {
     versions = [
-            android_material             : "1.9.0",
+            android_material             : "1.12.0",
             android_shell                : "1.0.0",
             android_snowfall             : "1.2.1",
             android_volley               : "1.2.0",
-            androidx_appcompat           : "1.3.1",
-            androidx_constraint          : "2.1.0",
+            androidx_appcompat           : "1.7.0",
+            androidx_constraint          : "2.1.4",
             androidx_coordinator         : "1.1.0",
-            androidx_core                : "1.6.0",
+            androidx_core                : "1.13.1",
             androidx_leanback            : "1.2.0-alpha01",
             androidx_leanback_paging     : "1.1.0-alpha08",
             androidx_leanback_tab        : "1.1.0-beta01",
-            androidx_localbroadcast      : "1.0.0",
+            androidx_localbroadcast      : "1.1.0",
             androidx_multidex            : "2.0.1",
             androidx_palette             : "1.0.0",
             androidx_recyclerview        : "1.2.1",
@@ -20,11 +20,10 @@ ext {
             fastlane_screengrab          : "2.0.0",
             guardian_jtorctl             : "0.4.5.7",
             ipt_proxy                    : "1.7.1",
-         //   portmapper                   : "2.0.5",
             tor_android                  : "0.4.8.11",
             pcap_core                    : "1.8.2",
             pcap_factory                 : "1.8.2",
-            androidx_work                : "2.7.1"
+            androidx_work                : "2.9.0"
     ]
 
     libs = [
@@ -49,11 +48,10 @@ ext {
             fastlane_screengrab            : "tools.fastlane:screengrab:$versions.fastlane_screengrab",
             guardian_jtorctl               : "info.guardianproject:jtorctl:$versions.guardian_jtorctl",
             ipt_proxy                      : "com.github.bitmold:OrbotIPtProxy:$versions.ipt_proxy",
-         //   portmapper                     : "com.offbynull.portmapper:portmapper:$versions.portmapper",
             tor_android                    : "info.guardianproject:tor-android:$versions.tor_android",
             pcap_core                      : "org.pcap4j:pcap4j-core:$versions.pcap_core",
             pcap_factory                   : "org.pcap4j:pcap4j-packetfactory-static:$versions.pcap_factory",
             androidx_work                  : "androidx.work:work-runtime:$versions.androidx_work",
-            androidx_work_kotlin          : "androidx.work:work-runtime-ktx:$versions.androidx_work"
+            androidx_work_kotlin           : "androidx.work:work-runtime-ktx:$versions.androidx_work"
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Mon Oct 09 23:36:42 EDT 2023
+#Fri Jun 21 17:56:51 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/intentintegrator/build.gradle
+++ b/intentintegrator/build.gradle
@@ -4,7 +4,7 @@ apply from: "../commons.gradle"
 android {
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         consumerProguardFiles "consumer-rules.pro"
     }
 

--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -5,7 +5,7 @@ apply from : '../dependencies.gradle'
 android {
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 
     buildTypes {
@@ -34,7 +34,6 @@ android {
 }
 
 dependencies {
-
     api libs.guardian_jtorctl
 
     //use locally built ipt_proxy+go_tun2socks


### PR DESCRIPTION
Everything is very outdated. This PR aims to fix that.

- Update AGP 8.1.2-> 8.4.1, Gradle 8.4 -> 8.7, Kt 1.7.10 -> 1.9.24
- Target Android SDK 33 -> 34 as needed by newer dep versions
- Remove deprecated `kotlin-android-extensions` that causes build failure
- Delete commented `portmapper` dependency and all of its references
- Delete unnecessary whitespaces and fix weird formatting

Also helpful for #915