### PR TITLE
Fix OrbotService not working on Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,11 @@
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- for Android 13 -->
+    <!-- For Android 13 -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+    <!-- For Android 14 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <queries>
         <intent>
@@ -40,8 +42,7 @@
         android:theme="@style/DefaultTheme"
         tools:replace="android:allowBackup"
         android:hasFragileUserData="false"
-        android:taskAffinity=""
-        >
+        android:taskAffinity="">
 
         <activity android:name=".OrbotActivity"
             android:excludeFromRecents="false"

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -73,6 +73,7 @@ import IPtProxy.IPtProxy;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
@@ -540,7 +541,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
                 filter.addAction(LOCAL_ACTION_NOTIFICATION_START);
 
                 mActionBroadcastReceiver = new ActionBroadcastReceiver();
-                registerReceiver(mActionBroadcastReceiver, filter);
+                ContextCompat.registerReceiver(this, mActionBroadcastReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) createNotificationChannel();
 


### PR DESCRIPTION
Apparently, the merging of #1053 broke OrbotService on the master branch on Android 14, due to new foreground service requirements. Apps that target Android 14 need to specify an export flag for broadcasts or they will be killed by the system.

How the docs phrase it:
>  In Android U, all receivers registering for non-system broadcasts are required to include a flag indicating the receiver's exported state. Apps registering for non-system broadcasts should use the ContextCompat#registerReceiver APIs with flags set to either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED. 

and the warning appearing on line 543 of OrbotService:
> mActionBroadcastReceiver is missing RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED flag for unprotected broadcasts registered for NEWNYM, ACTIVE, org.torproject.android.intent.action.STATUS, org.torproject.android.intent.action.ERROR, notification_start

The app would just crash on launch with the following error and ignore subsequent broadcast calls:
```
java.lang.SecurityException: org.torproject.android: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3041)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3024)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2966)
                                                                                                    	at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:5684)
                                                                                                    	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1852)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1792)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1780)
                                                                                                    	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
                                                                                                    	at org.torproject.android.service.OrbotService.onCreate(OrbotService.java:543)
                                                                                                    	at android.app.ActivityThread.handleCreateService(ActivityThread.java:4651)
                                                                                                    	at android.app.ActivityThread.-$$Nest$mhandleCreateService(Unknown Source:0)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2264)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.am.ActivityManagerService.registerReceiverWithFeature(ActivityManagerService.java:13927)
                                                                                                    	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2570)
                                                                                                    	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1339)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1275)
```

I solved this by adding said flag and using a compatibility API so that there is no code duplication.
```java
ContextCompat.registerReceiver(this, mActionBroadcastReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
```
which essentially calls something like this under the hood so we don't have to:
```java
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
    registerReceiver(mActionBroadcastReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
} else {
    registerReceiver(mActionBroadcastReceiver, filter);
}
```
and also adding a new (and necessary) permission to the manifest:
```xml
<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
```
<br>
Tested on Pixel 8 Emulator API 34