### PR TITLE
Feature/service process

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,7 @@
             android:name=".service.OrbotService"
             android:enabled="true"
             android:exported="true"
+            android:process=":tor"
             android:foregroundServiceType="systemExempted"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:stopWithTask="false">
@@ -123,6 +124,11 @@
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
+
+        <service android:name="org.torproject.jni.TorService"
+            android:process=":tor"
+            tools:node="merge"
+            tools:replace="android:process" />
 
         <service
             android:name=".ui.OrbotTileService"

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -13,7 +13,6 @@ import android.util.Log
 import android.view.View
 import android.view.WindowInsetsController
 import androidx.activity.addCallback
-
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
@@ -21,25 +20,22 @@ import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
-
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scottyab.rootbeer.RootBeer
-
-import org.torproject.android.util.sendIntentToService
-import org.torproject.android.ui.core.BaseActivity
 import org.torproject.android.service.OrbotConstants
-import org.torproject.android.ui.kindness.SnowflakeProxyService
-import org.torproject.android.util.Prefs
-import org.torproject.android.util.showToast
-import org.torproject.android.ui.more.LogBottomSheet
 import org.torproject.android.ui.connect.ConnectViewModel
 import org.torproject.android.ui.connect.RequestPostNotificationPermission
+import org.torproject.android.ui.core.BaseActivity
 import org.torproject.android.ui.core.DeviceAuthenticationPrompt
