### PR TITLE
Make Orbot AGP 10 Compliant 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ configure<ApplicationExtension> {
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.txt"
             )
-//            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.getByName("release")
         }
         getByName("debug") {
             isDebuggable = true
@@ -146,10 +146,8 @@ val updateBuiltinBridges = tasks.register<UpdateBridgeConfig>("updateBuiltinBrid
 
 }
 
-
 androidComponents {
     onVariants { variant ->
-// Rename APKs (Replaces removed archivesBaseName)
         base {
             archivesName.set("Orbot-${android.defaultConfig.versionName}")
         }
@@ -159,7 +157,7 @@ androidComponents {
             }
             variant.sources.assets?.addGeneratedSourceDirectory(
                 updateBuiltinBridges,
-                UpdateBridgeConfig::assetsDir // Points to the @get:OutputDirectory in your class
+                UpdateBridgeConfig::assetsDir
             )
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.api.dsl.ApplicationExtension
 import java.io.FileInputStream
-import java.net.URI
 import java.util.Date
 import java.util.Properties
 
@@ -84,10 +83,9 @@ configure<ApplicationExtension> {
             isShrinkResources = false
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.txt"
+                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.txt"
             )
-            signingConfig = signingConfigs.getByName("release")
+//            signingConfig = signingConfigs.getByName("release")
         }
         getByName("debug") {
             isDebuggable = true
@@ -132,18 +130,37 @@ configure<ApplicationExtension> {
 
 }
 
-// Increments versionCode by ABI type
+val updateBuiltinBridges = tasks.register<UpdateBridgeConfig>("updateBuiltinBridges") {
+    onlyIf { enabledForVariant.getOrElse(false) }
+
+    assetsDir.set(layout.projectDirectory.dir("src/main/assets"))
+
+    val dateStr: String = providers.exec {
+        commandLine("git", "log", "-n", "1", "--date=unix", assetsDir.get().asFile.path)
+    }.standardOutput.asText.get().trim().split("\n").filter { it.contains("Date:") }[0]
+    gitLogUnixTimestamp.set(dateStr.substring("Date:".length).trim().split(" ")[0])
+
+    gitStatusOutput.set(providers.exec {
+        commandLine("git", "status", "--porcelain")
+    }.standardOutput.asText.map { it.trim() }.orElse(""))
+
+}
+
+
 androidComponents {
     onVariants { variant ->
-        variant.outputs.forEach { output ->
-            if (output.versionCode.get() == orbotBaseVersionCode) {
-                val incrementMap =
-                    mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86" to 4, "x86_64" to 5)
-                val increment =
-                    incrementMap[output.filters.find { it.filterType.name == "ABI" }?.identifier]
-                        ?: 0
-                output.versionCode = (orbotBaseVersionCode) + increment
+// Rename APKs (Replaces removed archivesBaseName)
+        base {
+            archivesName.set("Orbot-${android.defaultConfig.versionName}")
+        }
+        if (variant.buildType == "release") {
+            updateBuiltinBridges.configure {
+                enabledForVariant.set(true)
             }
+            variant.sources.assets?.addGeneratedSourceDirectory(
+                updateBuiltinBridges,
+                UpdateBridgeConfig::assetsDir // Points to the @get:OutputDirectory in your class
+            )
         }
     }
 }
@@ -169,13 +186,13 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.work.kotlin)
     implementation(libs.upnp)
+    implementation(libs.quickie)
 
     // IPtProxy (for Snowflake, obfs4, dnstt and all other pluggable transports)
     implementation(libs.iptproxy)
     // uncomment to use a local build of IPtProxy:
     // implementation(files("../../IPtProxy/IPtProxy.aar"))
 
-    implementation(libs.quickie)
 
     // Tor
     implementation(files("../libs/geoip.jar"))
@@ -198,141 +215,13 @@ afterEvaluate {
     tasks.named("preBuild") {
         dependsOn(copyLicenseToAssets)
     }
-    tasks.matching {
-        it.name == "preFullpermReleaseBuild" ||
-                it.name == "preNightlyReleaseBuild"
-    }.configureEach {
-        dependsOn(updateBuiltinBridges)
-    }
+    tasks.named { it == "mergeNightlyDebugAssets" || it == "mergeFullpermDebugAssets" }
+        .configureEach {
+            mustRunAfter(updateBuiltinBridges)
+        }
 }
 
 val copyLicenseToAssets by tasks.registering(Copy::class) {
     from(rootProject.file("LICENSE"))
     into(layout.projectDirectory.dir("src/main/assets"))
-}
-
-val updateBuiltinBridges by tasks.registering {
-    onlyIf {
-        gradle.startParameter.taskNames.any {
-            it.contains("release", ignoreCase = true)
-        }
-    }
-    val assetsDir = layout.projectDirectory.dir("src/main/assets")
-    val outputFile = assetsDir.file("builtin-bridges.json").asFile
-    outputs.file(outputFile)
-
-    doLast {
-        assetsDir.asFile.mkdirs()
-        val oneDay = 60 * 60 * 24
-        val log: String =
-            providers.exec {
-                commandLine("git", "log", "-n", "1", "--date=unix", "$outputFile")
-            }.standardOutput.asText.get().trim()
-        val dateStr = log.split("\n").filter { it.contains("Date:") }[0]
-        val dateAsSeconds = dateStr.substring("Date:".length).trim().split(" ")[0].toLong()
-        val stale = Date().time / 1000 - dateAsSeconds > oneDay
-        if (!outputFile.exists() || stale) {
-            val bridgeUri = "https://bridges.torproject.org/moat/circumvention/builtin"
-            println("builtin-bridges.json missing or older than 24h, checking $bridgeUri for bridges...")
-            try {
-                URI(bridgeUri)
-                    .toURL()
-                    .openStream()
-                    .use { input ->
-                        outputFile.outputStream().use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                println("Successfully fetched builtin bridges.")
-
-                for (country in listOf(
-                    "ae",
-                    "af",
-                    "bd",
-                    "cn",
-                    "co",
-                    "global",
-                    "id",
-                    "ir",
-                    "kw",
-                    "pk",
-                    "qa",
-                    "ru",
-                    "sy",
-                    "tr",
-                    "ug",
-                    "uz"
-                )) {
-                    URI("https://raw.githubusercontent.com/dnstt-xyz/dnstt_xyz_app/refs/heads/main/assets/dns/$country.json")
-                        .toURL()
-                        .openStream()
-                        .use { input ->
-                            assetsDir.file("dns-$country.json").asFile.outputStream()
-                                .use { output ->
-                                    input.copyTo(output)
-                                }
-                        }
-                    println("Successfully fetched dns-$country.json.")
-                }
-            } catch (e: Exception) {
-                throw GradleException("ERROR: Could not fetch builtin bridges: ${e.message}", e)
-            }
-        } else {
-            println("builtin-bridges.json is fresh, skipping download.")
-        }
-
-        val statusOutput = try {
-            providers.exec {
-                commandLine("git", "status", "--porcelain")
-            }.standardOutput.asText.get().trim()
-        } catch (_: Exception) {
-            ""
-        }
-
-        if (statusOutput.isNotEmpty()) {
-            throw GradleException(
-                """
-                ERROR: Your working tree contains ${statusOutput.split("\n").size} uncommitted changes:
-                
-                $statusOutput
-
-                Please commit all changes (including builtin-bridges.json if updated)
-                BEFORE running a release build.
-
-                    git add -A
-                    git commit -m "Commit changes"
-
-                Then re-run:
-                    ./gradlew assembleRelease
-                """.trimIndent()
-            )
-        }
-    }
-}
-
-tasks.matching {
-    it.name.startsWith("assemble")
-}.configureEach {
-    finalizedBy(renameApkFiles)
-}
-
-val renameApkFiles by tasks.registering {
-    doLast {
-        val versionName = getVersionName().get()
-        val variantName = gradle.startParameter.taskNames
-            .find { it.contains("assemble") }
-            ?.substringAfter("assemble")
-            ?.replaceFirstChar { it.lowercase() }
-            ?: "debug"
-
-        listOf("nightly", "fullperm").forEach { flavor ->
-            layout.buildDirectory.dir("outputs/apk/$flavor/$variantName").get().asFile
-                .walkTopDown()
-                .filter { it.extension == "apk" }
-                .forEach { file ->
-                    val newName = file.name.replace("app-", "Orbot-${versionName}-")
-                    file.renameTo(File(file.parentFile, newName))
-                }
-        }
-    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/UpdateBridgeConfig.kt
+++ b/buildSrc/src/main/kotlin/UpdateBridgeConfig.kt
@@ -1,0 +1,89 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import org.gradle.api.GradleException
+import java.net.URI
+import java.io.File
+
+abstract class UpdateBridgeConfig : DefaultTask() {
+
+    @get:Input
+    abstract val enabledForVariant: Property<Boolean>
+
+    @get:Input
+    abstract val gitLogUnixTimestamp: Property<String>
+
+    @get:Input
+    abstract val gitStatusOutput: Property<String>
+
+    @get:OutputDirectory
+    val assetsDir: DirectoryProperty = project.objects.directoryProperty()
+
+    @TaskAction
+    fun run() {
+        if (!enabledForVariant.get()) return
+
+        // configuration cache safe (gradle provider based) git status check
+        val status = gitStatusOutput.get().trim()
+        if (status.isNotEmpty())
+            throw GradleException("ERROR: Working tree has uncommitted changes.\nCommit all changes (including updated bridges) before a release build.\n\n$status")
+
+        println("\n\n\uD83C\uDF0D checking to see if Tor Project's bridge config and Guardian Project's dnstt config have been updated for this release...")
+        val assetsFolder = assetsDir.get().asFile
+        if (!assetsFolder.exists()) assetsFolder.mkdirs()
+
+        val outputFile = File(assetsFolder, "builtin-bridges.json")
+        val lastCommitUnix = gitLogUnixTimestamp.getOrElse("0").trim().toLongOrNull() ?: 0L
+        val oneDaySeconds = 86400L
+        val isStale = (System.currentTimeMillis() / 1000) - lastCommitUnix > oneDaySeconds
+
+        if (!outputFile.exists() || isStale) {
+            println("\uD83E\uDD2E bridge configuration is stale...")
+            val bridgeUri = "https://bridges.torproject.org/moat/circumvention/builtin"
+            println("\uD83E\uDDC5 checking tor bridge config@$bridgeUri...")
+
+            try {
+                downloadFile(bridgeUri, outputFile)
+
+                val countries = listOf(
+                    "ae",
+                    "af",
+                    "bd",
+                    "cn",
+                    "co",
+                    "global",
+                    "id",
+                    "ir",
+                    "kw",
+                    "pk",
+                    "qa",
+                    "ru",
+                    "sy",
+                    "tr",
+                    "ug",
+                    "uz"
+                )
+                countries.forEach { country ->
+                    val url =
+                        "https://raw.githubusercontent.com/dnstt-xyz/dnstt_xyz_app/refs/heads/main/assets/dns/$country.json"
+                    println("\uD83D\uDD0E checking dnstt config@@$url...")
+                    val dest = File(assetsFolder, "dns-$country.json")
+                    downloadFile(url, dest)
+                }
+            } catch (e: Exception) {
+                throw GradleException("ERROR: Failed to fetch bridges: ${e.message}")
+            }
+            throw GradleException("\uD83C\uDF81 bridge files updated, please commit them and rerun the release build...")
+        }
+        println("\uD83C\uDF80 bridge and dnstt configurations are good, continuing with release...")
+    }
+
+    private fun downloadFile(url: String, destination: File) {
+        URI(url).toURL().openStream().use { input ->
+            destination.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ android.dependency.useConstraints=true
 android.uniquePackageNames=false
 android.useAndroidX=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+android.builtInKotlin=true
+android.newDsl=true
 org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,9 @@ android.useAndroidX=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.builtInKotlin=true
 android.newDsl=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.max-problems=0
+
 org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
The following gradle tasks in `app/build.gradle.kts` will prevent Orbot from being able to upgrade to AGP 10.0 which should be released in a few months:

- `:app:renameApkFiles`
- `:app:updateBuiltInBridges`

Today, gradle's [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) is an optional feature, but on AGP 10 it's going to be turned on by default and you can't disable it.

With the CC turned on, Orbot's build script has to be deterministic. These changes makes it so that we can keep building with new Android Studio releases, and also has the side effect of **significantly** improving compile speeds after an initial build. 

Renaming the APKs was pretty straightforward with a new API... However, refactoring the bridge update task to work under the CC was a good deal harder. There's now a build script `buildSrc/src/main/kotlin/UpdateBridgeConfig.kt` which is where we now hit tor's MOAT API and get dnstt config when assembling release builds of Orbot. The class is an abstract gradle `DefaultTask` and properties that we use to determine if the config needs to be regenerated (based around `git status`...) are now injected in the correct, deterministic, stateful way when gradle executes. 

I made sure that:
- all debug builds do not trigger the bridge updating logic ie (`./gradlew assembleDebug`, `./gradlew assembleFullpermDebug` and `./gradlew assembleNightlyDebug`)
- all release builds do trigger the bridge logic ie (`./gradlew assembleRelease`, `./gradlew assembleFullpermRelease` and `./gradlew asssembleNightlyRelease`)
- that running `./gradlew assemble` (which builds everything `debug` and `release) behaves as you'd expect (this is achieved by _always_ doing the debug builds _after_ the script evaluation for the bridge config is finished for the release builds...) 
- and that the resultant APKs all have the correct filename pattern that GP has been using for releases: 

## APK filename patterns:
<img width="1585" height="983" alt="filenames" src="https://github.com/user-attachments/assets/88f71d23-7fb0-4bf5-9249-2e989a5d6108" />

## When you try to make a release build without updating the bridge config after 24hrs
<img width="1585" height="906" alt="Screenshot From 2026-04-02 05-41-45" src="https://github.com/user-attachments/assets/adf90425-51a9-4074-9e35-5efbeb487a62" />

## Once things are updated in a release build:
<img width="1585" height="906" alt="Screenshot From 2026-04-02 05-41-11" src="https://github.com/user-attachments/assets/620c8c0d-91d4-4d7b-909e-2c3e6272b118" />

Really can't stress how much faster everything's building now. Wish this had been done sooner...

This closes #1617