### PR TITLE
Fix string with wrong default dns port

### DIFF
--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -63,7 +63,7 @@
     <string name="pref_transport_summary">Port sur lequel Tor offre son mandataire transparent (par défaut : 9040 ou 0 pour le désactiver)</string>
     <string name="pref_transport_dialog">Configuration du port du mandataire transparent</string>
     <string name="pref_dnsport_title">Port DNS de Tor</string>
-    <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 5400 ou 0 pour le désactiver)</string>
+    <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 9053 ou 0 pour le désactiver)</string>
     <string name="pref_dnsport_dialog">Configuration du port DNS</string>
     <string name="pref_torrc_title">Configuration personnalisée de Torrc</string>
     <string name="pref_torrc_summary">EXPERTS SEULEMENT : saisissez les lignes de configuration de torrc direct</string>


### PR DESCRIPTION
The default DNS port is now 9053.