### PR TITLE
Remove obsolete LibEvent URL in about

### DIFF
--- a/app-tv/src/main/res/layout/layout_about.xml
+++ b/app-tv/src/main/res/layout/layout_about.xml
@@ -68,13 +68,6 @@
 				android:textColorLink="#ffffff"
 				android:paddingLeft="15px"
 				android:textColor="#ffffff" />				
-			<TextView android:text="@string/libevent_version"
-				android:layout_width="fill_parent" 
-				android:layout_height="wrap_content"
-				android:autoLink="web"
-				android:textColorLink="#ffffff"
-				android:paddingLeft="15px"	
-				android:textColor="#ffffff" />	
 			<TextView android:text="@string/obfsproxy_version"
 				android:layout_width="fill_parent" 
 				android:layout_height="wrap_content"

--- a/app-tv/src/main/res/values-ar/strings.xml
+++ b/app-tv/src/main/res/values-ar/strings.xml
@@ -83,7 +83,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">برامج من الطرف الثالث:</string>
   <string name="tor_version">تور: https://www.torproject.org</string>
-  <string name="libevent_version">لب إيفينت النسخة http://www.monkey.org/~provos/libevent/ :v2.0.21</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
     <string name="pref_use_expanded_notifications">قم بأظهار التنبيه بشكل موسع بأستخدام تور. أخرج من البلد ورقم الآي بي رقم العنوان على الشبكة</string>

--- a/app-tv/src/main/res/values-ay/strings.xml
+++ b/app-tv/src/main/res/values-ay/strings.xml
@@ -85,7 +85,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">3ar jaljat-Software </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Imantat apayañ thakhinak Tor llikar mä wakichäwiw jist\'arañ muni %1$d. Wakichawitix uñt\'atachixa, iyaw sama.</string>

--- a/app-tv/src/main/res/values-az/strings.xml
+++ b/app-tv/src/main/res/values-az/strings.xml
@@ -84,8 +84,6 @@
     <string name="third_party_software">Xidməti Quraşdırma:</string>
   <string name="tor_version">
 Tor: https://www.torproject.org</string>
-  <string name="libevent_version">
-LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Torla birlikdə ətraflı bildirişi göstərib ölkə və IP-dən çıxın. </string>
   <string name="pref_use_expanded_notifications_title">Ətraflı bildirişlər</string>
     <string name="set_locale_title">Dil</string>

--- a/app-tv/src/main/res/values-be/strings.xml
+++ b/app-tv/src/main/res/values-be/strings.xml
@@ -85,7 +85,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">Праграмы іншых распрацоўнікаў: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Дадатак хоча адкрыць схаваны порт сервера %1$d сеткі Tor. Гэта бяспечна, калі вы давяраеце дадзенаму дадатку.</string>

--- a/app-tv/src/main/res/values-bg/strings.xml
+++ b/app-tv/src/main/res/values-bg/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Софтуер на трети страни: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Покажи разширена информация за Tor изходната държава и IP в лентата за известия</string>
   <string name="pref_use_expanded_notifications_title">Разширени известия</string>
     <string name="set_locale_title">Език</string>

--- a/app-tv/src/main/res/values-ca/strings.xml
+++ b/app-tv/src/main/res/values-ca/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Programari de terceres parts:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Una aplicació vol obrir el port de servidor ocults%1$d a la xarxa Tor. Això és segur si confieu en l\'aplicació</string>

--- a/app-tv/src/main/res/values-cs-rCZ/strings.xml
+++ b/app-tv/src/main/res/values-cs-rCZ/strings.xml
@@ -83,7 +83,6 @@
   <string name="project_home">Domovské(á) umístění projektu</string>
     <string name="third_party_software">Software třetích stran:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Zobrazit rozšířené oznánemí s Tor výstupní zemí a IP</string>
   <string name="pref_use_expanded_notifications_title">Rozšířené oznámení</string>
     <string name="set_locale_title">Jazyk</string>

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Drittanbieteranwendungen:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Eine Anwendung möchte den Versteckten Server-Anschluss %1$d zum Tor-Netz öffnen. Dies ist sicher, wenn Sie der Anwendung vertrauen.</string>

