### PR TITLE
Replace nonfunctional fastly front with cdn77 fronts

### DIFF
--- a/orbotservice/src/main/assets/fronts
+++ b/orbotservice/src/main/assets/fronts
@@ -1,5 +1,5 @@
-snowflake-target https://snowflake-broker.torproject.net.global.prod.fastly.net/
-snowflake-front github.githubassets.com
+snowflake-target https://1098762253.rsc.cdn77.org
+snowflake-front www.phpmyadmin.net,cdn.zk.mk,vod.sport1.de
 snowflake-stun stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.sonetel.net:3478,stun:stun.stunprotocol.org:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
 snowflake-target-direct https://snowflake-broker.torproject.net/
 snowflake-amp-front www.google.com


### PR DESCRIPTION
Related to https://github.com/guardianproject/orbot/pull/1191 and https://gitlab.torproject.org/tpo/anti-censorship/team/-/issues/151

Although, this change isn't necessary because, despite [being used to call IPtProxy's `startSnowflake`](https://github.com/guardianproject/orbot/blob/2117d27d0876090935e48fd4dea4e110a8089b24/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java#L371), this target/front configuration is never used and overridden by the [Snowflake bridge lines](https://github.com/guardianproject/orbot/blob/2117d27d0876090935e48fd4dea4e110a8089b24/orbotservice/src/main/assets/snowflake-brokers).

This is only really useful if there is a bridge line without a specified front.