### PR TITLE
Fix IllegalStateException crash from log

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -260,7 +260,8 @@ class OrbotActivity : BaseActivity() {
     }
 
     fun showLog() {
-        logBottomSheet.show(supportFragmentManager, OrbotActivity::class.java.simpleName)
-
+        if (!logBottomSheet.isAdded) {
+            logBottomSheet.show(supportFragmentManager, OrbotActivity::class.java.simpleName)
+        }
     }
 }


### PR DESCRIPTION
 by first checking if the fragment is already added before creating a new one. This ensures that only one instance of the log sheet exists at a time, preventing the possibility of an `IllegalStateException`.

After the fix:
[Screen_recording_20240406_140113.webm](https://github.com/guardianproject/orbot/assets/114044633/a857b286-fb04-4a67-a624-7cbd240d3122)


Tested on Pixel 8 API 34.