--- a/app-tv/src/main/res/values-el/strings.xml
+++ b/app-tv/src/main/res/values-el/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Λογισμικό τρίτων:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Κάποια εφαρμογή προσπαθεί να ανοίξει την κρυφή θύρα διακομιστή %1$dστο δίκτυο Tor. Πρόκειται για ασφαλή ενέργεια, εφόσον γνωρίζετε την εφαρμογή.</string>

--- a/app-tv/src/main/res/values-es-rAR/strings.xml
+++ b/app-tv/src/main/res/values-es-rAR/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software de terceros:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Una aplicación quiere abrir el puerto del servidor oculto %1$d a la red de tor. Esto es seguro si confías en la aplicación</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -87,7 +87,6 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software de terceras partes</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Una aplicación quiere abrir el puerto %1$d de servidor oculto a la red Tor. Esto es seguro si confía en la aplicación.</string>

--- a/app-tv/src/main/res/values-eu/strings.xml
+++ b/app-tv/src/main/res/values-eu/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Hirugarrengoen softwarea:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Aplikazio batek ezkutuko zerbitzariko %1$d ataka ireki nau du Tor sarera. Segurua da aplikazioaz fidatzen bazara.</string>

--- a/app-tv/src/main/res/values-fa/strings.xml
+++ b/app-tv/src/main/res/values-fa/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">3rd-Party-Software:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy نسخه‌ی 0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">اپلیکیشنی می‌خواهد پورت سرور %1$d را به شبکه تور بگشاید. در صورتی که به این برنامه اطمینان دارید، چنین کاری امن است.</string>

--- a/app-tv/src/main/res/values-fi/strings.xml
+++ b/app-tv/src/main/res/values-fi/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">3:n osapuolen ohjelmisto:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Näytä laajennettu ilmoitus (Torin ulostulon maa ja IP)</string>
   <string name="pref_use_expanded_notifications_title">Laajennetut ilmoitukset</string>
   <string name="set_locale_title">Kieli</string>

--- a/app-tv/src/main/res/values-fr-rFR/strings.xml
+++ b/app-tv/src/main/res/values-fr-rFR/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Logiciels tiers :</string>
   <string name="tor_version">Tor : https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21 : http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Montrer des notifications étendues avec le pays de sortie de Tor et l’IP</string>
   <string name="pref_use_expanded_notifications_title">Notifications étendues</string>
     <string name="set_locale_title">Langue</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Logiciels tiers :</string>
   <string name="tor_version">Tor : https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21 : http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8 : https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j : http://www.openssl.org</string>
   <string name="hidden_service_request">Une appli veut ouvrir le port %1$d du serveur caché au réseau Tor. Cela est sécuritaire si vous faites confiance à l’appli.</string>

--- a/app-tv/src/main/res/values-gl/strings.xml
+++ b/app-tv/src/main/res/values-gl/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software de Terceiros:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Unha aplicación quere abrir o porto oculto de servidor %1$d a rede Tor. Esto é seguro se vostede confía na app.</string>

--- a/app-tv/src/main/res/values-hi/strings.xml
+++ b/app-tv/src/main/res/values-hi/strings.xml
@@ -87,7 +87,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">तृतीय-पक्ष-सॉफ़्टवेयर:</string>
   <string name="tor_version">तोर : https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">एक ऐप Tor नेटवर्क पर %1$dछिपा सर्वर पोर्ट खोलना चाहता है। यदि आप ऐप पर विश्वास करते हैं, तो यह सुरक्षित है</string>

--- a/app-tv/src/main/res/values-hr/strings.xml
+++ b/app-tv/src/main/res/values-hr/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">Software treće strane:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Prikaži proširene obavijesti s Tor izlaznom državom i IP-em</string>
   <string name="pref_use_expanded_notifications_title">Proširene obavijesti</string>
   <string name="set_locale_title">Jezik</string>

