### PR TITLE
Remove obsolete JCenter repository

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,18 +7,10 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        // noinspection JcenterRepositoryObsolete
-        jcenter {
-            content {
-                includeGroup('com.jraska')
-                includeGroup('tools.fastlane')
-            }
-        }
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }


### PR DESCRIPTION
JCenter has been deprecated for years and has finally shut down last year: https://jfrog.com/blog/jcenter-sunset/.