### PR TITLE
Minor tweaks to bottom sheets for consistency

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/OrbotBottomSheetDIalogFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/OrbotBottomSheetDIalogFragment.kt
@@ -3,14 +3,18 @@ package org.torproject.android.ui
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.DialogInterface
+import android.graphics.Color
 import android.os.Bundle
 import android.util.DisplayMetrics
 import android.view.MotionEvent
 import android.view.View
 import android.widget.EditText
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+import org.torproject.android.R
 
 /**
 Class to setup default bottom sheet behavior for Config Connection, MOAT and any other
@@ -43,9 +47,11 @@ open class OrbotBottomSheetDialogFragment : BottomSheetDialogFragment() {
         dismiss()
     }
 
-    private fun setupRatio(bsd : BottomSheetDialog) {
+    private fun setupRatio(bsd: BottomSheetDialog) {
         val bottomSheet = bsd.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
         bottomSheet?.let {
+            it.setBackgroundResource(R.drawable.bottom_sheet_rounded)
+            it.setBackgroundColor(Color.TRANSPARENT)
             val behavior = BottomSheetBehavior.from(it)
             val layoutParams = it.layoutParams
             layoutParams.height = getHeight()

--- a/app/src/main/res/drawable/bottom_sheet_rounded.xml
+++ b/app/src/main/res/drawable/bottom_sheet_rounded.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/panel_widget_background" />
+    <corners
+        android:topLeftRadius="32dp"
+        android:topRightRadius="32dp"
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="0dp" />
+</shape>

--- a/app/src/main/res/drawable/btn_shape_round.xml
+++ b/app/src/main/res/drawable/btn_shape_round.xml
@@ -4,6 +4,6 @@
     android:shape="rectangle">
     <stroke
         android:width="1dp"
-        android:color="@android:color/black" />
-    <corners android:radius="10dp" />
+        android:color="@android:color/transparent" />
+    <corners android:radius="32dp" />
 </shape>

--- a/app/src/main/res/layout/config_connection_bottom_sheet.xml
+++ b/app/src/main/res/layout/config_connection_bottom_sheet.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#272030"
+    android:background="@drawable/bottom_sheet_rounded"
     android:paddingStart="10dp"
     android:paddingEnd="10dp">
 
     <View
         android:id="@+id/handle"
-        android:layout_width="40dp"
+        android:layout_width="30dp"
         android:layout_height="5dp"
         android:layout_marginTop="16dp"
         android:background="@android:color/darker_gray"
@@ -40,7 +39,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/activity_horizontal_margin"
-        android:background="#1C1425"
+        android:background="@drawable/btn_shape_round"
+        android:backgroundTint="#1C1425"
         android:orientation="horizontal"
         android:padding="6dp"
         app:layout_constraintTop_toBottomOf="@id/tvConfigSubHeader">
@@ -50,11 +50,10 @@
             style="@style/BottomSheetRadioHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
+            android:layout_margin="16dp"
             android:text="@string/not_sure"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
-
 
         <Button
             android:id="@+id/btnAskTor"
@@ -92,8 +91,9 @@
                 android:id="@+id/directContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:orientation="horizontal">
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground">
 
                 <RadioButton
                     android:id="@+id/rbDirect"
@@ -125,8 +125,9 @@
                 android:id="@+id/snowflakeContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:orientation="horizontal">
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground">
 
                 <RadioButton
                     android:id="@+id/rbSnowflake"
@@ -158,8 +159,9 @@
                 android:id="@+id/snowflakeAmpContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:orientation="horizontal">
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground">
 
                 <RadioButton
                     android:id="@+id/rbSnowflakeAmp"
@@ -196,8 +198,9 @@
                 android:id="@+id/snowflakeSqsContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
+                android:layout_marginBottom="12dp"
                 android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground"
                 android:visibility="gone">
 
                 <RadioButton
@@ -230,8 +233,9 @@
                 android:id="@+id/requestContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:orientation="horizontal">
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground">
 
                 <RadioButton
                     android:id="@+id/rbRequest"
@@ -263,8 +267,9 @@
                 android:id="@+id/customContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:orientation="horizontal">
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal"
+                android:background="?android:attr/selectableItemBackground">
 
                 <RadioButton
                     android:id="@+id/rbCustom"
@@ -295,7 +300,6 @@
         </RadioGroup>
     </androidx.core.widget.NestedScrollView>
 
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/mainGuideline"
         android:layout_width="wrap_content"
@@ -324,13 +328,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:background="@drawable/btn_shape_round"
-        android:backgroundTint="@color/orbot_btn_enabled_purple"
         android:paddingStart="@dimen/button_horizontal_large_margin"
         android:paddingEnd="@dimen/button_horizontal_large_margin"
         android:text="@string/connect"
         android:textColor="@android:color/white"
-
+        android:background="@drawable/btn_shape_round"
+        app:backgroundTint="@color/orbot_btn_enabled_purple"
         app:layout_constraintEnd_toEndOf="@id/tvCancel"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="parent"

--- a/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
+++ b/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:background="@color/new_background"
+    android:background="@drawable/bottom_sheet_rounded"
     android:paddingStart="10dp"
     android:paddingEnd="10dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent">
 
     <View
         android:id="@+id/handle"
-        android:layout_width="40dp"
+        android:layout_width="30dp"
         android:layout_height="5dp"
         android:background="@android:color/darker_gray"
         android:layout_marginTop="16dp"
@@ -50,13 +50,12 @@
         app:layout_constraintTop_toBottomOf="@id/tvCustomBridgeSubHeader"
         app:layout_constraintStart_toStartOf="parent"/>
 
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/mainGuideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent=".65"/>
+        app:layout_constraintGuide_percent=".85" />
 
     <TextView
         android:id="@+id/tvCancel"
@@ -83,11 +82,10 @@
         android:paddingStart="@dimen/button_horizontal_large_margin"
         android:paddingEnd="@dimen/button_horizontal_large_margin"
         android:background="@drawable/btn_shape_round"
-        android:backgroundTint="@color/orbot_btn_enabled_purple"
+        app:backgroundTint="@color/orbot_btn_enabled_purple"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/tvCancel"
         app:layout_constraintTop_toBottomOf="@id/mainGuideline"
         app:layout_constraintHorizontal_bias="0.5" />
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/kindess_config_bottom_sheet.xml
+++ b/app/src/main/res/layout/kindess_config_bottom_sheet.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/new_background"
+    android:background="@drawable/bottom_sheet_rounded"
     android:paddingStart="10dp"
     android:paddingEnd="10dp">
 
     <View
         android:id="@+id/handle"
-        android:layout_width="40dp"
+        android:layout_width="30dp"
         android:layout_height="5dp"
         android:background="@android:color/darker_gray"
         android:layout_marginTop="16dp"
@@ -40,9 +40,11 @@
         android:id="@+id/rowKindnessConfigWifi"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:background="@color/panel_widget_background"
-        android:layout_margin="10dp"
+        android:paddingVertical="4dp"
+        android:paddingHorizontal="16dp"
+        android:background="@drawable/btn_shape_round"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvCustomBridgeSubHeader">
@@ -53,11 +55,11 @@
             android:layout_height="wrap_content"
             android:text="@string/option_only_on_wifi"
             android:textSize="20sp"
-            android:paddingTop="@dimen/activity_horizontal_margin"
             android:textColor="@android:color/white"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/swKindnessConfigWifi"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/swKindnessConfigWifi"
@@ -78,9 +80,11 @@
         android:id="@+id/rowKindnessConfigPower"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:background="@color/panel_widget_background"
-        android:layout_margin="10dp"
+        android:paddingVertical="4dp"
+        android:paddingHorizontal="16dp"
+        android:background="@drawable/btn_shape_round"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/rowKindnessConfigWifi">
@@ -91,11 +95,11 @@
             android:layout_height="wrap_content"
             android:text="@string/option_only_when_charging"
             android:textSize="20sp"
-            android:paddingTop="@dimen/activity_horizontal_margin"
             android:textColor="@android:color/white"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/swKindnessConfigCharging"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/swKindnessConfigCharging"

--- a/app/src/main/res/layout/log_bottom_sheet.xml
+++ b/app/src/main/res/layout/log_bottom_sheet.xml
@@ -3,12 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/new_background"
+    android:background="@drawable/bottom_sheet_rounded"
     android:padding="10dp">
 
         <View
             android:id="@+id/handle"
-            android:layout_width="40dp"
+            android:layout_width="30dp"
             android:layout_height="5dp"
             android:background="@android:color/darker_gray"
             android:layout_marginTop="16dp"
@@ -18,17 +18,15 @@
 
         <TextView
             android:id="@+id/orbotLogHeader"
+            style="@style/BottomSheetHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/menu_log"
-            android:textColor="@color/bright_green"
+            android:layout_marginTop="32dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:layout_marginTop="44dp"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            app:layout_constraintEnd_toStartOf="@+id/btnCopyLog"
-            android:layout_marginEnd="272dp"
-            app:layout_constraintHorizontal_bias="0.0" />
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/btnCopyLog"
@@ -49,6 +47,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/orbotLogHeader"
+            android:paddingTop="16dp"
             android:paddingBottom="@dimen/button_horizontal_large_margin">
 
             <TextView

--- a/app/src/main/res/layout/moat_bottom_sheet.xml
+++ b/app/src/main/res/layout/moat_bottom_sheet.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@color/new_background"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bottom_sheet_rounded"
     android:paddingStart="10dp"
-    android:paddingEnd="10dp"
-    android:layout_height="match_parent">
+    android:paddingEnd="10dp">
 
     <View
         android:id="@+id/handle"
-        android:layout_width="40dp"
+        android:layout_width="30dp"
         android:layout_height="5dp"
         android:background="@android:color/darker_gray"
         android:layout_marginTop="16dp"
@@ -77,7 +77,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent=".65"/>
+        app:layout_constraintGuide_percent=".85" />
 
     <TextView
         android:id="@+id/tvCancel"
@@ -104,7 +104,7 @@
         android:paddingStart="@dimen/button_horizontal_large_margin"
         android:paddingEnd="@dimen/button_horizontal_large_margin"
         android:background="@drawable/btn_shape_round"
-        android:backgroundTint="@color/orbot_btn_enabled_purple"
+        app:backgroundTint="@color/orbot_btn_enabled_purple"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/tvCancel"
         app:layout_constraintTop_toBottomOf="@id/mainGuideline"


### PR DESCRIPTION
Applied a new rounded-corner background to all bottom sheet layouts using a shared drawable. Updated handle widths, margins, and button shapes for visual consistency. Improved padding, background, and text styles for a more modern and cohesive UI.

Tested on Pixel 8 API 35.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/2a481ebd-9181-4385-9207-4eb1efdf4e2f" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/e39e393c-583e-473e-9bae-3db397ffedcb" width="270" height="600"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/7b45fee9-79fa-4ad8-af72-82f16dacbfd7" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/bae44eae-83f1-405c-aec3-dbdee68e01c8" width="270" height="600"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/f192651c-4f1a-4cd1-8a29-263b333dc27d" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/d3ef5406-dbfd-4234-a567-12321e0e1484" width="270" height="600"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/12d9f82f-a28c-4748-8682-d95728ec44bb" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/78da7d28-4411-477f-a6b2-0c9bc198a123" width="270" height="600"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/908e57f6-2645-4919-a051-57b057874e78" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/6c5e54a0-faec-4be3-98fa-36ffe5bba22b" width="270" height="600"></td>
    </tr>
</table>