--- a/app-tv/src/main/res/values-hu/strings.xml
+++ b/app-tv/src/main/res/values-hu/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">3. fél szoftver:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Egy app egy rejtett szerver portot %1$d nyitna a Tor hálózatra. Ez biztonságos, ha megbízik az appban.</string>

--- a/app-tv/src/main/res/values-in/strings.xml
+++ b/app-tv/src/main/res/values-in/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android https://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Perangkat Lunak Pihak Ke-3:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Tampilkan notifikasi melebar dengan negara dan IP keluar Tor</string>
   <string name="pref_use_expanded_notifications_title">Notifikasi Melebar</string>
     <string name="set_locale_title">Bahasa</string>

--- a/app-tv/src/main/res/values-is/strings.xml
+++ b/app-tv/src/main/res/values-is/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Hugbúnaður frá 3ja aðila:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Forrit vill opna földu vefgáttina %1$d inn á Tor-netið. Þetta er öruggt ef þú treystir forritinu.</string>

--- a/app-tv/src/main/res/values-it/strings.xml
+++ b/app-tv/src/main/res/values-it/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software di terze parti:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Un\'app vuole aprire la porta %1$d del server nascosto alla rete Tor. È un\'azione sicura se ti fidi dell\'app.</string>

--- a/app-tv/src/main/res/values-iw/strings.xml
+++ b/app-tv/src/main/res/values-iw/strings.xml
@@ -76,7 +76,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">תוכנה-צד-ג׳: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="set_locale_title">שפה</string>
   <string name="pref_disable_network_summary">כבה את Tor כאשר אין חיבור לאינטרנט</string>
   <string name="newnym">החלפת אל זהות Tor חדשה!</string>

--- a/app-tv/src/main/res/values-ja/strings.xml
+++ b/app-tv/src/main/res/values-ja/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">第三者製のソフトウェア</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">アプリが非公開サーバーポート %1$d をTorネットワークに開放しようとしています。信頼できるアプリであればこれは安全です。</string>

--- a/app-tv/src/main/res/values-ko/strings.xml
+++ b/app-tv/src/main/res/values-ko/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">3rd-Party-Software: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">출구 및 IP 정보알림 보이기</string>
   <string name="pref_use_expanded_notifications_title">확장 알림</string>
     <string name="set_locale_title">언어</string>

--- a/app-tv/src/main/res/values-lv/strings.xml
+++ b/app-tv/src/main/res/values-lv/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Trešo personu programmatūra:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Rādīt paplašinātus paziņojumus, kur norādīts IP un Tor izejas valsts</string>
   <string name="pref_use_expanded_notifications_title">Paplašināti paziņojumi</string>
     <string name="set_locale_title">Valoda</string>

--- a/app-tv/src/main/res/values-mk/strings.xml
+++ b/app-tv/src/main/res/values-mk/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">Софтвер од производител од 3-та страна:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Апликација сака да отвори сокриена серверска порта %1$d кон Tor мрежата. Ова е безбедно доколку и верувате на апликацијата.</string>

--- a/app-tv/src/main/res/values-nb/strings.xml
+++ b/app-tv/src/main/res/values-nb/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Tredjepartsprogramvare:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: https://www.openssl.org</string>
     <string name="pref_use_expanded_notifications">Vis utvidede merknader med land og IP for utgangstrafikk fra Tor</string>

--- a/app-tv/src/main/res/values-nl/strings.xml
+++ b/app-tv/src/main/res/values-nl/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software van 3e partijen: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Een app wil de verborgenserverpoort %1$d tot het Tor-netwerk openen. Dit is veilig als je de app vertrouwt.</string>

--- a/app-tv/src/main/res/values-pl/strings.xml
+++ b/app-tv/src/main/res/values-pl/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Oprogramowanie 3rd-Party</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Pokaż rozszerzone powiadomienie z krajem Tor exit node oraz jego IP</string>
   <string name="pref_use_expanded_notifications_title">Rozszerzone Powiadomienia</string>
     <string name="set_locale_title">Język</string>

