### PR TITLE
Fix app suggested subtitle being cut

### DIFF
--- a/app/src/main/res/layout/layout_apps_item.xml
+++ b/app/src/main/res/layout/layout_apps_item.xml
@@ -18,7 +18,7 @@
 
     <TextView
         android:layout_marginTop="-4dp"
-        android:layout_marginBottom="-2dp"
+        android:layout_marginBottom="2dp"
         tools:visibility="visible"
         android:visibility="gone"
         android:id="@+id/tvSubheader"


### PR DESCRIPTION
Fixes the subtitle being cut from the bottom. Notice that the two g's in the word "messaging" were cut previously.

Tested on Pixel 8 API 34.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/b5047f8c-b061-473f-b8ce-597fa9bfee35" width="270" height="600"></td>
        <td><img src="https://github.com/guardianproject/orbot/assets/114044633/5d38570c-b647-47ed-bee6-5b121c00ff58" width="270" height="600"></td>
    </tr>
</table>