### PR TITLE
Fix build failure and use default config for app-tv settings

### DIFF
--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -35,9 +35,7 @@ android {
     productFlavors {
         teevee {
             dimension "teevee"
-            minSdkVersion 23 
-            applicationId "org.torproject.android.tv"
-            compileSdk 34
+            compileSdk 35
             versionCode 10020000
             versionName "orbot-tv-1.0.1-tor-0.4.7.14"
             archivesBaseName = "Orbot-TV-$versionName"


### PR DESCRIPTION
Fix build failure because dependencies require API 35