--- a/app-tv/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tv/src/main/res/values-pt-rBR/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software de Terceiros</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Um aplicativo precisa abrir uma porta tipo servidor escondida %1$dpara a Rede Tor. Isso é seguro se você confiar nesta aplicação.</string>

--- a/app-tv/src/main/res/values-pt-rPT/strings.xml
+++ b/app-tv/src/main/res/values-pt-rPT/strings.xml
@@ -41,7 +41,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software de terceiros:  </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="set_locale_title">idioma</string>
     <string name="pref_socks_title">SOCKS do Tor</string>
   <string name="pref_dnsport_title">Porta DNS do Tor</string>

--- a/app-tv/src/main/res/values-pt/strings.xml
+++ b/app-tv/src/main/res/values-pt/strings.xml
@@ -55,7 +55,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Programas de Terceiros: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications_title">Notificações Estendidas</string>
     <string name="set_locale_title">Idioma</string>
     <string name="newnym">Mudou para uma nova identidade do Tor!</string>

--- a/app-tv/src/main/res/values-ro/strings.xml
+++ b/app-tv/src/main/res/values-ro/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Aplicatii tertiare:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Arată notificări extinse cu Tor exit country şi IP</string>
   <string name="pref_use_expanded_notifications_title">Notificare Extinsă</string>
     <string name="set_locale_title">Limbă</string>

--- a/app-tv/src/main/res/values-ru/strings.xml
+++ b/app-tv/src/main/res/values-ru/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Программы сторонних разработчиков: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Приложение хочет открыть скрытый порт сервера %1$d сети Tor. Это безопасно, если вы доверяете данному приложению.</string>

--- a/app-tv/src/main/res/values-sk/strings.xml
+++ b/app-tv/src/main/res/values-sk/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Software tretích strán:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Zobraziť rozšírené upozornenie s výstupnou krajinou a IP adresou siete Tor</string>
   <string name="pref_use_expanded_notifications_title">Rozšírené upozornenia</string>
     <string name="set_locale_title">Jazyk</string>

--- a/app-tv/src/main/res/values-sr/strings.xml
+++ b/app-tv/src/main/res/values-sr/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Софтвер од стране неслужбених издавача:</string>
   <string name="tor_version">Toр: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="hidden_service_request">Апликација жели да отвори сакривен порт%1$d на серверу за Тор мрежу. Ово је сигуран потез уколико верујете апликацији.</string>
     <string name="pref_use_expanded_notifications">Прикажи опширно обавештење Тор излаза државе и IP-ја</string>
   <string name="pref_use_expanded_notifications_title">Опширно Обавештење</string>

--- a/app-tv/src/main/res/values-sv/strings.xml
+++ b/app-tv/src/main/res/values-sv/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Tredjepartsprogramvara:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">En app vill öppna dold serverport %1$d till Tor-nätverket. Det här är säkert om du litar på appen.</string>

--- a/app-tv/src/main/res/values-th/strings.xml
+++ b/app-tv/src/main/res/values-th/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">ซอฟต์แวร์โดยผู้ผลิตอื่น:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">โปรแกรมต้องการเปิดพอร์ต %1$d ที่ซ่อนอยู่ของเซิร์ฟเวอร์ให้เชื่อมกับเครือข่าย Tor การกระทำนี้ปลอดภัยถ้าคุณเชื่อถือโปรแกรมนั้น</string>

--- a/app-tv/src/main/res/values-tl/strings.xml
+++ b/app-tv/src/main/res/values-tl/strings.xml
@@ -82,7 +82,6 @@
 </string>
     <string name="third_party_software">3rd-Party-Software:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Ipakita ang pinalaking notification kasama ng Tor exit country at IP</string>
   <string name="pref_use_expanded_notifications_title">Pinalawak na Notifications</string>
     <string name="set_locale_title">Wika</string>

