### PR TITLE
Fix grammar in internet title string key

### DIFF
--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -222,7 +222,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
         tvSubtitle.visibility = View.VISIBLE
 
         progressBar.visibility = View.INVISIBLE
-        tvTitle.text = getString(R.string.no_interent_title)
+        tvTitle.text = getString(R.string.no_internet_title)
         tvSubtitle.text = getString(R.string.no_internet_subtitle)
 
         btnStartVpn.visibility = View.GONE

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -175,7 +175,7 @@
 \nالاتصال بتور</string>
     <string name="volunteer_mode_label">وضع اللطف</string>
     <string name="custom_bridge">جسر مخصص</string>
-    <string name="no_interent_title">اتصل بالإنترنت</string>
+    <string name="no_internet_title">اتصل بالإنترنت</string>
     <string name="no_internet_subtitle">تحتاج إلى اتصال بالإنترنت لاستخدام Orbot.</string>
     <string name="kindness_adjust_title">إعدادات</string>
     <string name="pref_http_dialog">تكوين منفذ HTTP</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -241,7 +241,7 @@
 \njumïpana.</string>
     <string name="not_sure">Pächastati\?</string>
     <string name="connection_direct">Chiqaki</string>
-    <string name="no_interent_title">Internetar waythapiyaña</string>
+    <string name="no_internet_title">Internetar waythapiyaña</string>
     <string name="pref_flag_secure_title">Pantalla jark\'aqäwi</string>
     <string name="many_ways">Tor ukarux kunaymantuqit waythapiyasispa. Yaqhipanakax yaqhanakat sipan kusa jumatak irnaqi.</string>
     <string name="kindess_config_detail">Yaqha Tor apnaqirinakatakix kunjama ukat kunawsas tispusitiwumax Snowflake proxy ukjam tukuspa uk mayjt\'ayam.</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -274,7 +274,7 @@
     <string name="connection_snowflake">Qar dənəciyi</string>
     <string name="ask_tor">Tordan soruşun</string>
     <string name="option_only_when_charging">Yalnız şarj edərkən</string>
-    <string name="no_interent_title">İnternetə qoşulun</string>
+    <string name="no_internet_title">İnternetə qoşulun</string>
     <string name="kindness_adjust_title">Parametrlər</string>
     <string name="setting_padding">Doldurma</string>
     <string name="action_use">istifadə edin</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -263,7 +263,7 @@
     <string name="snowflake_amp">Снежинка (AMP)</string>
     <string name="action_use">Използване</string>
     <string name="asking">ЗАПИТВАНЕ…</string>
-    <string name="no_interent_title">Свържете се с интернет</string>
+    <string name="no_internet_title">Свържете се с интернет</string>
     <string name="kindness_adjust_title">Настройки</string>
     <string name="no_internet_subtitle">За да използвате Orbot е необходим достъп до интернет.</string>
     <string name="not_sure">Не сте сигурни\?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -154,7 +154,7 @@
     <string name="connection_snowflake">Snowflake</string>
     <string name="connection_custom">Personalitzat</string>
     <string name="connected_title">Connectat</string>
-    <string name="no_interent_title">Connecta a internet</string>
+    <string name="no_internet_title">Connecta a internet</string>
     <string name="action_activate">Activa</string>
     <string name="title_choose_apps">Trieu les aplicacions</string>
     <string name="setting_debug">Depuració</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -112,7 +112,7 @@
     <string name="connection_snowflake">Snowflake</string>
     <string name="connection_custom">Vlastní</string>
     <string name="action_use">Použít</string>
-    <string name="no_interent_title">Připojit k Internetu</string>
+    <string name="no_internet_title">Připojit k Internetu</string>
     <string name="action_activate">Aktivovat</string>
     <string name="title_choose_apps">Vybrat aplikace</string>
     <string name="setting_padding">Výplň</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -221,7 +221,7 @@
     <string name="connection_snowflake">Snowflake</string>
     <string name="connection_custom">Brugerdefinerede</string>
     <string name="title_choose_apps">Vælg Apps</string>
-    <string name="no_interent_title">Forbind til internettet</string>
+    <string name="no_internet_title">Forbind til internettet</string>
     <string name="action_activate">Aktivér</string>
     <string name="setting_padding">Spaltefyld</string>
     <string name="setting_debug">Fejlfinding</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -265,7 +265,7 @@
     <string name="connection_snowflake">Snowflake</string>
     <string name="connection_custom">Benutzerdefiniert</string>
     <string name="action_use">Verwenden</string>
