### PR TITLE
Simplify nested contraint layouts in Kindness frag

### DIFF
--- a/app/src/main/res/layout/fragment_kindness.xml
+++ b/app/src/main/res/layout/fragment_kindness.xml
@@ -5,280 +5,256 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
         android:id="@+id/panel_kindness_activate"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="visible"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <ScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clickable="true"
-            android:focusable="true"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:paddingBottom="120dp"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:maxWidth="600dp">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <ImageView
+                android:id="@+id/ivOrbi"
+                android:layout_width="180dp"
+                android:layout_height="180dp"
+                android:layout_marginTop="20dp"
+                android:src="@drawable/orbiesnoozing"
+                android:contentDescription="@null" />
+
+            <TextView
+                android:id="@+id/tvTitleOff"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="120dp"
-                android:visibility="visible"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="4dp"
+                android:gravity="center"
+                android:text="@string/volunteer_mode_title"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textColor="@android:color/white" />
+
+            <TextView
+                android:id="@+id/tvSubtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:paddingStart="32dp"
+                android:paddingEnd="32dp"
+                android:gravity="center"
+                android:text="@string/volunteer_mode_subtitle_desc"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="@android:color/white" />
+
+            <Button
+                android:id="@+id/btnActionActivate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/btn_shape_round"
+                android:backgroundTint="@color/orbot_btn_enabled_purple"
+                android:paddingStart="@dimen/button_horizontal_large_margin"
+                android:paddingEnd="@dimen/button_horizontal_large_margin"
+                android:text="@string/action_activate"
+                android:textColor="@android:color/white"
+                android:layout_gravity="center_horizontal" />
+        </LinearLayout>
+    </ScrollView>
+
+    <ScrollView
+        android:id="@+id/panel_kindness_status"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:paddingBottom="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="gone">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:paddingBottom="120dp"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:maxWidth="600dp">
+
+            <ImageView
+                android:id="@+id/ivHeader"
+                android:layout_width="180dp"
+                android:layout_height="180dp"
+                android:layout_marginTop="20dp"
+                android:src="@drawable/kindness"
+                android:contentDescription="@null"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tvTitleOn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="4dp"
+                android:gravity="center_horizontal"
+                android:text="@string/volunteer_status_title"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textColor="@android:color/white"
+                android:textStyle="normal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ivHeader" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/rowVolunteerMode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:background="@color/panel_widget_background"
+                android:padding="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvTitleOn">
 
                 <ImageView
-                    android:id="@+id/ivOrbi"
-                    android:layout_width="180dp"
-                    android:layout_height="180dp"
-                    android:layout_marginTop="20dp"
-                    android:src="@drawable/orbiesnoozing"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:id="@+id/ivHeartOn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_heart"
+                    android:contentDescription="@null"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/tvTitleOff"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="4dp"
-                    android:gravity="center_horizontal"
-                    android:text="@string/volunteer_mode_title"
-                    android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
-                    android:textColor="@android:color/white"
-                    android:textStyle="normal"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/ivOrbi" />
-
-                <TextView
-                    android:textAlignment="center"
-                    android:gravity="center"
-                    android:id="@+id/tvSubtitle"
+                    android:id="@+id/swVolunteerHeader"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:paddingStart="32dp"
-                    android:paddingEnd="32dp"
-                    android:text="@string/volunteer_mode_subtitle_desc"
-                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
-                    android:textColor="@android:color/white"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tvTitleOff" />
+                    android:layout_marginStart="16dp"
+                    android:text="@string/volunteer_mode"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="@id/ivHeartOn"
+                    app:layout_constraintStart_toEndOf="@id/ivHeartOn"
+                    app:layout_constraintTop_toTopOf="@id/ivHeartOn" />
 
-                <Button
-                    android:id="@+id/btnActionActivate"
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/swVolunteerMode"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="@id/ivHeartOn"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/ivHeartOn"
+                    app:showText="false" />
+
+                <ImageView
+                    android:id="@+id/ivGear"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:background="@drawable/btn_shape_round"
-                    android:backgroundTint="@color/orbot_btn_enabled_purple"
-                    android:paddingStart="@dimen/button_horizontal_large_margin"
-                    android:paddingEnd="@dimen/button_horizontal_large_margin"
-                    android:text="@string/action_activate"
-                    android:textColor="@android:color/white"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:src="@drawable/ic_settings_gear"
+                    android:contentDescription="@null"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tvSubtitle" />
+                    app:layout_constraintTop_toBottomOf="@+id/ivHeartOn" />
+
+                <TextView
+                    android:id="@+id/swVolunteerAdjust"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/kindness_adjust_title"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="@id/ivGear"
+                    app:layout_constraintStart_toEndOf="@id/ivGear"
+                    app:layout_constraintStart_toStartOf="@id/swVolunteerHeader"
+                    app:layout_constraintTop_toTopOf="@id/ivGear" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </ScrollView>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/panel_kindness_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="gone">
-
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clickable="true"
-            android:focusable="true"
-            android:paddingBottom="20dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/volunteer_display_weekly"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="120dp"
+                android:layout_margin="10dp"
+                android:background="@color/panel_widget_background"
+                android:orientation="horizontal"
+                android:padding="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toBottomOf="@+id/rowVolunteerMode">
 
