### PR TITLE
Fix app selection

### DIFF
--- a/app/src/main/res/menu/app_main.xml
+++ b/app/src/main/res/menu/app_main.xml
@@ -21,10 +21,5 @@
     xmlns:yourapp="http://schemas.android.com/apk/res-auto"
     >
 
-    <item android:id="@+id/menu_save_apps"
-        android:title="@string/save"
-        yourapp:showAsAction="always|withText"
-        />
-
  
 </menu>


### PR DESCRIPTION
I was quite shocked today when I enabled an app in the Orbot app selector, only to find out it hadn't been torified.

There are two problems with the current code:

1. When "back" or the left arrow are used in the app selection "activity", all apps you added to the torified app list are forgotten. This means users are running unsecured apps rather than torified ones. That's a severe bug.
2. When you figure out that you have to hit the "save" button, you might think that actually makes the settings take effect. No. You have to leave the app selector activity using the "back" button (after hitting "save") for the app to finally be added to the VPN. This means if you select an app, "save", and then switch to the app, it won't be torified. That's another severe bug.

I really don't think there's any excuse to display a checked checkbox next to an app logo unless that app is actually running torified at that very moment. I think we can agree that is a problem that needs to be fixed, even if we disagree about whether I've chose the right way to fix it.

My fix is to remove the "save" button entirely and simply restart the VPN synchronously whenever a checkbox changes. This doesn't seem to cause noticeable delays, but even if it were to cause them, they're necessary, because we really don't want the user to falsely believe they're running through Tor when they're not.

Again, I'm happy to find another way to solve this