### PR TITLE
Migrate BottomSheet to WindowMetrics API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,7 @@ dependencies {
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.lifecycle.process)
+    implementation(libs.androidx.window)
     implementation(libs.retrofit.converter)
     implementation(libs.retrofit.lib)
     implementation(libs.rootbeer.lib)

--- a/app/src/main/java/org/torproject/android/ui/OrbotBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/OrbotBottomSheetDialogFragment.kt
@@ -1,15 +1,15 @@
 package org.torproject.android.ui
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.app.Dialog
 import android.graphics.Color
 import android.os.Bundle
-import android.util.DisplayMetrics
 import android.view.MotionEvent
 import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
+
+import androidx.window.layout.WindowMetricsCalculator
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -30,7 +30,7 @@ open class OrbotBottomSheetDialogFragment : BottomSheetDialogFragment() {
             bottomSheetView?.let {
                 it.setBackgroundResource(R.drawable.bottom_sheet_rounded)
                 it.setBackgroundColor(Color.TRANSPARENT)
-                setHeightIfAttached(activity, it)
+                setHeightResponsive(it)
                 val behavior = BottomSheetBehavior.from(it)
                 behavior.state = BottomSheetBehavior.STATE_EXPANDED
             }
@@ -39,15 +39,17 @@ open class OrbotBottomSheetDialogFragment : BottomSheetDialogFragment() {
         return dialog
     }
 
-    private fun setHeightIfAttached(activity: Activity?, bottomSheet: View) {
-        activity?.let {
-            val displayMetrics = DisplayMetrics()
-            requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
-            val height = (displayMetrics.heightPixels * getHeightRatio()).toInt()
-            val layoutParams = bottomSheet.layoutParams
-            layoutParams.height = height
-            bottomSheet.layoutParams = layoutParams
-        }
+    private fun setHeightResponsive(bottomSheet: View) {
+        val windowMetrics = WindowMetricsCalculator
+            .getOrCreate()
+            .computeCurrentWindowMetrics(requireActivity())
+
+        val windowHeight = windowMetrics.bounds.height()
+        val height = (windowHeight * getHeightRatio()).toInt()
+
+        val layoutParams = bottomSheet.layoutParams
+        layoutParams.height = height
+        bottomSheet.layoutParams = layoutParams
     }
 
     open fun getHeightRatio(): Float = 4 / 5f

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-localbroadcast = "1.1.0"
 androidx-preference = "1.2.1"
 androidx-rules = "1.7.0"
 androidx-runner = "1.7.0"
+androidx-window = "1.5.1"
 androidx-work = "2.11.1"
 guardian-jtorctl = "0.4.5.7"
 junit-jupiter = "6.0.3"
@@ -45,6 +46,7 @@ androidx-orchestrator = { module = "androidx.test:orchestrator", version.ref = "
 androidx-preference = { module = "androidx.preference:preference", version.ref = "androidx-preference" }
 androidx-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-rules" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-runner" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 androidx-work-kotlin = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
 guardian-jtorctl = { group = "info.guardianproject", name = "jtorctl", version.ref = "guardian-jtorctl" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit-jupiter" }


### PR DESCRIPTION
Replace deprecated Display.getMetrics() usage with WindowMetricsCalculator.computeCurrentWindowMetrics() to ensure correct behavior in multi-window mode, split-screen, rotation, and on foldables.

The previous nullable Activity safety check was also removed. The height calculation now uses requireActivity(), which is safe because it is executed inside setOnShowListener after the fragment is attached and the dialog is being shown. At that lifecycle point, the Fragment is guaranteed to have a non-null host Activity.

Tested on Pixel 9a API 36.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/31fc13fe-2447-4a9d-bc13-7f8c7c2fce38" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/10a3dcac-5ab1-4f5d-ae02-2cba03d6818a" width="270" height="600">
</td>
    </tr>
</table>