-                <ImageView
-                    android:id="@+id/ivHeader"
-                    android:layout_width="180dp"
-                    android:layout_height="180dp"
-                    android:layout_marginTop="20dp"
-                    android:src="@drawable/kindness"
-                    app:layout_constraintEnd_toEndOf="parent"
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="@string/volunteer_mode_weekly_label"
+                    android:textAllCaps="true"
+                    android:textColor="@color/progress_bar_purple"
+                    android:textSize="20sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/tvTitleOn"
-                    android:layout_width="match_parent"
+                    android:id="@+id/tvWeeklyTotal"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="4dp"
-                    android:gravity="center_horizontal"
-                    android:text="@string/volunteer_status_title"
-                    android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
-                    android:textColor="@android:color/white"
-                    android:textStyle="normal"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/ivHeader" />
-
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/rowVolunteerMode"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:background="@color/panel_widget_background"
-                    android:padding="16dp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tvTitleOn">
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="#" />
 
-
-                    <ImageView
-                        android:id="@+id/ivHeartOn"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/ic_heart"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/swVolunteerHeader"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:text="@string/volunteer_mode"
-                        android:textSize="24sp"
-                        app:layout_constraintBottom_toBottomOf="@id/ivHeartOn"
-                        app:layout_constraintStart_toEndOf="@id/ivHeartOn"
-                        app:layout_constraintTop_toTopOf="@id/ivHeartOn" />
-
-                    <androidx.appcompat.widget.SwitchCompat
-                        android:id="@+id/swVolunteerMode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textSize="24sp"
-                        app:layout_constraintBottom_toBottomOf="@id/ivHeartOn"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="@id/ivHeartOn"
-                        app:showText="false" />
-
-                    <ImageView
-                        android:id="@+id/ivGear"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:src="@drawable/ic_settings_gear"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/ivHeartOn" />
-
-                    <TextView
-                        android:id="@+id/swVolunteerAdjust"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/kindness_adjust_title"
-                        android:textSize="24sp"
-                        app:layout_constraintBottom_toBottomOf="@id/ivGear"
-                        app:layout_constraintStart_toEndOf="@id/ivGear"
-                        app:layout_constraintStart_toStartOf="@id/swVolunteerHeader"
-                        app:layout_constraintTop_toTopOf="@id/ivGear" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/volunteer_display_weekly"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:background="@color/panel_widget_background"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/rowVolunteerMode">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="sans-serif-medium"
-                        android:text="@string/volunteer_mode_weekly_label"
-                        android:textAllCaps="true"
-                        android:textColor="@color/progress_bar_purple"
-                        android:textSize="20sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/tvWeeklyTotal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="sans-serif-medium"
-                        android:textSize="24sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        tools:text="#" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="10dp"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginEnd="10dp"
-                    android:layout_marginBottom="200dp"
-                    android:background="@color/panel_widget_background"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/volunteer_display_weekly">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="sans-serif-medium"
-                        android:text="@string/volunteer_mode_alltime_label"
-                        android:textAllCaps="true"
-                        android:textColor="@color/progress_bar_purple"
-                        android:textSize="20sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/tvAlltimeTotal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:fontFamily="sans-serif-medium"
-                        android:textSize="24sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        tools:text="#" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </ScrollView>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:layout_marginBottom="200dp"
+                android:background="@color/panel_widget_background"
+                android:orientation="horizontal"
+                android:padding="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/volunteer_display_weekly">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="@string/volunteer_mode_alltime_label"
+                    android:textAllCaps="true"
+                    android:textColor="@color/progress_bar_purple"
+                    android:textSize="20sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tvAlltimeTotal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:fontFamily="sans-serif-medium"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="#" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Nested layouts by themselves, let alone nested `ContraintLayout`s are extremely detrimental to performance. This PR gets rid of them and flattens the layout, simplifying the code and improving the performance. The visual layout remains unchanged by this.

Tested on Pixel 8 API 35 and Pixel Tablet API 34.
