### PR TITLE
Bug Fixes Around New Connect Screen Log Printng 

### DIFF
--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -461,7 +461,7 @@ public class OrbotService extends VpnService {
                     //override the TorService event listener
                     conn.addRawEventListener(mOrbotRawEventListener);
 
-                    logNotice(getString(R.string.log_notice_connected_to_tor_control_port));
+                    logNotice(getString(R.string.status_connected_control_port));
 
                     var events = new ArrayList<>(Arrays.asList(TorControlCommands.EVENT_OR_CONN_STATUS, TorControlCommands.EVENT_CIRCUIT_STATUS, TorControlCommands.EVENT_NOTICE_MSG, TorControlCommands.EVENT_WARN_MSG, TorControlCommands.EVENT_ERR_MSG, TorControlCommands.EVENT_BANDWIDTH_USED, TorControlCommands.EVENT_NEW_DESC, TorControlCommands.EVENT_ADDRMAP));
                     if (Prefs.useDebugLogging())

--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
@@ -84,10 +84,9 @@ class ConnectFragment : Fragment(),
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.logState.collect { logline ->
-                    LocalizedTorStatusLogs.setTextviewOnFormattedLog(logline, binding.tvSubtitle)
+                    LocalizedLogsToDisplay.updateLabelIfDisplayed(logline, binding.tvSubtitle, context)
                 }
             }
-
         }
 
         viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/java/org/torproject/android/ui/connect/LocalizedLogsToDisplay.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/LocalizedLogsToDisplay.kt
@@ -1,11 +1,12 @@
 package org.torproject.android.ui.connect
 
+import android.content.Context
 import android.widget.TextView
 import org.torproject.android.R
 
-object LocalizedTorStatusLogs {
-    private val logsWePrint = mapOf(
-        "Connected to tor control port" to R.string.status_connected_control_port,
+object LocalizedLogsToDisplay {
+
+    private val systemLogsToDisplay = mapOf(
         "(handshake)" to R.string.status_handshake,
         "(handshake_done)" to R.string.status_handshake_done,
         "(circuit_create)" to R.string.status_circuit_create,
@@ -22,11 +23,21 @@ object LocalizedTorStatusLogs {
         "(loading_descriptors)" to R.string.status_loading_descriptors,
     )
 
-    fun setTextviewOnFormattedLog(logline: String, label: TextView) {
-        logsWePrint.keys.forEach { key ->
+    private val localizedLogsToDisplay = listOf(R.string.status_connected_control_port)
+
+    fun updateLabelIfDisplayed(logline: String, label: TextView, context: Context?) {
+        if (logline.isBlank()) return
+        systemLogsToDisplay.keys.forEach { key ->
             if (logline.contains(key)) {
-                label.setText(logsWePrint[key]!!)
+                label.setText(systemLogsToDisplay[key]!!)
                 return
+            }
+        }
+        if (context == null) return
+        localizedLogsToDisplay.forEach {
+            val str = context.getString(it)
+            if (logline.contains(str)) {
+                label.text = str
             }
         }
     }


### PR DESCRIPTION
- Noticed that the `ConnectFragment` was checking if a log contained "Connected to control port" and if contained would print "Tor service has started". The former String isn't  hardcoded but actually is `R.string.log_notice_connected_to_tor_control_port` - one of our dynamically localized ones. This means that prior to this fix, "Tor service has started" would only be displayed if Orbot is in Enlgish.
- Moved longwinded if/else/else/else avalanche out of `ConnectFragment` and into a more compact file that maps Strings to we want to print. 