-    <string name="no_interent_title">Mit dem Internet verbinden</string>
+    <string name="no_internet_title">Mit dem Internet verbinden</string>
     <string name="setting_padding">Rahmenabstand</string>
     <string name="setting_debug">Debug</string>
     <string name="menu_kindness">Freundlichkeit</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -243,7 +243,7 @@
     <string name="many_ways">Υπάρχουν πολλοί τρόποι για να φτάσετε στην Tor. Μερικοί μπορεί να λειτουργούν καλύτερα από άλλους για εσάς.</string>
     <string name="action_use">Χρήση</string>
     <string name="asking">ΕΡΩΤΩΝΤΑΣ...</string>
-    <string name="no_interent_title">Σύνδεση στο διαδίκτυο</string>
+    <string name="no_internet_title">Σύνδεση στο διαδίκτυο</string>
     <string name="no_internet_subtitle">Χρειάζεστε σύνδεση στο διαδίκτυο για να χρησιμοποιήσετε το Orbot.</string>
     <string name="action_activate">Ενεργοποίηση</string>
     <string name="power_user_mode">Λειτουργία Power User</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -273,7 +273,7 @@
     <string name="kindess_config_detail">Configure how and when your device can act as a Snowflake proxy for other Tor users.</string>
     <string name="hide_apps">Hide apps from network monitoring and get access when they are blocked.</string>
     <string name="pref_isolate_protocol">Isolate client protocols</string>
-    <string name="no_interent_title">Connect to Internet</string>
+    <string name="no_internet_title">Connect to Internet</string>
     <string name="setting_padding">Padding</string>
     <string name="option_only_on_wifi">Only on Wifi</string>
     <string name="option_only_when_charging">Only when charging</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -65,7 +65,7 @@
     <string name="action_activate">Aktivigi</string>
     <string name="action_use">Uzu</string>
     <string name="connect">Konekti</string>
-    <string name="no_interent_title">Konekti al Interreto</string>
+    <string name="no_internet_title">Konekti al Interreto</string>
     <string name="menu_more">Pli</string>
     <string name="connection_direct">Rekta</string>
     <string name="connection_custom">Propra</string>

--- a/app/src/main/res/values-es-rCU/strings.xml
+++ b/app/src/main/res/values-es-rCU/strings.xml
@@ -265,7 +265,7 @@
     <string name="ask_tor">Preguntar a Tor</string>
     <string name="action_use">Usar</string>
     <string name="asking">PIDIENDO…</string>
-    <string name="no_interent_title">Conectar a internet</string>
+    <string name="no_internet_title">Conectar a internet</string>
     <string name="no_internet_subtitle">Necesitas una conexión a internet para usar Orbot.</string>
     <string name="kindness_adjust_title">Ajustes</string>
     <string name="kindess_config_detail">Configurar cómo y cuándo tu dispositivo puede actuar como un Proxy Snowflake para otros usuarios de Tor.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -268,7 +268,7 @@
     <string name="many_ways">Hay muchas formas de conectarse a Tor. Algunas pueden funcionar mejor que otras para ti.</string>
     <string name="action_use">Uso</string>
     <string name="asking">PREGUNTANDO…</string>
-    <string name="no_interent_title">Conectarse a Internet</string>
+    <string name="no_internet_title">Conectarse a Internet</string>
     <string name="no_internet_subtitle">Necesitas estar conectado a Internet para usar Orbot.</string>
     <string name="kindness_adjust_title">Ajustes</string>
     <string name="ask_tor">Preguntale a Tor</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -110,7 +110,7 @@
     <string name="app_suggested_subtitle">Orbot funciona mejor con aplicaciones de mensajería y redes sociales.</string>
     <string name="log_copied">Registro copiado</string>
     <string name="apps_other_apps">Otras aplicaciones</string>
-    <string name="no_interent_title">Conectarse al Internet</string>
+    <string name="no_internet_title">Conectarse al Internet</string>
     <string name="app_name">Orbot</string>
     <string name="menu_stop">Detener</string>
     <string name="menu_about">Acerca de</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -252,7 +252,7 @@
     <string name="volunteer_status_title">Täna on parem
 \ntänu sinule.</string>
     <string name="app_suggested_subtitle">Orbot töötab kõige paremini koos sõnumite ja sotsiaalmeedia rakendustega.</string>
