### PR TITLE
Make sure toggle stays in position after switching views

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
@@ -76,6 +76,7 @@ class ConnectFragment : Fragment(),
                         }
 
                         is ConnectUiState.On -> {
+                            binding.switchConnect.isChecked = true
                             lastState = OrbotConstants.ACTION_START
                             doLayoutOn(requireContext())
                         }


### PR DESCRIPTION
The toggle turns off when switching from Connect fragment to More fragment and back to Connect fragment.

Fixes #1530