### PR TITLE
Refactor ConnectFragment to use shared view model

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectUiState.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectUiState.kt
@@ -3,7 +3,7 @@ package org.torproject.android.ui.connect
 sealed class ConnectUiState {
     object NoInternet : ConnectUiState()
     object Off : ConnectUiState()
-    object Starting : ConnectUiState()
+    data class Starting(val bootstrapPercent: Int?) : ConnectUiState()
     object On : ConnectUiState()
     object Stopping : ConnectUiState()
 }

--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectViewModel.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectViewModel.kt
@@ -3,9 +3,13 @@ package org.torproject.android.ui.connect
 import android.content.Context
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 
 import org.torproject.android.core.NetworkUtils.isNetworkAvailable
 import org.torproject.android.service.OrbotConstants
@@ -14,14 +18,41 @@ class ConnectViewModel : ViewModel() {
     private val _uiState = MutableStateFlow<ConnectUiState>(ConnectUiState.Off)
     val uiState: StateFlow<ConnectUiState> = _uiState
 
+    private val _eventChannel = Channel<ConnectEvent>(Channel.BUFFERED)
+    val events = _eventChannel.receiveAsFlow()
+
     fun updateState(context: Context, status: String?) {
         val newState = when {
             !isNetworkAvailable(context) -> ConnectUiState.NoInternet
-            status == OrbotConstants.STATUS_STARTING -> ConnectUiState.Starting
+            status == OrbotConstants.STATUS_STARTING -> ConnectUiState.Starting(null)
             status == OrbotConstants.STATUS_ON -> ConnectUiState.On
             status == OrbotConstants.STATUS_STOPPING -> ConnectUiState.Stopping
             else -> ConnectUiState.Off
         }
         _uiState.value = newState
     }
+
+    fun updateBootstrapPercent(percent: Int) {
+        val currentState = _uiState.value
+        if (currentState is ConnectUiState.Starting) {
+            _uiState.value = currentState.copy(bootstrapPercent = percent)
+        }
+    }
+
+    fun triggerStartTorAndVpn() {
+        viewModelScope.launch {
+            _eventChannel.send(ConnectEvent.StartTorAndVpn)
+        }
+    }
+
+    fun triggerRefreshMenuList() {
+        viewModelScope.launch {
+            _eventChannel.send(ConnectEvent.RefreshMenuList)
+        }
+    }
+}
+
+sealed class ConnectEvent {
+    object StartTorAndVpn : ConnectEvent()
+    object RefreshMenuList : ConnectEvent()
 }


### PR DESCRIPTION
This PR improves the communication between `OrbotActivity` and `ConnectFragment` by refactoring how they interact and share state. Previously, `OrbotActivity` directly accessed `fragConnect`, causing tight coupling and stale UI state when background events occurred.

This also fixes the bug where the `ConnectFragment` UI did not reflect state changes (like Tor connecting) until the user manually switched tabs. It also improves architecture by separating responsibilities and using recommended ViewModel patterns.

Closes #1033
Closes #1102 
Closes #1326 