-    <string name="no_interent_title">Ühendage internetiga</string>
+    <string name="no_internet_title">Ühendage internetiga</string>
     <string name="no_internet_subtitle">Orbot\'i kasutamiseks on vaja internetiühendust.</string>
     <string name="kindess_config_detail">Konfigureerige, kuidas ja millal teie seade saab tegutseda Snowflake\'i proxy\'ina teiste Tor\'i kasutajate jaoks.</string>
     <string name="log_copied">Logi kopeeritud</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -153,7 +153,7 @@
     <string name="btn_refresh">Birkargatu</string>
     <string name="drawer_close">Itxi</string>
     <string name="action_use">Erabili</string>
-    <string name="no_interent_title">Konektatu internetera</string>
+    <string name="no_internet_title">Konektatu internetera</string>
     <string name="allow">Baimendu</string>
     <string name="deny">Ukatu</string>
     <string name="setting_debug">Araztu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -269,7 +269,7 @@
     <string name="many_ways">راه‌های زیادی برای اتّصال به تور وجود دارد. برخی ممکن است بهتر از دیگران برای شما کار کنند.</string>
     <string name="action_use">استفاده</string>
     <string name="asking">پرسیدن…</string>
-    <string name="no_interent_title">به اینترنت وصل شوید</string>
+    <string name="no_internet_title">به اینترنت وصل شوید</string>
     <string name="no_internet_subtitle">برای استفاده از روبوت پیازی نیاز به اینترنت دارید.</string>
     <string name="kindness_adjust_title">تنظیمات</string>
     <string name="kindess_config_detail">پیکربندی کنید که چگونه و چه زمانی دستگاه شما می‌تواند به عنوان یک پروکسی دانه برف برای سایر کاربران Tor عمل کند.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -267,7 +267,7 @@
     <string name="kindess_config_detail">Määritä miten ja milloin laitteesi voi toimia Snowflake-välityspalvelimena muille Tor-käyttäjille.</string>
     <string name="not_sure">Etkö osaa valita\?</string>
     <string name="many_ways">Tor voidaan tavoittaa monilla tavoilla. Jotkin saattavat sopia sinulle muita paremmin.</string>
-    <string name="no_interent_title">Yhdistä Internetiin</string>
+    <string name="no_internet_title">Yhdistä Internetiin</string>
     <string name="pref_isolate_protocol">Eristä pääteprotokollat</string>
     <string name="pref_isolate_port">Eristä kohdeportit</string>
     <string name="pref_isolate_port_summary">Käytä jokaiselle kohdeportille eri ketjua.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -260,7 +260,7 @@
     <string name="snowflake_amp">Snowflake (AMP méthode)</string>
     <string name="many_ways">Il existe de nombreuses façons d\'atteindre Tor. Certaines peuvent fonctionner mieux que d\'autres pour vous.</string>
     <string name="power_user_description">Pour les utilisateurs familiers avec Tor. Permet de démarrer Orbot sans le paramètre VPN et montre les ports SOCKS et HTTP ouverts</string>
-    <string name="no_interent_title">Se connecter à l\'internet</string>
+    <string name="no_internet_title">Se connecter à l\'internet</string>
     <string name="menu_kindness">La gentillesse</string>
     <string name="option_only_on_wifi">Uniquement sur Wifi</string>
     <string name="volunteer_mode_label">Mode gentillesse</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -205,7 +205,7 @@
 \n• ये कभी भी बंद किया जा सकता है</string>
     <string name="proxy_ports">प्रॉक्सी पोर्ट</string>
     <string name="solve_captcha">कैप्चा सुलझाएं</string>
-    <string name="no_interent_title">इंटरनेट से जुड़ें</string>
+    <string name="no_internet_title">इंटरनेट से जुड़ें</string>
     <string name="kindness_adjust_title">चलते हुए अपनेआप बदलें…</string>
     <string name="kindess_config_detail">सेट करें कि आपका डिवाइस दूसरे टॉर यूज़रों के लिए कब स्नोफ्लेक्स प्रॉक्सी के तरह काम कर सकता है।</string>
     <string name="asking">पूछ रहे है।</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -148,7 +148,7 @@
     <string name="menu_help_others">Segítsen másoknak</string>
     <string name="menu_header_learn">Tudjon meg többet</string>
     <string name="action_activate">Aktiválás</string>
