### PR TITLE
Make Orbot direct boot aware

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,7 +110,7 @@
             android:enabled="true"
             android:exported="true"
             android:permission="android.permission.RECEIVE_BOOT_COMPLETED"
-            android:directBootAware="false">
+            android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />

--- a/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
@@ -16,10 +16,10 @@ class OnBootReceiver : BroadcastReceiver() {
         try {
 
             if (Prefs.startOnBoot() && !sReceivedBoot) {
-                //   if (isNetworkAvailable(context)) {
-                startService(OrbotConstants.ACTION_START, context)
-                sReceivedBoot = true
-                // }
+                if (isNetworkAvailable(context)) {
+                    startService(OrbotConstants.ACTION_START, context)
+                    sReceivedBoot = true
+                }
             }
 
         }


### PR DESCRIPTION
Orbot will not startup quickly on boot if it is not direct boot aware. If Orbot is direct boot aware, it must check for internet connectivity first or it will try to start too soon and hang.