+import org.torproject.android.ui.kindness.SnowflakeProxyService
+import org.torproject.android.ui.more.LogBottomSheet
+import org.torproject.android.util.Prefs
+import org.torproject.android.util.sendIntentToService
+import org.torproject.android.util.showToast
 
 class OrbotActivity : BaseActivity() {
 
@@ -153,17 +149,14 @@ class OrbotActivity : BaseActivity() {
             true
         }
 
-        with(LocalBroadcastManager.getInstance(this)) {
-            registerReceiver(
-                orbotServiceBroadcastReceiver, IntentFilter(OrbotConstants.LOCAL_ACTION_STATUS)
-            )
-            registerReceiver(
-                orbotServiceBroadcastReceiver, IntentFilter(OrbotConstants.LOCAL_ACTION_LOG)
-            )
-            registerReceiver(
-                orbotServiceBroadcastReceiver, IntentFilter(OrbotConstants.LOCAL_ACTION_PORTS)
-            )
+        val filter = IntentFilter().apply {
+            addAction(OrbotConstants.LOCAL_ACTION_STATUS)
+            addAction(OrbotConstants.LOCAL_ACTION_LOG)
+            addAction(OrbotConstants.LOCAL_ACTION_PORTS)
         }
+
+        ContextCompat.registerReceiver(this, orbotServiceBroadcastReceiver, filter,
+            ContextCompat.RECEIVER_NOT_EXPORTED)
 
         requestNotificationPermission()
 
@@ -256,7 +249,8 @@ class OrbotActivity : BaseActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(orbotServiceBroadcastReceiver)
+
+        unregisterReceiver(orbotServiceBroadcastReceiver)
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -336,7 +336,8 @@ public class OrbotService extends VpnService {
         if (packageName != null)
             sendBroadcast(reply.setPackage(packageName));
 
-        LocalBroadcastManager.getInstance(this).sendBroadcast(reply.setAction(LOCAL_ACTION_STATUS));
+        sendBroadcast(reply.setAction(LOCAL_ACTION_STATUS).setPackage(getPackageName()));
+
         if (mPortSOCKS != -1 && mPortHTTP != -1)
             sendCallbackPorts(mPortSOCKS, mPortHTTP, mPortDns, mPortTrans);
     }
@@ -406,8 +407,10 @@ public class OrbotService extends VpnService {
         // Down the line a better approach needs to happen for sending back the onion names' updated
         // status, perhaps just adding it as an extra to the normal Intent callback...
         var oldStatus = mCurrentStatus;
-        var intent = new Intent(LOCAL_ACTION_V3_NAMES_UPDATED);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+
+        sendBroadcast(new Intent(LOCAL_ACTION_V3_NAMES_UPDATED)
+                .setPackage(getPackageName()));
+
         mCurrentStatus = oldStatus;
     }
 
@@ -487,8 +490,9 @@ public class OrbotService extends VpnService {
     }
 
     private void sendLocalStatusOffBroadcast() {
-        var localOffStatus = new Intent(LOCAL_ACTION_STATUS).putExtra(EXTRA_STATUS, STATUS_OFF);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(localOffStatus);
+        sendBroadcast(new Intent(LOCAL_ACTION_STATUS)
+                .putExtra(EXTRA_STATUS, STATUS_OFF)
+                .setPackage(getPackageName()));
     }
 
     private void initControlConnection() {
@@ -569,7 +573,11 @@ public class OrbotService extends VpnService {
 
     private void sendCallbackLogMessage(final String logMessage) {
         var notificationMessage = logMessage;
-        var localIntent = new Intent(LOCAL_ACTION_LOG).putExtra(LOCAL_EXTRA_LOG, logMessage);
+
+        var localIntent = new Intent(LOCAL_ACTION_LOG)
+                .putExtra(LOCAL_EXTRA_LOG, logMessage)
+                .setPackage(getPackageName());
+
         if (logMessage.contains(LOG_NOTICE_HEADER)) {
             notificationMessage = notificationMessage.substring(LOG_NOTICE_HEADER.length());
             if (notificationMessage.contains(LOG_NOTICE_BOOTSTRAPPED)) {
@@ -583,12 +591,19 @@ public class OrbotService extends VpnService {
             }
         }
         showToolbarNotification(notificationMessage, NOTIFY_ID, R.drawable.ic_stat_tor);
-        mHandler.post(() -> LocalBroadcastManager.getInstance(OrbotService.this).sendBroadcast(localIntent));
+        mHandler.post(() -> sendBroadcast(localIntent));
     }
 
     private void sendCallbackPorts(int socksPort, int httpPort, int dnsPort, int transPort) {
-        var intent = new Intent(LOCAL_ACTION_PORTS).putExtra(EXTRA_SOCKS_PROXY_PORT, socksPort).putExtra(EXTRA_HTTP_PROXY_PORT, httpPort).putExtra(EXTRA_DNS_PORT, dnsPort).putExtra(EXTRA_TRANS_PORT, transPort);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        var intent = new Intent(LOCAL_ACTION_PORTS)
+                .putExtra(EXTRA_SOCKS_PROXY_PORT, socksPort)
+                .putExtra(EXTRA_HTTP_PROXY_PORT, httpPort)
+                .putExtra(EXTRA_DNS_PORT, dnsPort)
+                .putExtra(EXTRA_TRANS_PORT, transPort)
+                .setPackage(getPackageName());
+
+        sendBroadcast(intent);
+
         if (Prefs.useVpn() && mVpnManager != null) mVpnManager.handleIntent(new Builder(), intent);
     }
 
@@ -609,7 +624,7 @@ public class OrbotService extends VpnService {
         Prefs.putUseVpn(false);
         mVpnManager.handleIntent(new Builder(), new Intent(ACTION_STOP));
         // tell UI, if it's open, to update immediately (don't wait for onResume() in Activity...)
-        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_STOP));
+        sendBroadcast(new Intent(ACTION_STOP).setPackage(getPackageName()));
     }
 
     private void setExitNode(String newExits) {
@@ -742,8 +757,9 @@ public class OrbotService extends VpnService {
                         SmartConnect.updateProgress(100);
                     }
 
-                    var localStatus = new Intent(LOCAL_ACTION_STATUS).putExtra(EXTRA_STATUS, mCurrentStatus);
-                    LocalBroadcastManager.getInstance(OrbotService.this).sendBroadcast(localStatus); // update the activity with what's new
+                    sendBroadcast(new Intent(LOCAL_ACTION_STATUS)
+                            .putExtra(EXTRA_STATUS, mCurrentStatus)
+                            .setPackage(getPackageName())); // update the activity with what's new
                 }
             }
         }


### PR DESCRIPTION
I just put `OrbotService` and `TorService` in another process together.

The interface between OrbotService and the rest of the app seems just to be the broadcasts, which I could switch from local broadcasts to normal ones.

This *seems* to work on first glance.

Is this a bad idea? Why? @syphyr, what do you think?

related: #1479 