### PR TITLE
Fix: v3 client auth not applied unless onion service hosting enabled

### DIFF
--- a/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
@@ -91,15 +91,16 @@ object TorConfig {
             conf.add("ReachableAddresses $reachableAddressesPorts")
         }
 
+        // Always add client authorization config if any entries exist.
+        val clientAuthLines = StringBuffer()
+        V3ClientAuthColumns.addClientAuthToTorrc(clientAuthLines, context,
+            V3ClientAuthColumns.createV3AuthDir(context))
+        conf.addAll(clientAuthLines.split("\n"))
+
         if (Prefs.hostOnionServicesEnabled) {
             val extraLines = StringBuffer()
-
-            // Add any needed client authorization and hosted onion service config lines to torrc.
-            V3ClientAuthColumns.addClientAuthToTorrc(extraLines, context,
-                V3ClientAuthColumns.createV3AuthDir(context))
             OnionServiceColumns.addV3OnionServicesToTorrc(extraLines, context,
                 OnionServiceColumns.createV3OnionDir(context))
-
             conf.addAll(extraLines.split("\n"))
         }
 


### PR DESCRIPTION
## Summary

- v3 client authorization (`ClientOnionAuthDir` + `.auth_private` files) is only written to the torrc when `Prefs.hostOnionServicesEnabled` is `true`
- This means users who add client auth keys via ⋮ → Onion Services → Client Authorization but don't also enable onion service **hosting** will silently fail to authenticate — Tor logs show "Fail to decrypt descriptor for requested onion address"
- Client authorization (connecting **to** auth-protected onion services as a client) is independent of **hosting** onion services and should not be gated behind the same preference

## Fix

Move the `addClientAuthToTorrc()` call outside the `if (Prefs.hostOnionServicesEnabled)` block so client auth keys are always included in the generated torrc when entries exist in the database.

## Test plan

- [ ] Add v3 client auth entry in Orbot (domain + x25519 private key)
- [ ] Do NOT enable onion service hosting
- [ ] Connect to a .onion service with client authorization enabled
- [ ] Verify connection succeeds (previously fails with "Fail to decrypt descriptor")
- [ ] Verify hosted onion services still work when hosting is enabled