### PR TITLE
Camo Mode Samsung One UI Fix

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/more/camo/CamoFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/camo/CamoFragment.kt
@@ -1,10 +1,13 @@
 package org.torproject.android.ui.more.camo
 
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
@@ -16,6 +19,7 @@ import org.torproject.android.service.util.getKey
 import org.torproject.android.service.util.Prefs
 import org.torproject.android.ui.more.MoreActionAdapter
 import org.torproject.android.ui.OrbotMenuAction
+import java.lang.reflect.Field
 import kotlin.String
 
 class CamoFragment : Fragment() {
@@ -70,6 +74,17 @@ class CamoFragment : Fragment() {
         rvCamoApps.adapter = MoreActionAdapter(listItems)
         val spanCount = if (resources.configuration.screenWidthDp < 600) 2 else 4
         rvCamoApps.layoutManager = GridLayoutManager(requireContext(), spanCount)
+        if (hasSamsungOneUI()) {
+            val tvSamsungOneUI = view.findViewById<TextView>(R.id.tvCamoSamsung)
+            tvSamsungOneUI.visibility = View.VISIBLE
+            tvSamsungOneUI.setOnClickListener {
+                // open "Notifications part of Settings app
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                    startActivity(Intent(android.provider.Settings.ACTION_NOTIFICATION_ASSISTANT_SETTINGS))
+                else // just open the Settings app
+                    startActivity(Intent(android.provider.Settings.ACTION_SETTINGS))
+            }
+        }
         return view
     }
 
@@ -91,6 +106,15 @@ class CamoFragment : Fragment() {
         if (isSelected) item.backgroundColor =
             ContextCompat.getColor(requireContext(), R.color.panel_card_image)
         return item
+    }
+
+    // https://stackoverflow.com/questions/60122037/how-can-i-detect-samsung-one-ui
+    private fun hasSamsungOneUI(): Boolean {
+        val semPlatformIntField: Field =
+            Build.VERSION::class.java.getDeclaredField("SEM_PLATFORM_INT")
+        val version: Int = semPlatformIntField.getInt(null) - 90000
+        return Build.FINGERPRINT.contains("samsung") &&
+                version >= 0
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_camo.xml
+++ b/app/src/main/res/layout/fragment_camo.xml
@@ -13,6 +13,7 @@
         android:padding="16dp">
 
         <TextView
+            android:textColor="@android:color/white"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -28,6 +29,18 @@
             android:layout_height="wrap_content"
             android:clipToPadding="false"
             tools:listitem="@layout/item_more_action" />
+
+        <TextView
+            android:textAlignment="center"
+            tools:visibility="visible"
+            android:visibility="gone"
+            android:textColor="@android:color/white"
+            android:id="@+id/tvCamoSamsung"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_gravity="center"
+            android:text="@string/camo_samsung_instructions"/>
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,6 +289,7 @@
     <string name="camo_dialog_enable_confirm_msg" formatted="true">Orbot will camouflage itself as the app %1$s. This will hide all notification details about Tor and change how the appearance of Orbot on your home screen.\n\nCamouflaging as %2$s will restart Orbot.</string>
     <string name="camo_dialog_disable_confirm_msg">Orbot will resume displaying notification information about your Tor connection and will appear as normal on your home screen.\n\nDisabling Camouflage Mode will restart Orbot.</string>
     <string name="camo_dialog_disable_title">Disable Camouflage Mode</string>
+    <string name="camo_samsung_instructions">On Your Samsung Galaxy device Camouflage Mode\'s notifications will only work by opening your Settings -> Notifications -> Advanced Settings and disabling \"Show app icon in notifications\". Click here to open Notification Settings.</string>
 
     <string name="pref_camo_mode_title">Camouflage Mode</string>
     <string name="pref_camo_mode_description">Disguise how Orbot\'s icon, label and notification text will appear on your device</string>


### PR DESCRIPTION
Includes a disclaimer on Samsung devices with One UI which default to using the app icon notifications and ignoring notifications icons that apps set programatically.  

Tested on a galaxy A15 and works fine. 