-    <string name="no_interent_title">Csatlakozás az internethez</string>
+    <string name="no_internet_title">Csatlakozás az internethez</string>
     <string name="kibibyte">KiB</string>
     <string name="title_choose_apps">Alkalmazások kiválasztása</string>
     <string name="setting_debug">Hibakeresés</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -115,7 +115,7 @@
     <string name="bridges_obtained_connecting">Կամուրջները ստացվեցի՜ն: Միացվում է tor-ին…</string>
     <string name="btn_copy_log">Պատճենել մատյանը</string>
     <string name="action_use">Օգտվել</string>
-    <string name="no_interent_title">Միացեք համացանցին</string>
+    <string name="no_internet_title">Միացեք համացանցին</string>
     <string name="no_internet_subtitle">Orbot-ից օգտվելու համար Ձեզ պետք է միացում համացանցին:</string>
     <string name="confirm_service_deletion">Հաստատել ծառայության ջնջումը</string>
     <string name="start_tor_again_for_finish_the_process">Գործընթացի ավարտման համար մեկնարկեք Tor-ը կրկին</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -37,7 +37,7 @@
     <string name="connection_snowflake">Snowflake</string>
     <string name="apps_other_apps">Altere applicationes</string>
     <string name="action_activate">Activar</string>
-    <string name="no_interent_title">Connecter te a internet</string>
+    <string name="no_internet_title">Connecter te a internet</string>
     <string name="connection_direct">Directe</string>
     <string name="title_choose_apps">Seliger le applicationes</string>
     <string name="app_name">Orbot</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -267,7 +267,7 @@
     <string name="not_sure">Tidak yakin\?</string>
     <string name="ask_tor">Tanyakan Tor</string>
     <string name="many_ways">Ada lebih banyak cara untuk mencapai Tor. Beberapa dapat bekerja dengan baik daripada yang lain untuk Anda.</string>
-    <string name="no_interent_title">Hubungkan ke internet</string>
+    <string name="no_internet_title">Hubungkan ke internet</string>
     <string name="no_internet_subtitle">Anda membutuhkan koneksi internet untuk menggunakan Orbot.</string>
     <string name="kindness_adjust_title">Atur ketika berjalan…</string>
     <string name="kindess_config_detail">Atur bagaimana dan kapan perangkat Anda dapat menjadi sebagai proksi Snowflake untuk pengguna Tor lain.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -265,7 +265,7 @@
     <string name="ask_tor">Spurðu Tor</string>
     <string name="many_ways">Það eru margar aðferðir við að ná sambandi við Tor. Sumar gætu virkað betur fyrir þig en aðrar.</string>
     <string name="action_use">Nota</string>
-    <string name="no_interent_title">Tengjast við internetið</string>
+    <string name="no_internet_title">Tengjast við internetið</string>
     <string name="no_internet_subtitle">Þú þarft internettengingu til að nota Orbot.</string>
     <string name="kindness_adjust_title">Stillingar</string>
     <string name="pref_isolate_port_summary">Nota mismunandi rás fyrir hverja markgátt</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -193,7 +193,7 @@
     <string name="connection_custom">Personalizzato</string>
     <string name="trying_to_connect_title">Connessione in corso…</string>
     <string name="menu_header_features">Funzionalità</string>
-    <string name="no_interent_title">Connetti a internet</string>
+    <string name="no_internet_title">Connetti a internet</string>
     <string name="setting_debug">Debug</string>
     <string name="setting_padding">Riempimento (padding)</string>
     <string name="menu_kindness">Altruismo</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -137,7 +137,7 @@
     <string name="menu_tor_connection">חיבור Tor</string>
     <string name="drawer_close">סגירה</string>
     <string name="next">הבא</string>
-    <string name="no_interent_title">התחברות לאינטרנט</string>
+    <string name="no_internet_title">התחברות לאינטרנט</string>
     <string name="allow">להתיר</string>
     <string name="deny">לסרב</string>
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">לאפשר יומן ניפוי תקלות אל פלט (חובה להשתמש ב־adb או ב־aLogCat כדי לצפות)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -263,7 +263,7 @@
     <string name="pref_isolate_protocol_summary">接続中のプロトコルごとに別の回路を使用する</string>
     <string name="many_ways">Torに到達する方法はたくさんあります。いくつかは、あなたにとってより良い方法であるかもしれません。</string>
     <string name="action_use">使用</string>
