### PR TITLE
Fix deprecated networking getters

### DIFF
--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -5,10 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Paint
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.net.VpnService
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -19,10 +16,14 @@ import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.*
+
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+
 import net.freehaven.tor.control.TorControlCommands
+
+import org.torproject.android.core.NetworkUtils.isNetworkAvailable
 import org.torproject.android.core.putNotSystem
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
@@ -78,7 +79,6 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
             if (!isNetworkAvailable(requireContext())) {
                 doLayoutNoInternet(requireContext())
             } else {
-
                 when (lastStatus) {
                     OrbotConstants.STATUS_OFF -> doLayoutOff()
                     OrbotConstants.STATUS_STARTING -> doLayoutStarting(requireContext())
@@ -88,44 +88,12 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
                         doLayoutOff()
                     }
                 }
-
             }
 
 
         }
 
         return view
-    }
-
-    private fun isNetworkAvailable(context: Context?): Boolean {
-        if (context == null) return false
-        val connectivityManager =
-            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val capabilities =
-                connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-            if (capabilities != null) {
-                when {
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
-                        return true
-                    }
-
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> {
-                        return true
-                    }
-
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> {
-                        return true
-                    }
-                }
-            }
-        } else {
-            val activeNetworkInfo = connectivityManager.activeNetworkInfo
-            if (activeNetworkInfo != null && activeNetworkInfo.isConnected) {
-                return true
-            }
-        }
-        return false
     }
 
     private fun stopTorAndVpn() {

--- a/appcore/src/main/java/org/torproject/android/core/NetworkUtils.kt
+++ b/appcore/src/main/java/org/torproject/android/core/NetworkUtils.kt
@@ -1,0 +1,20 @@
+package org.torproject.android.core
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+object NetworkUtils {
+    @JvmStatic
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return when {
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> true
+            else -> false
+        }
+    }
+}

--- a/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OnBootReceiver.kt
@@ -3,25 +3,21 @@ package org.torproject.android.core
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.os.Build
+
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
 import org.torproject.android.service.util.Prefs
 
 class OnBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-
         try {
-
             if (Prefs.startOnBoot() && !sReceivedBoot) {
                 //   if (isNetworkAvailable(context)) {
                 startService(OrbotConstants.ACTION_START, context)
                 sReceivedBoot = true
                 // }
             }
-
         }
         catch (re: java.lang.RuntimeException) {
             //catch this to avoid malicious launches as document Cure53 Audit: ORB-01-009 WP1/2: Orbot DoS via exported activity (High)
@@ -29,9 +25,7 @@ class OnBootReceiver : BroadcastReceiver() {
     }
 
     private fun startService(action: String, context: Context) {
-
         try {
-
             val intent = Intent(context, OrbotService::class.java).apply {
                 this.action = action
             }.putNotSystem()
@@ -48,23 +42,5 @@ class OnBootReceiver : BroadcastReceiver() {
 
     companion object {
         private var sReceivedBoot = false
-    }
-
-    private fun isNetworkAvailable(context: Context): Boolean {
-        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (connectivityManager.isDefaultNetworkActive)
-                return true
-
-            val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-            if (capabilities != null) {
-                when {
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> return true
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> return true
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> return true
-                }
-            }
-        }
-        return connectivityManager.activeNetworkInfo?.isConnected ?: false
     }
 }


### PR DESCRIPTION
Resolves:
- `'getter for activeNetworkInfo: NetworkInfo?' is deprecated. Deprecated in Java`
- `'getter for isConnected: Boolean' is deprecated. Deprecated in Java`