### PR TITLE
Improve the scroll in log bottom sheet

### DIFF
--- a/app/src/main/res/layout/log_bottom_sheet.xml
+++ b/app/src/main/res/layout/log_bottom_sheet.xml
@@ -42,25 +42,25 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_goneMarginBottom="20dp" />
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/btnCopyLog"
             android:paddingBottom="@dimen/button_horizontal_large_margin">
 
-                <TextView
-                    android:id="@+id/orbotLog"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:fontFamily="monospace"
-                    android:textColor="@color/bright_green"
-                    android:gravity="start"
-                    android:textIsSelectable="true"
-                    android:textSize="12sp"
-                    android:text=""
-                    android:textAppearance="?android:attr/textAppearanceSmallInverse"/>
+            <TextView
+                android:id="@+id/orbotLog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textColor="@color/bright_green"
+                android:gravity="start"
+                android:textIsSelectable="true"
+                android:textSize="12sp"
+                android:text=""
+                android:textAppearance="?android:attr/textAppearanceSmallInverse" />
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Per the documentation:
> For vertical scrolling, consider androidx.core.widget.NestedScrollView instead of scroll view which offers greater user interface flexibility and support for the material design scrolling patterns.

I can confirm that scrolling through the log is much easier, as the sheet can no longer be accidentally closed when scrolling.

Tested on Pixel 8 API 34.