### PR TITLE
Use internal Kotlin provided by AGP 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-android.builtInKotlin=false
 android.dependency.useConstraints=true
-android.newDsl=false
 android.nonTransitiveRClass=true
 android.r8.strictFullModeForKeepRules=false
 android.uniquePackageNames=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,5 +65,4 @@ quickie = { group = "io.github.g00fy2.quickie", name = "quickie-bundled", versio
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
The plugin `org.jetbrains.kotlin.android` is deprecated in AGP 9 and will stop working with AGP 10.  The android kotlin plugin is now built into AGP 9.