### PR TITLE
Sync minSdkVersion to match the rest of project

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         applicationId "org.torproject.android"
         versionName getVersionName()
-        minSdkVersion 24
+        minSdkVersion 23
         compileSdkVersion 33
         targetSdkVersion 33
         multiDexEnabled true


### PR DESCRIPTION
Set minSdkVersion in app/build.gradle to the same thing as the rest of the project. This commit basically reverts c1d997e3fbe6ebb1a34ee045a29c0f8d2fd858c6

Currently, OrbotLib supports API 23 and tor-android supports API 19.  I can not find a valid reason to bump Orbot to API 24.