### PR TITLE
Implement a new floating navbar

### DIFF
--- a/app/src/main/res/layout/activity_orbot.xml
+++ b/app/src/main/res/layout/activity_orbot.xml
@@ -13,23 +13,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
+        app:layout_constraintBottom_toTopOf="@id/floating_bottom_nav"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintVertical_bias="0"
         app:navGraph="@navigation/nav_graph" />
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
-        app:itemIconTint="@color/bottom_nav_color"
-        app:itemTextColor="@color/bottom_nav_color"
+    <include
+        android:id="@+id/floating_bottom_nav"
+        layout="@layout/floating_bottom_nav"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:menu="@menu/main_bottom_nav" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/floating_bottom_nav.xml
+++ b/app/src/main/res/layout/floating_bottom_nav.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="360dp"
+    android:layout_height="72dp"
+    android:layout_margin="24dp"
+    android:clipToPadding="false"
+    android:clipChildren="false"
+    app:cardCornerRadius="32dp"
+    app:cardElevation="12dp"
+    app:strokeWidth="0dp"
+    app:cardBackgroundColor="@android:color/black"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent">
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="6dp"
+        android:background="@android:color/transparent"
+        app:itemIconTint="@color/bottom_nav_color"
+        app:itemTextColor="@color/bottom_nav_color"
+        app:labelVisibilityMode="selected"
+        app:menu="@menu/main_bottom_nav" />
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
The current navbar feels out of place ever since edgeToEdge has been enabled by default on Android. Moreover, it is stretched out and is poorly optimized for larger devices and on landscape. I thus decided to wrap it inside a cardview to turn it into a floating component which has the benefit of feeling more material-like and more modern. The logic remains unchanged. Open to tweaking the margins/dimensions/colors better as I chose some initial defaults that made sense.

Tested on Pixel 8 API 35 and Pixel Tablet API 34.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/5ee3d3f0-2003-4ddb-8a35-1eacffe55426" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/b109d463-bd0c-4cb3-be6a-3c2324cd119a" width="270" height="600">
</td>
    </tr>
</table>
<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/6acf2b77-859d-4a04-a376-eb4478a9ccb2"></td>
        <td><img src="https://github.com/user-attachments/assets/22a945bf-63e9-45cc-990f-921c31275a86"></td>
    </tr>
</table>