### PR TITLE
Allow ipv6 addrs to be used in a bridge line's arguments 

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -36,7 +36,7 @@ class CustomBridgeBottomSheet :
                     + """((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[\da-fA-F:]+])""" // Cheap IPv4 and IPv6 address test
                     + """(:\d{1,5})?)\s+""" // Optional port number, space after address
                     + """([\da-fA-F]{40})?""" // Optional bridge fingerprint
-                    + """[ \t\f\w\-/+:=.,]*$""" // Optional bridge arguments (different per bridge type, subject to change)
+                    + """[ \t\f\w\-/+:=.,\[\]]*$""" // Optional bridge arguments (different per bridge type, subject to change)
         )
 
         fun isValidBridge(input: String): Boolean {


### PR DESCRIPTION
Closes #1672, previously webtunnel bridges with the `addr` field would incorrectly validate because the last line of this regex:

```kt
private val validBridgeRegex = Regex(
            """^"""
                    + """((meek_lite|obfs4|webtunnel|snowflake|dnstt)\s+)?""" // Optional bridge type: Currently supported PTs + vanilla bridges
                    + """((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[\da-fA-F:]+])""" // Cheap IPv4 and IPv6 address test
                    + """(:\d{1,5})?)\s+""" // Optional port number, space after address
                    + """([\da-fA-F]{40})?""" // Optional bridge fingerprint
                    + """[ \t\f\w\-/+:=.,]*$""" // Optional bridge arguments (different per bridge type, subject to change)
        )
```

did not take into account the square bracket `[` chars `]` needed to write an ipv6 address. 

This is a cheap fix on top of the existing logic, and corrects the problem blocking  people from using webtunnel as reported in #1672. A nicer implementation would be to actually validate each bridge type to ensure has the correct optional bridge arguments. 