### PR TITLE
Decouple exit node selection from fragment lookup

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
@@ -38,8 +38,7 @@ import org.torproject.jni.TorService
 
 private const val DEFAULT_THROTTLE_INTERVAL = 4000L
 
-class ConnectFragment : Fragment(),
-    ExitNodeBottomSheet.ExitNodeSelectedCallback {
+class ConnectFragment : Fragment() {
 
     lateinit var binding: FragmentConnectBinding
 
@@ -66,6 +65,15 @@ class ConnectFragment : Fragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().supportFragmentManager.setFragmentResultListener(
+            ExitNodeBottomSheet.REQUEST_KEY_EXIT_NODE_SELECTED,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            onExitNodeSelected(
+                bundle.getString(ExitNodeBottomSheet.BUNDLE_KEY_COUNTRY_CODE).orEmpty()
+            )
+        }
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -377,7 +385,7 @@ class ConnectFragment : Fragment(),
             .show(requireActivity().supportFragmentManager, ConfigConnectionBottomSheet.TAG)
     }
 
-    override fun onExitNodeSelected(countryCode: String) {
+    private fun onExitNodeSelected(countryCode: String) {
 
         //tor format expects "{" for country code
         Prefs.exitNodes = "{$countryCode}"

--- a/app/src/main/java/org/torproject/android/ui/connect/ExitNodeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ExitNodeBottomSheet.kt
@@ -6,26 +6,18 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.navigation.fragment.NavHostFragment
-
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-
 import org.torproject.android.R
 import org.torproject.android.localization.Languages
-import org.torproject.android.util.StringUtils
-import org.torproject.android.util.Prefs
 import org.torproject.android.ui.OrbotBottomSheetDialogFragment
-
+import org.torproject.android.util.Prefs
+import org.torproject.android.util.StringUtils
 import java.text.Collator
 import java.util.Locale
 import java.util.TreeMap
 
 class ExitNodeBottomSheet : OrbotBottomSheetDialogFragment() {
-
-    interface ExitNodeSelectedCallback {
-        fun onExitNodeSelected(countryCode: String)
-    }
 
     private val sortedCountries = TreeMap<String, Locale>(Collator.getInstance())
     private lateinit var rvList: RecyclerView
@@ -94,10 +86,13 @@ class ExitNodeBottomSheet : OrbotBottomSheetDialogFragment() {
                 val prev = selectedCode
                 selectedCode = code
                 notifyItemChanged(list.indexOfFirst { it.first == prev })
-                val navHostFragment = requireActivity().supportFragmentManager.fragments[0] as NavHostFragment
-                val connectFrag = navHostFragment.childFragmentManager.fragments.last() as ConnectFragment
                 notifyItemChanged(position)
-                connectFrag.onExitNodeSelected(code)
+                parentFragmentManager.setFragmentResult(
+                    REQUEST_KEY_EXIT_NODE_SELECTED,
+                    Bundle().apply {
+                        putString(BUNDLE_KEY_COUNTRY_CODE, code)
+                    }
+                )
                 dismiss()
             }
         }
@@ -106,6 +101,9 @@ class ExitNodeBottomSheet : OrbotBottomSheetDialogFragment() {
     }
 
     companion object {
+        const val REQUEST_KEY_EXIT_NODE_SELECTED = "request_key_exit_node_selected"
+        const val BUNDLE_KEY_COUNTRY_CODE = "bundle_key_country_code"
+
         private val COUNTRY_CODES = arrayOf(
             "DE",
             "AT",


### PR DESCRIPTION
The previous implementation depended on incidental fragment ordering and a concrete fragment type being present in a specific position. That made the flow brittle and vulnerable to navigation changes. Using a fragment result contract makes the interaction explicit and removes the bottom sheet's knowledge of the current fragment stack.