-    <string name="no_interent_title">インターネットに接続</string>
+    <string name="no_internet_title">インターネットに接続</string>
     <string name="no_internet_subtitle">Orbotを使用するには、インターネット接続が必要です。</string>
     <string name="snowflake_amp">Snowflake (AMP)</string>
     <string name="log_copied">ログをコピーしました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -131,7 +131,7 @@
     <string name="deny">거절</string>
     <string name="hidden_services">Onion 서비스</string>
     <string name="allow">허용</string>
-    <string name="no_interent_title">인터넷에 연결하기</string>
+    <string name="no_internet_title">인터넷에 연결하기</string>
     <string name="menu_kindness">상냥함</string>
     <string name="btn_refresh">새로고침</string>
 </resources>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -264,7 +264,7 @@
     <string name="connection_custom">Pasirinktinis</string>
     <string name="setting_debug">Derinimas</string>
     <string name="action_use">Naudoti</string>
-    <string name="no_interent_title">Prisijunkite prie interneto</string>
+    <string name="no_internet_title">Prisijunkite prie interneto</string>
     <string name="no_internet_subtitle">Norint naudotis \"Orbot\", reikia interneto ryšio.</string>
     <string name="not_sure">Nesate tikri\?</string>
     <string name="ask_tor">Paklauskite Tor</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -248,7 +248,7 @@
     <string name="option_only_when_charging">Tikai uzlādes laikā</string>
     <string name="hide_apps">Paslēpiet lietotnes no tīkla uzraudzības un iegūstiet piekļuvi, ja tās ir bloķētas.</string>
     <string name="pref_isolate_port_summary">Katrai galamērķa ostai izmantojiet atšķirīgu ķēdi</string>
-    <string name="no_interent_title">Savienojums ar internetu</string>
+    <string name="no_internet_title">Savienojums ar internetu</string>
     <string name="pref_isolate_protocol">Izolēt klienta protokolus</string>
     <string name="custom_bridge_subtitle">Visdrīzāk, lai saglabātu savienojumu, ja Tor ir nopietni bloķēts. Nepieciešama uzticamas personas tilta adrese.</string>
     <string name="volunteer_mode_weekly_label">Nedēļas kopsumma</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -34,7 +34,7 @@
     <string name="next">അടുത്തത്</string>
     <string name="action_activate">സജീവമാക്കുക</string>
     <string name="title_choose_apps">ആപ്പുകൾ തിരഞ്ഞെടുക്കുക</string>
-    <string name="no_interent_title">ഇന്റർനെറ്റ് ആയിട്ട് ബന്ധിപ്പിക്കുക</string>
+    <string name="no_internet_title">ഇന്റർനെറ്റ് ആയിട്ട് ബന്ധിപ്പിക്കുക</string>
     <string name="setting_padding">പാഡിങ്</string>
     <string name="setting_debug">ഡീബഗ്</string>
     <string name="menu_more">കൂടുതൽ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -198,7 +198,7 @@
     <string name="connect">Koble til</string>
     <string name="action_activate">Aktiver</string>
     <string name="title_choose_apps">Velg programmer</string>
-    <string name="no_interent_title">Koble til internett</string>
+    <string name="no_internet_title">Koble til internett</string>
     <string name="connection_direct">Direkte</string>
     <string name="connection_snowflake">Snowflake</string>
     <string name="connection_custom">Egendefinert</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -271,7 +271,7 @@
     <string name="pref_isolate_port_summary">Użyj innego obwodu dla każdego portu docelowego</string>
     <string name="pref_isolate_protocol_summary">Użyj innego obwodu dla każdego protokołu łączącego</string>
     <string name="ask_tor">Zapytaj Tor</string>
-    <string name="no_interent_title">Podłączenie do Internetu</string>
+    <string name="no_internet_title">Podłączenie do Internetu</string>
     <string name="kindess_config_detail">Skonfiguruj, jak i kiedy Twoje urządzenie może działać jako proxy Snowflake dla innych użytkowników Tor.</string>
     <string name="log_copied">Dziennik skopiowany</string>
     <string name="connection_direct">Bezpośrednio</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -267,7 +267,7 @@
     <string name="ask_tor">Pergunte ao Tor</string>
     <string name="action_use">Usar</string>
     <string name="asking">PEDIDO…</string>
