### PR TITLE
Fix title alignment in bottom sheets

### DIFF
--- a/app/src/main/res/layout/config_connection_bottom_sheet.xml
+++ b/app/src/main/res/layout/config_connection_bottom_sheet.xml
@@ -25,7 +25,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:layout_marginTop="32dp"
-        android:layout_marginStart="64dp"/>
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:id="@+id/tvConfigSubHeader"

--- a/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
+++ b/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
@@ -26,7 +26,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="32dp"
-        android:layout_marginStart="118dp" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:textColor="@android:color/white"

--- a/app/src/main/res/layout/kindess_config_bottom_sheet.xml
+++ b/app/src/main/res/layout/kindess_config_bottom_sheet.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@color/new_background"
     android:paddingStart="10dp"
     android:paddingEnd="10dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <View
         android:id="@+id/handle"

--- a/app/src/main/res/layout/moat_bottom_sheet.xml
+++ b/app/src/main/res/layout/moat_bottom_sheet.xml
@@ -26,7 +26,8 @@
         android:text="@string/solve_captcha"
         style="@style/BottomSheetHeader"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <FrameLayout
         android:id="@+id/captchaContainer"


### PR DESCRIPTION
<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/12c9dcc5-dabe-4466-ac47-83e7ed8eda5c" width="270" height="600">
</td>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/3731a92b-1eea-4e40-9e54-5d86ec831547" width="270" height="600">
</td>
    </tr>
    <tr>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/ad1f41c8-9780-4b2a-9529-cf37d1eb7caa" width="270" height="600">
</td>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/dafd85d6-4468-492c-9e5b-e65f9d8ee50c" width="270" height="600">
</td>
    </tr>
    <tr>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/a43c7998-5165-44ce-844c-d2e484975902" width="270" height="600">
</td>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/274d12f1-a1f6-4cc2-ae33-ca0fb20d8538" width="270" height="600">
</td>
    </tr>
</table>

Bottom sheet titles were manually (and incorrectly) set in #1024. 
This PR removes hardcoded paddings and properly centers the titles on all devices.

Tested on Pixel 8 API 34.