### PR TITLE
Always copy the license file to fix ./gradlew assemble

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,7 +206,7 @@ val copyLicenseToAssets by tasks.registering(Copy::class) {
 val updateBuiltinBridges by tasks.registering {
     onlyIf {
         gradle.startParameter.taskNames.any {
-            it.contains("Release") || it.contains("release")
+            it.contains("release", ignoreCase = true)
         }
     }
     val assetsDir = layout.projectDirectory.dir("src/main/assets")


### PR DESCRIPTION
Fix `gradlew assemble` from failing because the LICENSE file is not copied to assets first.
This PR makes gradle always copy the LICENSE file to the assets directory with both release and debug builds.
The task for checking for updated bridges will still only be for release builds.