### PR TITLE
Fix IllegalStateException on app exit

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -215,21 +215,20 @@ class OrbotActivity : BaseActivity() {
                                     allCircumventionAttemptsFailed = false
                                     return
                                 }
-                                var shouldDoOffLayout = true
-                                if (Prefs.getConnectionPathway().equals(Prefs.PATHWAY_SMART)) {
-                                    shouldDoOffLayout = false
+                                if (!Prefs.getConnectionPathway().equals(Prefs.PATHWAY_SMART) && fragConnect.isAdded && fragConnect.context != null) {
+                                    fragConnect.doLayoutOff()
                                 }
-                                if (shouldDoOffLayout && fragConnect.isAdded) fragConnect.doLayoutOff()
-                            } else fragConnect.doLayoutOff()
+                            } else if (fragConnect.isAdded && fragConnect.context != null) {
+                                fragConnect.doLayoutOff()
+                            }
                         }
 
-                        OrbotConstants.STATUS_STARTING -> fragConnect.doLayoutStarting(this@OrbotActivity)
-                        OrbotConstants.STATUS_ON -> fragConnect.doLayoutOn(this@OrbotActivity)
+                        OrbotConstants.STATUS_STARTING -> if (fragConnect.isAdded && fragConnect.context != null) fragConnect.doLayoutStarting(this@OrbotActivity)
+                        OrbotConstants.STATUS_ON -> if (fragConnect.isAdded && fragConnect.context != null) fragConnect.doLayoutOn(this@OrbotActivity)
                         OrbotConstants.STATUS_STOPPING -> {}
                     }
 
                     previousReceivedTorStatus = status
-
                 }
 
                 OrbotConstants.LOCAL_ACTION_LOG -> {


### PR DESCRIPTION
This PR introduces a safeguard in the app’s UI update logic to prevent `IllegalStateException` by ensuring that the `ConnectFragment` is attached to a context before performing any layout changes. It refines the condition checks within the when statement to include a context check alongside the existing `isAdded` check, thus improving stability during state transitions.

Tested on Pixel 8 API 34.

Fixes #907 