### PR TITLE
Show detected custom bridge type as a chip

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -37,9 +37,7 @@ class CustomBridgeBottomSheet() :
         fun isValidBridge(input: String): Boolean {
             return input.lines()
                 .filter { it.isNotEmpty() && it.isNotBlank() }
-                .all {
-                    it.matches(validBridgeRegex)
-                }
+                .all { it.matches(validBridgeRegex) }
         }
     }
 
@@ -149,6 +147,30 @@ class CustomBridgeBottomSheet() :
             binding.etBridges.error = requireContext().getString(R.string.invalid_bridge_format)
         } else {
             binding.etBridges.error = null
+        }
+
+        val bridgeType = detectBridgeType(inputText)
+
+        if (bridgeType != null) {
+            binding.bridgeTypeChip.visibility = View.VISIBLE
+            binding.bridgeTypeChip.text = "✔ $bridgeType"
+        } else {
+            binding.bridgeTypeChip.visibility = View.GONE
+        }
+    }
+
+    private fun detectBridgeType(input: String): String? {
+        val firstLine = input.lineSequence().firstOrNull { it.isNotBlank() }?.trim() ?: return null
+        val firstToken = firstLine.split(Regex("\\s+"), limit = 2).firstOrNull() ?: return null
+
+        return when (firstToken.lowercase()) {
+            "obfs4" -> "obfs4"
+            "meek_lite" -> "meek_lite"
+            "snowflake" -> "snowflake"
+            "webtunnel" -> "webtunnel"
+            else -> {
+                if (isValidBridge(firstLine)) "vanilla" else null
+            }
         }
     }
 }

--- a/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
+++ b/app/src/main/res/layout/custom_bridge_bottom_sheet.xml
@@ -64,6 +64,25 @@
             app:layout_constraintBottom_toTopOf="@id/btnAction"
             app:layout_constraintTop_toBottomOf="@id/tvCustomBridgeSubHeader" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/bridgeTypeChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="36dp"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
+            android:background="@drawable/btn_shape_round"
+            android:backgroundTint="@color/dark_purple"
+            android:textColor="@android:color/white"
+            android:textAllCaps="false"
+            android:textSize="16sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/btnAction"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
         <ImageButton
             android:id="@+id/btnScan"
             android:layout_width="wrap_content"


### PR DESCRIPTION
This is more of a UX change that can help beginner users by informing them of the bridge type they entered. Obviously the phrase I used is for debugging purposes. Also, the UI can potentially be improved for this bottom sheet but I don't have any great ideas yet. Open to suggestions.

<img width="270" height="600" alt="Screenshot_20251021_222527" src="https://github.com/user-attachments/assets/591c16cb-e72d-419e-8bcc-793706c97518" />

Tested on Pixel 8 API 35.