### PR TITLE
Improve status display formatting in MoreFragment

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
@@ -2,7 +2,6 @@ package org.torproject.android.ui.more
 
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -37,25 +36,35 @@ class MoreFragment : Fragment() {
     }
 
     private fun updateStatus() {
-        val sb = StringBuilder()
+        val labels = listOf("HTTP proxy", "SOCKS proxy", "Orbot", "Tor")
+        val labelWidth = labels.maxOf { it.length } + 6
 
-        sb.append(getString(R.string.proxy_ports)).append(" ")
-
-        if (httpPort != -1 && socksPort != -1) {
-            sb.append("\nHTTP: ").append(httpPort).append(" -  SOCKS: ").append(socksPort)
-        } else {
-            sb.append(": " + getString(R.string.ports_not_set))
+        fun row(label: String, value: String): String {
+            return label.padEnd(labelWidth) + value
         }
 
-        sb.append("\n\n")
+        val rows = mutableListOf<String>()
 
-        val manager = requireActivity().packageManager
-        val info =
-            manager.getPackageInfo(requireActivity().packageName, PackageManager.GET_ACTIVITIES)
-        sb.append(getString(R.string.app_name)).append(" ${info.versionName}\n")
-        sb.append("Tor v${getTorVersion()}")
+        rows += if (httpPort != -1 && socksPort != -1) {
+            listOf(
+                row("HTTP proxy", httpPort.toString()),
+                row("SOCKS proxy", socksPort.toString())
+            )
+        } else {
+            listOf(
+                row("HTTP proxy", getString(R.string.ports_not_set)),
+                row("SOCKS proxy", getString(R.string.ports_not_set))
+            )
+        }
 
-        tvStatus.text = sb.toString()
+        val pm = requireActivity().packageManager
+        val info = pm.getPackageInfo(requireActivity().packageName, 0)
+        val normalizedVersion = info.versionName?.substringBefore("tor")?.dropLast(1)
+
+        rows += row("Orbot", "v$normalizedVersion")
+        rows += row("Tor", "v${getTorVersion()}")
+
+        tvStatus.text = rows.joinToString("\n")
     }
 
     override fun onCreateView(

--- a/app/src/main/res/layout/fragment_more.xml
+++ b/app/src/main/res/layout/fragment_more.xml
@@ -20,13 +20,19 @@
             android:padding="16dp"
             tools:listitem="@layout/item_more_action" />
 
-        <TextView
-            android:id="@+id/tvVersion"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="12dp"
-            android:gravity="center"
-            tools:text="Orbot vX.X.X" />
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/tvVersion"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_margin="12dp"
+                android:gravity="start"
+                android:fontFamily="monospace" />
+        </FrameLayout>
 
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Small ~~spring~~ winter cleanup to prettify the formatting of network and app details in the MoreFragment. Everything looks less cluttered and easier to understand at a glance now. Some small code refactor as well.

Tested on Pixel 8 API 35 and Pixel Tablet API 34.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/c10b998d-f43d-4419-ba0e-ff552ee9bcef" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/a5696bbe-3ae1-4a52-8d33-021e4fdc4f90" width="270" height="600">
</td>
    </tr>
</table>