### PR TITLE
ACTION_STOP is now public in TorService

### DIFF
--- a/app/src/main/java/org/torproject/android/service/OrbotConstants.kt
+++ b/app/src/main/java/org/torproject/android/service/OrbotConstants.kt
@@ -5,8 +5,6 @@ import androidx.core.net.toUri
 object OrbotConstants {
     const val TAG = "Orbot"
 
-    const val ACTION_STOP = "org.torproject.android.intent.action.STOP"
-
     const val PREF_REACHABLE_ADDRESSES = "pref_reachable_addresses"
     const val PREF_REACHABLE_ADDRESSES_PORTS = "pref_reachable_addresses_ports"
 

--- a/app/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
+++ b/app/src/main/java/org/torproject/android/service/vpn/OrbotVpnManager.java
@@ -69,7 +69,7 @@ public class OrbotVpnManager implements Handler.Callback {
                 Log.d(TAG, "starting VPN");
                 isStarted = true;
             }
-            case ACTION_STOP -> {
+            case TorService.ACTION_STOP -> {
                 isStarted = false;
                 Log.d(TAG, "stopping VPN");
                 stopVPN();

--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
@@ -153,7 +153,7 @@ class ConnectFragment : Fragment(),
 
     fun stopTorAndVpn() {
         doLayoutOff()
-        setState(OrbotConstants.ACTION_STOP)
+        setState(TorService.ACTION_STOP)
         binding.tvSubtitle.text = ""
     }
 

--- a/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
@@ -22,6 +22,7 @@ import org.torproject.android.ui.OrbotMenuAction
 import org.torproject.android.ui.v3onionservice.OnionServiceActivity
 import org.torproject.android.ui.v3onionservice.clientauth.ClientAuthActivity
 import org.torproject.android.util.StringUtils
+import org.torproject.jni.TorService
 
 class MoreFragment : Fragment() {
     private var httpPort = -1
@@ -139,7 +140,7 @@ class MoreFragment : Fragment() {
     private fun doExit() {
         val killIntent = Intent(
             requireActivity(), OrbotService::class.java
-        ).setAction(OrbotConstants.ACTION_STOP)
+        ).setAction(TorService.ACTION_STOP)
             .putExtra(OrbotConstants.ACTION_STOP_FOREGROUND_TASK, true)
         requireContext().sendIntentToService(killIntent)
         requireActivity().finish()


### PR DESCRIPTION
It is no longer necessary to define ACTION_STOP in OrbotConstants because ACTION_STOP is now made public in TorService.

This PR requires latest version of tor-android which includes the following change: https://github.com/guardianproject/tor-android/commit/7e5b3c5714c560a82144eaaf6d8f93f61185f658

Fixes build error:

app/src/main/java/org/torproject/android/service/OrbotService.java:635: error: reference to ACTION_STOP is ambiguous
both variable ACTION_STOP in TorService and variable ACTION_STOP in OrbotConstants match