### PR TITLE
Group settings menu into logical pref screens

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -16,6 +16,7 @@ import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceScreen
 import org.torproject.android.R
 import org.torproject.android.localization.Languages
 import org.torproject.android.ui.core.BaseActivity
@@ -48,13 +49,6 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
                 }
                 false
             }
-
-
-        // kludge for #992
-        val categoryNodeConfig = findPreference<Preference>("category_node_config")
-        categoryNodeConfig?.title =
-            "${categoryNodeConfig.title}" + "\n\n" + "${categoryNodeConfig.summary}"
-        categoryNodeConfig?.summary = null
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             // if defined in XML, disable the persistent notification preference on Oreo+
@@ -96,6 +90,35 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        val screenTitle = preferenceScreen?.title
+        if (!screenTitle.isNullOrEmpty()) {
+            activity?.title = screenTitle
+        } else {
+            activity?.setTitle(R.string.menu_settings)
+        }
+    }
+
+    override fun onNavigateToScreen(preferenceScreen: PreferenceScreen) {
+        val fragment = SettingsPreferenceFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_PREFERENCE_ROOT, preferenceScreen.key)
+            }
+        }
+
+        parentFragmentManager.beginTransaction()
+            .setCustomAnimations(
+                R.anim.slide_in_right,
+                R.anim.slide_out_left,
+                R.anim.slide_in_left,
+                R.anim.slide_out_right
+            )
+            .replace(R.id.settings_container, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,8 +2,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     app:iconSpaceReserved="false">
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/pref_general_group"
+        android:key="category_general"
         app:iconSpaceReserved="false">
 
         <ListPreference
@@ -77,10 +78,11 @@
             android:defaultValue="false"
             app:iconSpaceReserved="false"/>
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/volunteer_mode"
+        android:key="category_kindness"
         app:iconSpaceReserved="false">
 
         <CheckBoxPreference
@@ -90,9 +92,9 @@
             android:title="@string/snowflake_proxy_msg_title"
             app:iconSpaceReserved="false" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:key="category_node_config"
         android:title="@string/pref_node_configuration"
         app:iconSpaceReserved="false"
@@ -125,10 +127,11 @@
             android:title="@string/strict_nodes"
             app:iconSpaceReserved="false" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/reachable_addresses"
+        android:key="category_reachable_addresses"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:defaultValue="false"
@@ -145,11 +148,11 @@
             android:summary="@string/ports_reachable_behind_a_restrictive_firewall"
             android:title="@string/reachable_ports"
             app:iconSpaceReserved="false" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="Connectivity"
-
+        android:key="category_connectivity"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:defaultValue="false"
@@ -193,12 +196,11 @@
             android:summary="@string/pref_disable_ipv4_summary"
             android:title="@string/pref_disable_ipv4"
             app:iconSpaceReserved="false" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/setting_padding"
-
-
+        android:key="category_padding"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:defaultValue="false"
@@ -228,11 +230,11 @@
             android:summary="@string/pref_reduced_circuit_padding_summary"
             android:title="@string/pref_reduced_circuit_padding"
             app:iconSpaceReserved="false" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/pref_proxy_title"
-
+        android:key="category_proxy"
         app:iconSpaceReserved="false">
         <EditTextPreference
             android:dialogTitle="@string/pref_proxy_type_dialog"
@@ -267,11 +269,11 @@
             android:summary="@string/pref_proxy_password_summary"
             android:title="@string/pref_proxy_password_title"
             app:iconSpaceReserved="false" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:title="@string/setting_debug"
-
+        android:key="category_debug"
         app:iconSpaceReserved="false">
 
         <EditTextPreference
@@ -334,6 +336,6 @@
             android:title="@string/pref_disable_network_title"
             app:iconSpaceReserved="false" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Reduces clutter by grouping the settings menu into more logical sections.

Tested on Pixel 8 API 35.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/a4a01756-da42-479e-9143-9a4f791d4fa9" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/a5622042-ffe3-45df-b5cf-0e176dd54b35" width="270" height="600"></td>
    </tr>
</table>