-    <string name="no_interent_title">Conectar à internet</string>
+    <string name="no_internet_title">Conectar à internet</string>
     <string name="kindness_adjust_title">Configurações</string>
     <string name="no_internet_subtitle">Você precisa de uma conexão com a Internet para usar o Orbot.</string>
     <string name="pref_isolate_protocol">Isole os protocolos do cliente</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -267,7 +267,7 @@
     <string name="menu_more">Mais</string>
     <string name="hide_apps">Oculte apps do monitoramento da rede e obtenha acesso quando eles estiverem bloqueados.</string>
     <string name="pref_isolate_protocol">Isolar os protocolos do cliente</string>
-    <string name="no_interent_title">Ligar à Internet</string>
+    <string name="no_internet_title">Ligar à Internet</string>
     <string name="kindness_adjust_title">Ajustar quando for ativo…</string>
     <string name="option_only_on_wifi">Apenas ligado à Wi-Fi</string>
     <string name="option_only_when_charging">Só durante o carregamento</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -189,7 +189,7 @@
     <string name="snowflake_amp">Snowflake (AMP)</string>
     <string name="get_a_bridge">Punte de la Tor (Obfs4)</string>
     <string name="asking">CERERE…</string>
-    <string name="no_interent_title">Conectare la internet</string>
+    <string name="no_internet_title">Conectare la internet</string>
     <string name="kindess_config_detail">Configurați cum și când dispozitivul dvs. poate acționa ca proxy Snowflake pentru alți utilizatori Tor.</string>
     <string name="allow">Permiteți</string>
     <string name="deny">Refuzați</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -266,7 +266,7 @@
     <string name="ask_tor">Спросить у Tor</string>
     <string name="action_use">Использовать</string>
     <string name="asking">ЗАПРОС…</string>
-    <string name="no_interent_title">Подключиться к интернету</string>
+    <string name="no_internet_title">Подключиться к интернету</string>
     <string name="no_internet_subtitle">Для использования Orbot необходимо подключение к интернету.</string>
     <string name="kindness_adjust_title">Настройки</string>
     <string name="kindess_config_detail">Настройте, как и когда ваше устройство может использоваться в качестве прокси-сервера Snowflake для других пользователей Tor.</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -235,7 +235,7 @@
     <string name="having_trouble_subtitle">Ďalej môžeme vyskúšať most Tor, ale budeme potrebovať vašu pomoc</string>
     <string name="apps_suggested_title">Navrhované aplikácie</string>
     <string name="not_sure">Nie ste si istí\?</string>
-    <string name="no_interent_title">Pripojenie k internetu</string>
+    <string name="no_internet_title">Pripojenie k internetu</string>
     <string name="no_internet_subtitle">Na používanie služby Orbot potrebujete internetové pripojenie.</string>
     <string name="power_user_mode">Režim Power User</string>
     <string name="power_user_description">Pre používateľov, ktorí poznajú Tor. Umožňuje spustiť Orbot bez nastavenia VPN a zobrazuje otvorené porty SOCKS a HTTP</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -253,7 +253,7 @@
     <string name="smart_connect_subtitle">Orbot se poskuša povezati s Torom prek katerega koli razpoložljivega načina: neposredno, snažinka, most.</string>
     <string name="custom_bridge_description">Most po meri zagotovi nekdo, ki ga poznate. Povprašajte v svojih zaupanja vrednih omrežjih in organizacijah, ali jih kdo gosti.</string>
     <string name="log_copied">Dnevnik kopiran</string>
-    <string name="no_interent_title">Povežite se z internetom</string>
+    <string name="no_internet_title">Povežite se z internetom</string>
     <string name="kindess_config_detail">Konfigurirajte, kako in kdaj lahko vaša naprava deluje kot proksi snežinka za druge uporabnike Tora.</string>
     <string name="root_warning">Orbot je zaznal, da je vaša naprava korenirana, kar lahko povzroči varnostne težave.</string>
     <string name="configure_header">Natavite svojo Tor povezavo</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -258,7 +258,7 @@
     <string name="ask_tor">Pyetni Tor-in</string>
     <string name="option_only_when_charging">Vetëm kur ngarkohet bateria</string>
     <string name="pref_isolate_port_summary">Përdorni një qark të ndryshëm për çdo portë vendmbërritje</string>
