### PR TITLE
Remove redundant VPN check for outbound proxy config

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/tor/TorConfig.kt
+++ b/orbotservice/src/main/java/org/torproject/android/service/tor/TorConfig.kt
@@ -74,26 +74,23 @@ object TorConfig {
         if (transport == Transport.NONE) {
             conf.add("UseBridges 0")
 
-            if (!Prefs.useVpn()) {
-                // Set the proxy here if we aren't using a bridge.
-                val proxyType = prefs?.getString("pref_proxy_type", null)
+            val proxyType = prefs?.getString("pref_proxy_type", null)
 
-                if (!proxyType.isNullOrEmpty()) {
-                    val proxyHost = prefs.getString("pref_proxy_host", null)
-                    val proxyPort = prefs.getString("pref_proxy_port", null)
-                    val proxyUser = prefs.getString("pref_proxy_username", null)
-                    val proxyPass = prefs.getString("pref_proxy_password", null)
+            if (!proxyType.isNullOrEmpty()) {
+                val proxyHost = prefs.getString("pref_proxy_host", null)
+                val proxyPort = prefs.getString("pref_proxy_port", null)
+                val proxyUser = prefs.getString("pref_proxy_username", null)
+                val proxyPass = prefs.getString("pref_proxy_password", null)
 
-                    if (!proxyHost.isNullOrEmpty() && !proxyPort.isNullOrEmpty()) {
-                        conf.add("${proxyType}Proxy $proxyHost:$proxyPort")
+                if (!proxyHost.isNullOrEmpty() && !proxyPort.isNullOrEmpty()) {
+                    conf.add("${proxyType}Proxy $proxyHost:$proxyPort")
 
-                        if (proxyUser != null && proxyPass != null) {
-                            if (proxyType.equals("socks5", ignoreCase = true)) {
-                                conf.add("Socks5ProxyUsername $proxyUser")
-                                conf.add("Socks5ProxyPassword $proxyPass")
-                            } else {
-                                conf.add("${proxyType}ProxyAuthenticator $proxyUser:$proxyPort")
-                            }
+                    if (proxyUser != null && proxyPass != null) {
+                        if (proxyType.equals("socks5", ignoreCase = true)) {
+                            conf.add("Socks5ProxyUsername $proxyUser")
+                            conf.add("Socks5ProxyPassword $proxyPass")
+                        } else {
+                            conf.add("${proxyType}ProxyAuthenticator $proxyUser:$proxyPort")
                         }
                     }
                 }


### PR DESCRIPTION
Tor's outbound proxy does not conflict with VPN mode, so remove this check.