--- a/app-tv/src/main/res/values-tr/strings.xml
+++ b/app-tv/src/main/res/values-tr/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
   <string name="third_party_software">Üçüncü Taraf Yazılım:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Bir uygulama Tor ağına %1$d gizli sunucu kapısını açmak istiyor. Uygulamaya güveniyorsanız bu işlem güvenlidir.</string>

--- a/app-tv/src/main/res/values-uk/strings.xml
+++ b/app-tv/src/main/res/values-uk/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Програми сторонніх розробників: </string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">Програма хоче відкрити прихований серверний порт %1$d у мережу Tor. Це безпечно, якщо ви довіряєте застосунку.</string>

--- a/app-tv/src/main/res/values-vi/strings.xml
+++ b/app-tv/src/main/res/values-vi/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">Phần mềm bên thứ 3:</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">Hiển thị thông báo mở rộng với IP và quốc gia của nút cuối (Tor exit-node)</string>
   <string name="pref_use_expanded_notifications_title">Thông báo mở rộng</string>
     <string name="set_locale_title">Ngôn ngữ</string>

--- a/app-tv/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tv/src/main/res/values-zh-rCN/strings.xml
@@ -84,7 +84,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">第三方软件：</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
     <string name="pref_use_expanded_notifications">显示扩展的通知，有关 Tor 出口的国家和 IP</string>
   <string name="pref_use_expanded_notifications_title">扩展的通知</string>
     <string name="set_locale_title">语言</string>

--- a/app-tv/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tv/src/main/res/values-zh-rTW/strings.xml
@@ -86,7 +86,6 @@
   <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">第三方軟體：</string>
   <string name="tor_version">Tor: https://www.torproject.org</string>
-  <string name="libevent_version">LibEvent v2.0.21: http://www.monkey.org/~provos/libevent/</string>
   <string name="obfsproxy_version">Obfs4proxy v0.0.8: https://github.com/Yawning/obfs4</string>
   <string name="openssl_version">OpenSSL v1.0.2j: http://www.openssl.org</string>
   <string name="hidden_service_request">有一個應用要開啟隱藏的伺服器端口 %1$d 到 Tor 網路,如果信得過此應用才進行此操作</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -94,7 +94,6 @@
     <string name="project_urls">https://www.torproject.org/docs/android\nhttps://guardianproject.info/apps/orbot/</string>
     <string name="third_party_software">3rd-Party-Software: </string>
     <string name="tor_version">Tor: https://www.torproject.org</string>
-    <string name="libevent_version">LibEvent: http://www.monkey.org/~provos/libevent/</string>
     <string name="obfsproxy_version">Obfs4proxy: https://github.com/Yawning/obfs4</string>
     <string name="openssl_version">OpenSSL: http://www.openssl.org</string>
     <string name="hidden_service_request">An app wants to open onion server port %1$d to the Tor network. This is safe if you trust the app.</string>

--- a/app/src/main/res/layout/layout_about.xml
+++ b/app/src/main/res/layout/layout_about.xml
@@ -79,14 +79,6 @@
             android:textColorLink="@android:color/white" />
 
         <TextView
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:autoLink="web"
-            android:text="@string/libevent_url"
-            android:textColor="@android:color/white"
-            android:textColorLink="@android:color/white" />
-
-        <TextView
             android:id="@+id/tvObfs4"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,6 @@
     <string name="orbot_url" translatable="false">https://orbot.app/</string>
     <string name="orbot_github" translatable="false">https://github.com/guardianproject/orbot/</string>
     <string name="tor_url" translatable="false">Tor: https://www.torproject.org</string>
-    <string name="libevent_url" translatable="false">LibEvent: http://www.monkey.org/~provos/libevent/</string>
     <string name="obfs4_url" translatable="false">obfs4 v%s: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird</string>
     <string name="snowflake_url" translatable="false">Snowflake v%s: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake</string>
     <string name="openssl_url" translatable="false">OpenSSL: http://www.openssl.org</string>


### PR DESCRIPTION
The old URL now redirects to the new one: https://www.libevent.org

Edit: Orbot does not directly rely on LibEvent, thus all links have been removed.