-    <string name="no_interent_title">Lidhu në internet</string>
+    <string name="no_internet_title">Lidhu në internet</string>
     <string name="pref_isolate_protocol">Izolo protokolle klienti</string>
     <string name="kindness_adjust_title">Rregullime</string>
     <string name="full_device_vpn">VPN Për Krejt Pajisjen</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -231,7 +231,7 @@
     <string name="title_choose_apps">Välj appar</string>
     <string name="action_use">Använd</string>
     <string name="asking">FRÅGAR...</string>
-    <string name="no_interent_title">Anslut till internet</string>
+    <string name="no_internet_title">Anslut till internet</string>
     <string name="no_internet_subtitle">Du behöver en internetuppkoppling för att använda Orbot.</string>
     <string name="kindness_adjust_title">Inställningar</string>
     <string name="configure_header">Konfigurera din Tor-anslutning</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -168,7 +168,7 @@
     <string name="ask_tor">Tor-dan Sora</string>
     <string name="action_use">Ulan</string>
     <string name="asking">SORAÝAR…</string>
-    <string name="no_interent_title">Internede baglan</string>
+    <string name="no_internet_title">Internede baglan</string>
     <string name="no_internet_subtitle">Orbot ulanmak üçin internet birikmesi gerek.</string>
     <string name="menu_kindness">Hoşniýetlilik</string>
     <string name="menu_more">Has köp</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -265,7 +265,7 @@
     <string name="many_ways">Tor\'a erişmenin birçok yolu vardır. Bazıları sizin için diğerlerinden daha iyi çalışabilir.</string>
     <string name="action_use">Kullan</string>
     <string name="asking">SORUYOR…</string>
-    <string name="no_interent_title">İnternete bağlan</string>
+    <string name="no_internet_title">İnternete bağlan</string>
     <string name="kindness_adjust_title">Ayarlar</string>
     <string name="snowflake_amp">Snowflake (AMP)</string>
     <string name="no_internet_subtitle">Orbot\'u kullanmak için internet bağlantınızın olması gerekir.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -262,7 +262,7 @@
     <string name="log_copied">Журнал скопійовано</string>
     <string name="action_use">Використати</string>
     <string name="many_ways">Існує багато способів отримати доступ до Tor. Деякі з них можуть працювати для вас краще, ніж інші.</string>
-    <string name="no_interent_title">Підключення до Інтернету</string>
+    <string name="no_internet_title">Підключення до Інтернету</string>
     <string name="snowflake_amp">Snowflake (спосіб 2)</string>
     <string name="not_sure">Не впевнений\?</string>
     <string name="ask_tor">Запитайте Tor</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -283,7 +283,7 @@
     <string name="ask_tor">Hãy hỏi Tor</string>
     <string name="smart_connect">Smart Connect Kết nối Thông minh (mặc định)</string>
     <string name="asking">ĐANG HỎI...</string>
-    <string name="no_interent_title">Kết nối tới Internet</string>
+    <string name="no_internet_title">Kết nối tới Internet</string>
     <string name="no_internet_subtitle">Bạn cần một kết nối internet để sử dụng Orbot.</string>
     <string name="kindness_adjust_title">Cài đặt</string>
     <string name="setting_padding">Định khoảng cách Padding</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -262,7 +262,7 @@
     <string name="volunteer_status_title">今天因你
 \n而更好。</string>
     <string name="action_use">使用方法</string>
-    <string name="no_interent_title">连接到互联网</string>
+    <string name="no_internet_title">连接到互联网</string>
     <string name="menu_more">更多</string>
     <string name="connection_direct">私信</string>
     <string name="connection_snowflake">Snowflake</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,7 +267,7 @@
     <string name="many_ways">There are many ways to reach Tor. Some may work better than others for you.</string>
     <string name="action_use">Use</string>
     <string name="asking">ASKING…</string>
-    <string name="no_interent_title">Connect to internet</string>
+    <string name="no_internet_title">Connect to internet</string>
     <string name="no_internet_subtitle">You need an internet connection to use Orbot.</string>
     <string name="kindness_adjust_title">Settings</string>
     <string name="kindess_config_detail">Configure how and when your device can act as a Snowflake proxy for other Tor users.</string>


### PR DESCRIPTION
Correct misspelled `no_interent_title` -> `no_internet_title`

No visual changes, only affects the string key in resources.